### PR TITLE
Records page

### DIFF
--- a/app/controllers/RecordsController.scala
+++ b/app/controllers/RecordsController.scala
@@ -1,0 +1,15 @@
+package controllers
+
+import auth.OidcSecurity
+import javax.inject.{Inject, Singleton}
+import org.pac4j.play.scala.SecurityComponents
+import play.api.i18n.I18nSupport
+import play.api.mvc.{Action, AnyContent, Request}
+
+@Singleton
+class RecordsController @Inject()(val controllerComponents: SecurityComponents) extends OidcSecurity with I18nSupport {
+
+  def recordsPage(consignmentId: Long): Action[AnyContent] = secureAction { implicit request: Request[AnyContent] =>
+    Ok(views.html.records())
+  }
+}

--- a/app/controllers/RecordsController.scala
+++ b/app/controllers/RecordsController.scala
@@ -1,13 +1,17 @@
 package controllers
 
 import auth.OidcSecurity
+import configuration.{GraphQLConfiguration, KeycloakConfiguration}
 import javax.inject.{Inject, Singleton}
 import org.pac4j.play.scala.SecurityComponents
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, Request}
 
 @Singleton
-class RecordsController @Inject()(val controllerComponents: SecurityComponents) extends OidcSecurity with I18nSupport {
+class RecordsController @Inject()(val controllerComponents: SecurityComponents,
+                                  val graphqlConfiguration: GraphQLConfiguration,
+                                  val keycloakConfiguration: KeycloakConfiguration
+                                 ) extends OidcSecurity with I18nSupport {
 
   def recordsPage(consignmentId: Long): Action[AnyContent] = secureAction { implicit request: Request[AnyContent] =>
     Ok(views.html.records())

--- a/app/views/records.scala.html
+++ b/app/views/records.scala.html
@@ -1,0 +1,6 @@
+@()(implicit messages: Messages)
+
+@main(Messages("records.header")) {
+<h1 class="govuk-heading-xl">@Messages("records.title")</h1>
+<p>Placeholder page for records after successful upload</p>
+}

--- a/conf/messages
+++ b/conf/messages
@@ -22,6 +22,8 @@ transferAgreement.droAppraisalSelection=I confirm that the DRO has signed off on
 transferAgreement.droSensitivity=I confirm that the DRO has signed off on the sensitivity review and that all records are OPEN i.e. no FOI exemptions apply to these records.
 upload.header=Upload
 upload.title=Upload
+records.header=Records
+records.title=Records
 
 # Progress indicator step numbers
 seriesDetails.progress=1

--- a/conf/routes
+++ b/conf/routes
@@ -11,6 +11,7 @@ POST    /series                                            controllers.SeriesDet
 GET     /consignment/:consignmentId/transfer-agreement     controllers.TransferAgreementController.transferAgreement(consignmentId: Long)
 POST    /consignment/:consignmentId/transfer-agreement     controllers.TransferAgreementController.transferAgreementSubmit(consignmentId: Long)
 GET     /consignment/:consignmentId/upload                 controllers.UploadController.uploadPage(consignmentId: Long)
+GET     /consignment/:consignmentId/records                controllers.RecordsController.recordsPage(consignmentId: Long)
 
 # Map static resources from the /public folder to the /assets URL path
 GET     /assets/*file               controllers.Assets.versioned(path="/public", file: Asset)

--- a/test/controllers/RecordsControllerSpec.scala
+++ b/test/controllers/RecordsControllerSpec.scala
@@ -1,21 +1,34 @@
 package controllers
 
+import configuration.GraphQLConfiguration
 import org.scalatest.Matchers._
 import play.api.test.FakeRequest
-import play.api.test.Helpers.{GET, contentAsString, contentType, status, _}
+import play.api.test.Helpers.{status => playStatus, _}
 import util.FrontEndTestHelper
 
+import scala.concurrent.ExecutionContext
+
 class RecordsControllerSpec extends FrontEndTestHelper {
+  implicit val ec: ExecutionContext = ExecutionContext.global
 
   "RecordsController GET" should {
 
     "render the records page after initial upload is complete and user clicks continue" in {
-      val controller = new RecordsController(getAuthorisedSecurityComponents)
+      val controller = new RecordsController(getAuthorisedSecurityComponents,
+        new GraphQLConfiguration(app.configuration), getValidKeycloakConfiguration)
       val recordsPage = controller.recordsPage(123).apply(FakeRequest(GET, "/consignment/123/records"))
-      status(recordsPage) mustBe OK
+      playStatus(recordsPage) mustBe OK
       contentType(recordsPage) mustBe Some("text/html")
       contentAsString(recordsPage) must include ("records.header")
       contentAsString(recordsPage) must include ("records.title")
+    }
+
+    "return a redirect to the auth server with an unauthenticated user" in {
+      val controller = new RecordsController(getUnauthorisedSecurityComponents,
+        new GraphQLConfiguration(app.configuration), getValidKeycloakConfiguration)
+      val recordsPage = controller.recordsPage(123).apply(FakeRequest(GET, "/consignment/123/records"))
+      redirectLocation(recordsPage).get must startWith ("/auth/realms/tdr/protocol/openid-connect/auth")
+      playStatus(recordsPage) mustBe FOUND
     }
   }
 

--- a/test/controllers/RecordsControllerSpec.scala
+++ b/test/controllers/RecordsControllerSpec.scala
@@ -1,0 +1,22 @@
+package controllers
+
+import org.scalatest.Matchers._
+import play.api.test.FakeRequest
+import play.api.test.Helpers.{GET, contentAsString, contentType, status, _}
+import util.FrontEndTestHelper
+
+class RecordsControllerSpec extends FrontEndTestHelper {
+
+  "RecordsController GET" should {
+
+    "render the records page after initial upload is complete and user clicks continue" in {
+      val controller = new RecordsController(getAuthorisedSecurityComponents)
+      val recordsPage = controller.recordsPage(123).apply(FakeRequest(GET, "/consignment/123/records"))
+      status(recordsPage) mustBe OK
+      contentType(recordsPage) mustBe Some("text/html")
+      contentAsString(recordsPage) must include ("records.header")
+      contentAsString(recordsPage) must include ("records.title")
+    }
+  }
+
+}


### PR DESCRIPTION
This pr creates the records placeholder page upon completion of successful upload. Right now it is only accessible through the link. 
I was thinking of adding a button to the upload placeholder page but have left that for now as I wasn't 100% sure no one was working on that page atm.

closes #45 