### PR TITLE
Update tdr-generated-graphql dependency

### DIFF
--- a/app/controllers/SeriesDetailsController.scala
+++ b/app/controllers/SeriesDetailsController.scala
@@ -31,7 +31,8 @@ class SeriesDetailsController @Inject()(val controllerComponents: SecurityCompon
   )
 
   private def getSeriesDetails(request: Request[AnyContent], status: Status, form: Form[SelectedSeriesData])(implicit requestHeader: RequestHeader) = {
-    val userTransferringBody: Option[String] = request.token.transferringBody
+    val userTransferringBody: String = request.token.transferringBody
+      .getOrElse(throw new RuntimeException(s"Transferring body missing from token for user ${request.token.userId}"))
     val variables: getSeries.Variables = new getSeries.Variables(userTransferringBody)
 
     getSeriesClient.getResult(request.token.bearerAccessToken, getSeries.document, Some(variables)).map(data => {

--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ libraryDependencies ++= Seq(
   "com.softwaremill.sttp.client" %% "async-http-client-backend-future" % "2.0.0-RC9",
   "uk.gov.nationalarchives" %% "tdr-graphql-client" % "0.0.5",
   "uk.gov.nationalarchives" %% "tdr-auth-utils" % "0.0.5",
-  "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.29",
+  "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.31",
   "com.github.tomakehurst" % "wiremock-jre8" % "2.26.0" % Test,
   "org.mockito" % "mockito-core" % "3.3.0" % Test
 )


### PR DESCRIPTION
The latest version makes the transferring body a compulsory argument when fetching the series.