### PR TITLE
Mock keycloak server and redis cache.

### DIFF
--- a/test/controllers/DashboardControllerSpec.scala
+++ b/test/controllers/DashboardControllerSpec.scala
@@ -1,14 +1,11 @@
 package controllers
 
 import org.scalatest.Matchers._
-import org.scalatestplus.mockito.MockitoSugar
-import org.scalatestplus.play.PlaySpec
-import org.scalatestplus.play.guice.GuiceOneAppPerTest
+import play.api.test.FakeRequest
 import play.api.test.Helpers.{GET, contentAsString, contentType, status, _}
-import play.api.test.{FakeRequest, Injecting}
 import util.FrontEndTestHelper
 
-class DashboardControllerSpec extends PlaySpec with GuiceOneAppPerTest with Injecting with MockitoSugar with FrontEndTestHelper {
+class DashboardControllerSpec extends FrontEndTestHelper {
 
   "DashboardController GET" should {
 
@@ -21,7 +18,7 @@ class DashboardControllerSpec extends PlaySpec with GuiceOneAppPerTest with Inje
     }
 
     "return a redirect to the auth server with an unauthenticated user" in {
-      val controller = inject[DashboardController]
+      val controller = new DashboardController(getUnauthorisedSecurityComponents())
       val home = controller.dashboard().apply(FakeRequest(GET, "/"))
       redirectLocation(home).get should include ("/auth/realms/tdr/protocol/openid-connect/auth")
       status(home) mustBe 303

--- a/test/controllers/HomeControllerSpec.scala
+++ b/test/controllers/HomeControllerSpec.scala
@@ -7,7 +7,7 @@ import util.FrontEndTestHelper
 
 import scala.concurrent._
 
-class HomeControllerSpec extends  FrontEndTestHelper {
+class HomeControllerSpec extends FrontEndTestHelper {
 
   "HomeController GET" should {
 

--- a/test/controllers/HomeControllerSpec.scala
+++ b/test/controllers/HomeControllerSpec.scala
@@ -1,14 +1,13 @@
 package controllers
 
-import org.scalatestplus.play._
-import org.scalatestplus.play.guice._
 import play.api.mvc.Result
 import play.api.test.Helpers._
 import play.api.test._
+import util.FrontEndTestHelper
 
 import scala.concurrent._
 
-class HomeControllerSpec extends PlaySpec with GuiceOneAppPerTest with Injecting {
+class HomeControllerSpec extends  FrontEndTestHelper {
 
   "HomeController GET" should {
 

--- a/test/util/FrontEndTestHelper.scala
+++ b/test/util/FrontEndTestHelper.scala
@@ -86,7 +86,6 @@ trait FrontEndTestHelper extends PlaySpec with MockitoSugar with Injecting with 
     // Mock the init method to stop it calling out to the keycloak server
     doNothing().when(configuration).init()
 
-
     // Mock the redirect return when the client is unauthorised
     val client = mock[KeycloakOidcClient]
     doAnswer(_ => "OidcClient").when(client).getName


### PR DESCRIPTION
For an unauthorised user, the tests were trying to contact the keycloak
server which doesn't exist when the tests are running. I've mocked this
out in the unauthorised tests.
There were also exceptions relating to redis because there was no redis
instance to connect to. These weren't causing anything to fail but they
were annoying. I've mocked out the redis module so these exceptions
don't happen.

I've moved the overrides to the test helper trait and changed the tests
to use this.