### PR TITLE
Hardcode the string "true" in the HTML's value parameter

### DIFF
--- a/app/views/inputSingleCheckbox.scala.html
+++ b/app/views/inputSingleCheckbox.scala.html
@@ -6,9 +6,8 @@ args: (Symbol, Any)*
 @import viewsapi.FormFunctions._
 
 @elements = @{new FieldElements(field.id, field, null, args.toMap, messages) }
-@value = {@elements.args.get(Symbol("_value"))}
 @label = {@elements.args.get(Symbol("_label"))}
-@isSelected = {@elements.args.selectedInput(value.toString)}
+@isSelected = {@elements.args.selectedInput("true")}
 
 <div class="govuk-form-group @elements.setErrorClass">
     @errorMessage(elements)
@@ -20,7 +19,7 @@ args: (Symbol, Any)*
                     id="@elements.id"
                     name="@elements.id"
                     type="checkbox"
-                    value="@value"
+                    value="true"
             />
             <label class="govuk-label govuk-checkboxes__label" for="@elements.id">
                 @label


### PR DESCRIPTION
A small issue was that the code has to call .toString on value in order to pass it into the "elements.args.selectedInput" method (on line 11, now line 10).

This is because in the views, Play converts Strings (and maybe other types) to a "play.twirl.api.Html" (to work nicely with the view template); it probably does not expect further method calls.

Since the value for a checkbox is always the string "true", it is not necessary for the code to check the args Map for the value of "value", it is sufficient to just pass the String "true" into selectedInput. The same goes for the HTML (instead of referencing @value, "true" can be hardcoded); although, since checkboxes are always "true", it is not really necessary to have the value in the HTML