### PR TITLE
Remove custom Pac4J authorizer

### DIFF
--- a/app/auth/OidcSecurity.scala
+++ b/app/auth/OidcSecurity.scala
@@ -1,9 +1,10 @@
 package auth
 
+import org.pac4j.core.authorization.authorizer.DefaultAuthorizers
 import org.pac4j.core.profile.CommonProfile
 import org.pac4j.play.scala.{SecureAction, Security}
 import play.api.mvc.AnyContent
 
 trait OidcSecurity extends Security[CommonProfile] {
-  val secureAction: SecureAction[CommonProfile, AnyContent, AuthenticatedRequest] = Secure("OidcClient", authorizers = "custom")
+  val secureAction: SecureAction[CommonProfile, AnyContent, AuthenticatedRequest] = Secure("OidcClient", authorizers = DefaultAuthorizers.NONE)
 }

--- a/app/modules/SecurityModule.scala
+++ b/app/modules/SecurityModule.scala
@@ -1,12 +1,8 @@
 package modules
 
-import java.util
-
 import com.google.inject.{AbstractModule, Provides}
-import org.pac4j.core.authorization.authorizer.Authorizer
 import org.pac4j.core.client.Clients
 import org.pac4j.core.config.Config
-import org.pac4j.core.context.WebContext
 import org.pac4j.core.profile.CommonProfile
 import org.pac4j.oidc.client.OidcClient
 import org.pac4j.oidc.config.OidcConfiguration
@@ -59,28 +55,6 @@ class SecurityModule extends AbstractModule {
     val clients = new Clients(oidcClient)
     val config = new Config(clients)
     config.setHttpActionAdapter(new FrontendHttpActionAdaptor())
-    config.addAuthorizer("custom", new CustomAuthoriser)
     config
   }
-}
-
-/*
-pac4j has a default authoriser which checks for csrf tokens. The problem
-is that it doesn't work and there's not a lot of documentation on how to
-make it work.
-
-The other problem is that play has csrf checkers which are more than
-adequate so what we need is to turn off the pac4j one.
-
-If you don't provide an authoriser, it gives you the csrf one by default
-so the trick is to give it a dummy authoriser to stop it checking the
-csrf one. Which is what this does.
-
-This has no effect on whether logged out users can see or not see
-certain pages. This is authorisation which we're not doing in the front
-end, although if we do decide to do front end authorisation, we can
-expand the CustomAuthoriser class to something more useful.
-*/
-class CustomAuthoriser extends Authorizer[CommonProfile] {
-  override def isAuthorized(context: WebContext, profiles: util.List[CommonProfile]): Boolean = true
 }


### PR DESCRIPTION
Use Pac4J's built-in `DefaultAuthorizers.NONE` setting to prevent Pac4J applying extra authorization rules, rather than defining our own empty authorizer.

This may eventually be replaced if we add client-side authorization (on top of the existing API-level authorization).

This addresses an [old review comment](https://github.com/nationalarchives/tdr-transfer-frontend/pull/41/files#r391775764) which we put on hold to get the transfer agreement branch merged.