### PR TITLE
Trigger integration deployment from master build

### DIFF
--- a/Jenkinsfile-deploy
+++ b/Jenkinsfile-deploy
@@ -17,7 +17,7 @@ pipeline {
       }
       steps {
         checkout scm
-        sh "npm install"
+        sh "npm ci"
         sh "npm run build"
         sh 'sbt -no-colors test scalastyle'
         sh "sbt -no-colors dist"

--- a/Jenkinsfile-deploy
+++ b/Jenkinsfile-deploy
@@ -4,6 +4,7 @@ pipeline {
   }
   parameters {
     choice(name: "STAGE", choices: ["intg", "staging", "prod"], description: "The stage you are building the front end for")
+    string(name: "TO_DEPLOY", description: "The git tag, branch or commit reference to deploy, e.g. 'v123'")
   }
   stages {
     stage("Build") {

--- a/Jenkinsfile-deploy
+++ b/Jenkinsfile-deploy
@@ -47,7 +47,7 @@ pipeline {
       steps {
         script {
           def accountNumber = getAccountNumberFromStage()
-          sh "python /update_service.py ${accountNumber} ${params.STAGE} frontend"
+          sh "python3 /update_service.py ${accountNumber} ${params.STAGE} frontend"
           slackSend color: "good", message: "The front end app has been updated in ECS", channel: "#tdr"
         }
       }

--- a/Jenkinsfile-deploy
+++ b/Jenkinsfile-deploy
@@ -1,3 +1,5 @@
+def releaseBranch = "release-${env.STAGE}"
+
 pipeline {
   agent {
     label "master"
@@ -50,6 +52,17 @@ pipeline {
           def accountNumber = getAccountNumberFromStage()
           sh "python3 /update_service.py ${accountNumber} ${params.STAGE} frontend"
           slackSend color: "good", message: "The front end app has been updated in ECS", channel: "#tdr"
+        }
+      }
+    }
+    stage("Update release branch") {
+      agent {
+        label "master"
+      }
+      steps {
+        sh "git branch -f ${releaseBranch} HEAD"
+        sshagent(['github-jenkins']) {
+          sh("git push -f origin ${releaseBranch}")
         }
       }
     }

--- a/Jenkinsfile-testing
+++ b/Jenkinsfile-testing
@@ -1,3 +1,5 @@
+def versionTag = "v${env.BUILD_NUMBER}"
+
 pipeline {
   agent none
 
@@ -23,9 +25,6 @@ pipeline {
       stages {
         stage('Tag Release') {
           steps {
-            script {
-              versionTag = "v${env.BUILD_NUMBER}"
-            }
             sh "git tag ${versionTag}"
             sshagent(['github-jenkins']) {
               sh("git push origin ${versionTag}")
@@ -34,7 +33,13 @@ pipeline {
         }
         stage('Deploy to integration') {
           steps {
-            build job: "TDR Front End Deploy", wait: false
+            build(
+                job: "TDR Front End Deploy",
+                parameters: [
+                    string(name: "STAGE", value: "intg"),
+                    string(name: "TO_DEPLOY", value: versionTag)
+                ],
+                wait: false)
           }
         }
       }

--- a/Jenkinsfile-testing
+++ b/Jenkinsfile-testing
@@ -13,20 +13,29 @@ pipeline {
         sh 'sbt -no-colors test scalastyle'
       }
     }
-    stage('Tag Release') {
+    stage('Post-build') {
       agent {
         label "master"
       }
       when {
         expression { env.BRANCH_NAME == "master"}
       }
-      steps {
-        script {
-          versionTag = "v${env.BUILD_NUMBER}"
+      stages {
+        stage('Tag Release') {
+          steps {
+            script {
+              versionTag = "v${env.BUILD_NUMBER}"
+            }
+            sh "git tag ${versionTag}"
+            sshagent(['github-jenkins']) {
+              sh("git push origin ${versionTag}")
+            }
+          }
         }
-        sh "git tag ${versionTag}"
-        sshagent(['github-jenkins']) {
-          sh("git push origin ${versionTag}")
+        stage('Deploy to integration') {
+          steps {
+            build job: "TDR Front End Deploy", wait: false
+          }
         }
       }
     }


### PR DESCRIPTION
When the Jenkins master build passes, start a deployment to the integration environment by triggering the deployment job. Pass parameters to the deployment build: the stage (which is always "intg" if we're running an automated deployment) and the git reference (which is the git tag that the master build has just created).

Also update the Jenkinsfile to use Python 3, and run "[npm ci](https://blog.npmjs.org/post/171556855892/introducing-npm-ci-for-faster-more-reliable)" instead of "npm install" to make the builds more reproducible.