### PR TITLE
Tag jenkins builds with build number

### DIFF
--- a/Jenkinsfile-testing
+++ b/Jenkinsfile-testing
@@ -13,5 +13,22 @@ pipeline {
             sh 'sbt -no-colors test scalastyle'
         }
     }
+    stage('Tag Release') {
+        agent {
+            label "master"
+        }
+        when {
+            expression { env.BRANCH_NAME == "master"}
+        }
+        steps {
+            script {
+                versionTag = "v${env.BUILD_NUMBER}"
+            }
+            sh "git tag ${versionTag}"
+            sshagent(['github-jenkins']) {
+                sh("git push origin ${versionTag}")
+            }
+        }
+    }
   }
 }


### PR DESCRIPTION
Add a version tag to every master build so that we can specify which version to deploy to each AWS environment.

This requires the jenkins build to use SSH to connect to github.