### PR TITLE
Upgrade GraphQL client library

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ libraryDependencies ++= Seq(
   "com.softwaremill.sttp.client" %% "core" % "2.0.0-RC9",
   "com.softwaremill.sttp.client" %% "circe" % "2.0.0-RC9",
   "com.softwaremill.sttp.client" %% "async-http-client-backend-future" % "2.0.0-RC9",
-  "uk.gov.nationalarchives" %% "tdr-graphql-client" % "0.0.1",
+  "uk.gov.nationalarchives" %% "tdr-graphql-client" % "0.0.5",
   "uk.gov.nationalarchives" %% "tdr-auth-utils" % "0.0.5",
   "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.29",
   "com.github.tomakehurst" % "wiremock-jre8" % "2.26.0" % Test,

--- a/test/controllers/TransferAgreementControllerSpec.scala
+++ b/test/controllers/TransferAgreementControllerSpec.scala
@@ -12,6 +12,7 @@ import play.api.i18n.Langs
 import play.api.test.CSRFTokenHelper._
 import play.api.test.FakeRequest
 import play.api.test.Helpers.{GET, contentAsString, contentType, redirectLocation, status => playStatus, _}
+import uk.gov.nationalarchives.tdr.GraphQLClient
 import util.{EnglishLang, FrontEndTestHelper}
 
 import scala.concurrent.ExecutionContext
@@ -98,7 +99,7 @@ class TransferAgreementControllerSpec extends FrontEndTestHelper {
     "renders an error when a valid form is submitted but there is an error from the api" in {
       val consignmentId = 1L
       val client = new GraphQLConfiguration(app.configuration).getClient[ata.Data, ata.Variables]()
-      val data: client.GraphqlData = client.GraphqlData(Option.empty, List(client.GraphqlError("Error", Nil, Nil)))
+      val data: client.GraphqlData = client.GraphqlData(Option.empty, List(GraphQLClient.GraphqlError("Error", Nil, Nil)))
       val dataString: String = data.asJson.printWith(Printer(dropNullValues = false, ""))
       wiremockServer.stubFor(post(urlEqualTo("/graphql"))
         .willReturn(okJson(dataString)))


### PR DESCRIPTION
The latest version of the library (0.0.5) serialises optional variables differently. If they are set to `None`, the library now skips the variable rather than setting it to `null`.

This makes it possible to remove deprecated variables from the API, because a variable that has been removed must not be present in the query, even if it is set to `null`.