### PR TITLE
Fix TA test so errors are shown with invalid form submission

### DIFF
--- a/test/controllers/TransferAgreementControllerSpec.scala
+++ b/test/controllers/TransferAgreementControllerSpec.scala
@@ -124,7 +124,7 @@ class TransferAgreementControllerSpec extends FrontEndTestHelper {
 
       playStatus(transferAgreementSubmit) mustBe BAD_REQUEST
       contentAsString(transferAgreementSubmit) must include("govuk-error-message")
-      contentAsString(transferAgreementSubmit) must include("Error")
+      contentAsString(transferAgreementSubmit) must include("error")
     }
   }
 }


### PR DESCRIPTION
Test was case sensitive and had "Error" rather than "error",
GDS and HTML error elements use lower case which is why using "Error" did not work.