### PR TITLE
Set expire session with token to be true.

### DIFF
--- a/app/modules/SecurityModule.scala
+++ b/app/modules/SecurityModule.scala
@@ -45,6 +45,7 @@ class SecurityModule extends AbstractModule {
     val secret = configuration.get[String]("auth.secret")
     oidcConfiguration.setSecret(secret)
     oidcConfiguration.setDiscoveryURI(s"$authUrl/auth/realms/tdr/.well-known/openid-configuration")
+    oidcConfiguration.setExpireSessionWithToken(true)
     val oidcClient = new OidcClient[OidcConfiguration](oidcConfiguration)
     oidcClient.setCallbackUrl(callback)
     oidcClient

--- a/app/modules/SecurityModule.scala
+++ b/app/modules/SecurityModule.scala
@@ -45,6 +45,7 @@ class SecurityModule extends AbstractModule {
     val secret = configuration.get[String]("auth.secret")
     oidcConfiguration.setSecret(secret)
     oidcConfiguration.setDiscoveryURI(s"$authUrl/auth/realms/tdr/.well-known/openid-configuration")
+    // Setting this causes pac4j to get a new access token using the refresh token when the original access token expires
     oidcConfiguration.setExpireSessionWithToken(true)
     val oidcClient = new OidcClient[OidcConfiguration](oidcConfiguration)
     oidcClient.setCallbackUrl(callback)


### PR DESCRIPTION
When this is set to true, if the token has expired, it will get the
refresh token and call keycloak to get a new access token, and then
store that access token in the cache.

There is a brief description of this functionality at the end of this
page https://www.pac4j.org/docs/clients/openid-connect.html.

The method that refreshes the token is here
https://github.com/pac4j/pac4j/blob/master/pac4j-oidc/src/main/java/org/pac4j/oidc/credentials/authenticator/OidcAuthenticator.java#L160

This is called eventually from the profileManager.get(true) line in our
TokenSecurity class.

I've tested this and it will check the expiry on the token and get a new
one silently in the background.