### PR TITLE
Only deploy each version to Docker Hub once

### DIFF
--- a/Jenkinsfile-deploy
+++ b/Jenkinsfile-deploy
@@ -9,33 +9,18 @@ pipeline {
     string(name: "TO_DEPLOY", description: "The git tag, branch or commit reference to deploy, e.g. 'v123'")
   }
   stages {
-    stage("Build") {
-      agent {
-        ecs {
-          inheritFrom "transfer-frontend"
-        }
-      }
-      steps {
-        checkout scm
-        sh "npm ci"
-        sh "npm run build"
-        sh 'sbt -no-colors test scalastyle'
-        sh "sbt -no-colors dist"
-        stash includes: "Dockerfile", name: "Dockerfile"
-        stash includes: "target/universal/tdr-transfer-frontend-*.zip", name: "tdr-transfer-frontend-zip"
-      }
-    }
     stage("Docker") {
       agent {
         label "master"
       }
       steps {
-        unstash "tdr-transfer-frontend-zip"
-        unstash "Dockerfile"
         script {
           docker.withRegistry('', 'docker') {
-            docker.build("nationalarchives/tdr-transfer-frontend:${params.STAGE}").push()
-            slackSend color: "good", message: "The front end app has been pushed to docker hub", channel: "#tdr"
+            sh "docker pull nationalarchives/tdr-transfer-frontend:${params.TO_DEPLOY}"
+            sh "docker tag nationalarchives/tdr-transfer-frontend:${params.TO_DEPLOY} nationalarchives/tdr-transfer-frontend:${params.STAGE}"
+            sh "docker push nationalarchives/tdr-transfer-frontend:${params.STAGE}"
+
+            slackSend color: "good", message: "The front end app ${params.STAGE} tag has been upated to the ${params.TO_DEPLOY} version in Docker Hub", channel: "#tdr"
           }
         }
       }

--- a/Jenkinsfile-testing
+++ b/Jenkinsfile-testing
@@ -31,6 +31,37 @@ pipeline {
             }
           }
         }
+        stage("Build Docker image") {
+          agent {
+            ecs {
+              inheritFrom "transfer-frontend"
+            }
+          }
+          steps {
+            checkout scm
+            sh "npm ci"
+            sh "npm run build"
+            sh 'sbt -no-colors test scalastyle'
+            sh "sbt -no-colors dist"
+            stash includes: "Dockerfile", name: "Dockerfile"
+            stash includes: "target/universal/tdr-transfer-frontend-*.zip", name: "tdr-transfer-frontend-zip"
+          }
+        }
+        stage("Push Docker image") {
+          agent {
+            label "master"
+          }
+          steps {
+            unstash "tdr-transfer-frontend-zip"
+            unstash "Dockerfile"
+            script {
+              docker.withRegistry('', 'docker') {
+                docker.build("nationalarchives/tdr-transfer-frontend:${versionTag}").push()
+                slackSend color: "good", message: "Pushed version ${versionTag} of the front end app to docker hub", channel: "#tdr"
+              }
+            }
+          }
+        }
         stage('Deploy to integration') {
           steps {
             build(


### PR DESCRIPTION
When code is merged to master, build and deploy it to Docker Hub, using the version tag (e.g 'v123') as the Docker tag.

When a version is deployed to an environment, pull the tagged Docker image and re-tag it with the environment name.

This means that we can deploy specific version numbers to ECS, without having to update the task definition in ECS every time.

This process is slightly inefficient because the deployment build has to pull the image in order to re-tag it, but there doesn't seem to be an easy way to add a tag in Docker Hub without pulling and pushing an image.