### PR TITLE
Make the HTML ids for error messages unique

### DIFF
--- a/app/views/errorMessage.scala.html
+++ b/app/views/errorMessage.scala.html
@@ -1,7 +1,9 @@
 @import views.html.helper._
 @(elements: FieldElements)(implicit messages: Messages)
+
 @if(elements.hasErrors) {
-    <span id="error" class="govuk-error-message">
+
+    <span id="@elements.id-error" class="govuk-error-message">
         <span class="govuk-visually-hidden">@Messages("screenReader.error")</span> @elements.errors.mkString(", ")
-        </span>
+    </span>
 }

--- a/app/views/errorMessage.scala.html
+++ b/app/views/errorMessage.scala.html
@@ -2,7 +2,6 @@
 @(elements: FieldElements)(implicit messages: Messages)
 
 @if(elements.hasErrors) {
-
     <span id="@elements.id-error" class="govuk-error-message">
         <span class="govuk-visually-hidden">@Messages("screenReader.error")</span> @elements.errors.mkString(", ")
     </span>


### PR DESCRIPTION
Was going back and forth as to whether id should be in Kebab case like other HTML ids or Camel case like the ids on the transferAgreement page; kept it as Camel.