### PR TITLE
Handle authorisation errors from the API

### DIFF
--- a/app/auth/RequestWithToken.scala
+++ b/app/auth/RequestWithToken.scala
@@ -1,10 +1,7 @@
 package auth
 
-import com.nimbusds.oauth2.sdk.token.BearerAccessToken
-import org.keycloak.representations.AccessToken
 import play.api.mvc.{AnyContent, Request}
 import uk.gov.nationalarchives.tdr.keycloak.Token
-
 
 class RequestWithToken(request: Request[AnyContent], val token: Token)
 

--- a/app/controllers/TransferAgreementController.scala
+++ b/app/controllers/TransferAgreementController.scala
@@ -12,7 +12,6 @@ import play.api.data.Form
 import play.api.data.Forms._
 import play.api.i18n.{I18nSupport, Lang, Langs}
 import play.api.mvc.{Action, AnyContent, Request, Result}
-import services.ConsignmentService
 import uk.gov.nationalarchives.tdr.error.NotAuthorisedError
 import validation.ValidatedActions
 
@@ -22,7 +21,6 @@ import scala.concurrent.{ExecutionContext, Future}
 class TransferAgreementController @Inject()(val controllerComponents: SecurityComponents,
                                             val graphqlConfiguration: GraphQLConfiguration,
                                             val keycloakConfiguration: KeycloakConfiguration,
-                                            val getConsignmentService: ConsignmentService,
                                             langs: Langs)
                                            (implicit val ec: ExecutionContext) extends ValidatedActions with I18nSupport {
 

--- a/app/controllers/TransferAgreementController.scala
+++ b/app/controllers/TransferAgreementController.scala
@@ -12,7 +12,7 @@ import play.api.data.Form
 import play.api.data.Forms._
 import play.api.i18n.{I18nSupport, Lang, Langs}
 import play.api.mvc.{Action, AnyContent, Request, Result}
-import services.GetConsignmentService
+import services.ConsignmentService
 import uk.gov.nationalarchives.tdr.error.NotAuthorisedError
 import validation.ValidatedActions
 
@@ -22,7 +22,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class TransferAgreementController @Inject()(val controllerComponents: SecurityComponents,
                                             val graphqlConfiguration: GraphQLConfiguration,
                                             val keycloakConfiguration: KeycloakConfiguration,
-                                            val getConsignmentService: GetConsignmentService,
+                                            val getConsignmentService: ConsignmentService,
                                             langs: Langs)
                                            (implicit val ec: ExecutionContext) extends ValidatedActions with I18nSupport {
 

--- a/app/errors/AuthorisationException.scala
+++ b/app/errors/AuthorisationException.scala
@@ -1,0 +1,3 @@
+package errors
+
+class AuthorisationException(message: String) extends Exception(message)

--- a/app/errors/ErrorHandler.scala
+++ b/app/errors/ErrorHandler.scala
@@ -1,0 +1,29 @@
+package errors
+
+import javax.inject.Inject
+import play.api.Logging
+import play.api.http.HttpErrorHandler
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.Results._
+import play.api.mvc.{RequestHeader, Result}
+
+import scala.concurrent.Future
+
+class ErrorHandler @Inject() (val messagesApi: MessagesApi) extends HttpErrorHandler with I18nSupport with Logging {
+
+  override def onClientError(request: RequestHeader, statusCode: Int, message: String): Future[Result] = {
+    logger.error(s"Client error with status code $statusCode at path '${request.path}' with message: '$message'")
+
+    Future.successful(
+      Status(statusCode)("A client error occurred: " + message)
+    )
+  }
+
+  override def onServerError(request: RequestHeader, exception: Throwable): Future[Result] = {
+    logger.error(s"Internal server error at path '${request.path}'", exception)
+
+    Future.successful(
+      InternalServerError(views.html.error(s"A server error occurred: ${exception.getMessage}")(request2Messages(request)))
+    )
+  }
+}

--- a/app/errors/ErrorHandler.scala
+++ b/app/errors/ErrorHandler.scala
@@ -22,8 +22,13 @@ class ErrorHandler @Inject() (val messagesApi: MessagesApi) extends HttpErrorHan
   override def onServerError(request: RequestHeader, exception: Throwable): Future[Result] = {
     logger.error(s"Internal server error at path '${request.path}'", exception)
 
-    Future.successful(
-      InternalServerError(views.html.error(s"A server error occurred: ${exception.getMessage}")(request2Messages(request)))
-    )
+    val response = exception match {
+      case authException: AuthorisationException =>
+        Forbidden(views.html.error(s"Not authorised: ${authException.getMessage}")(request2Messages(request)))
+      case e =>
+        InternalServerError(views.html.error(s"A server error occurred: ${e.getMessage}")(request2Messages(request)))
+    }
+
+    Future.successful(response)
   }
 }

--- a/app/errors/GraphQlException.scala
+++ b/app/errors/GraphQlException.scala
@@ -1,0 +1,6 @@
+package errors
+
+import uk.gov.nationalarchives.tdr.error.GraphQlError
+
+class GraphQlException(errors: List[GraphQlError])
+  extends RuntimeException(s"GraphQL response contained errors: ${errors.map(e => e.message).mkString}")

--- a/app/services/ApiErrorHandling.scala
+++ b/app/services/ApiErrorHandling.scala
@@ -1,7 +1,7 @@
 package services
 
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken
-import errors.AuthorisationException
+import errors.{AuthorisationException, GraphQlException}
 import sangria.ast.Document
 import uk.gov.nationalarchives.tdr.GraphQLClient
 import uk.gov.nationalarchives.tdr.error.NotAuthorisedError
@@ -20,8 +20,7 @@ object ApiErrorHandling {
       result.errors match {
         case Nil => result.data.get
         case List(authError: NotAuthorisedError) => throw new AuthorisationException(authError.message)
-        // TODO: Create generic exception
-        case errors => throw new RuntimeException(errors.map(e => e.message).mkString)
+        case errors => throw new GraphQlException(errors)
       }
     })
   }

--- a/app/services/ApiErrorHandling.scala
+++ b/app/services/ApiErrorHandling.scala
@@ -1,0 +1,28 @@
+package services
+
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken
+import errors.AuthorisationException
+import sangria.ast.Document
+import uk.gov.nationalarchives.tdr.GraphQLClient
+import uk.gov.nationalarchives.tdr.error.NotAuthorisedError
+
+import scala.concurrent.{ExecutionContext, Future}
+
+object ApiErrorHandling {
+  def sendApiRequest[Data, Variables](
+                                       graphQlClient: GraphQLClient[Data, Variables],
+                                       document: Document,
+                                       token: BearerAccessToken,
+                                       variables: Variables
+                                     )(implicit executionContext: ExecutionContext): Future[Data] = {
+
+    graphQlClient.getResult(token, document, Some(variables)).map(result => {
+      result.errors match {
+        case Nil => result.data.get
+        case List(authError: NotAuthorisedError) => throw new AuthorisationException(authError.message)
+        // TODO: Create generic exception
+        case errors => throw new RuntimeException(errors.map(e => e.message).mkString)
+      }
+    })
+  }
+}

--- a/app/services/ConsignmentService.scala
+++ b/app/services/ConsignmentService.scala
@@ -38,9 +38,10 @@ class ConsignmentService @Inject()(val graphqlConfiguration: GraphQLConfiguratio
     val variables: addConsignment.Variables = AddConsignment.addConsignment.Variables(addConsignmentInput)
 
     addConsignmentClient.getResult(token, addConsignment.document, Some(variables)).map(data => {
-      data.data match {
-        case Some(consignment) => consignment.addConsignment
-        case None => throw new RuntimeException(data.errors.map(e => e.message).mkString)
+      data.errors match {
+        case Nil => data.data.get.addConsignment
+        case List(authError: NotAuthorisedError) => throw new AuthorisationException(authError.message)
+        case errors => throw new RuntimeException(errors.map(e => e.message).mkString)
       }
     })
   }

--- a/app/services/ConsignmentService.scala
+++ b/app/services/ConsignmentService.scala
@@ -4,13 +4,12 @@ import java.util.UUID
 
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken
 import configuration.GraphQLConfiguration
-import errors.AuthorisationException
 import graphql.codegen.AddConsignment.addConsignment
 import graphql.codegen.GetConsignment.getConsignment
 import graphql.codegen.types.AddConsignmentInput
 import graphql.codegen.{AddConsignment, GetConsignment}
 import javax.inject.{Inject, Singleton}
-import uk.gov.nationalarchives.tdr.error.NotAuthorisedError
+import services.ApiErrorHandling._
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -24,25 +23,16 @@ class ConsignmentService @Inject()(val graphqlConfiguration: GraphQLConfiguratio
   def consignmentExists(consignmentId: UUID,
                         token: BearerAccessToken): Future[Boolean] = {
     val variables: getConsignment.Variables = new GetConsignment.getConsignment.Variables(consignmentId)
-    getConsignmentClient.getResult(token, getConsignment.document, Some(variables)).map(data => {
-      data.errors match {
-        case Nil => data.data.isDefined && data.data.get.getConsignment.isDefined
-        case List(authError: NotAuthorisedError) => throw new AuthorisationException(authError.message)
-        case errors => throw new RuntimeException(errors.map(e => e.message).mkString)
-      }
-    })
+
+    sendApiRequest(getConsignmentClient, getConsignment.document, token, variables)
+      .map(data => data.getConsignment.isDefined)
   }
 
   def createConsignment(seriesId: UUID, token: BearerAccessToken): Future[addConsignment.AddConsignment] = {
     val addConsignmentInput: AddConsignmentInput = AddConsignmentInput(seriesId)
     val variables: addConsignment.Variables = AddConsignment.addConsignment.Variables(addConsignmentInput)
 
-    addConsignmentClient.getResult(token, addConsignment.document, Some(variables)).map(data => {
-      data.errors match {
-        case Nil => data.data.get.addConsignment
-        case List(authError: NotAuthorisedError) => throw new AuthorisationException(authError.message)
-        case errors => throw new RuntimeException(errors.map(e => e.message).mkString)
-      }
-    })
+    sendApiRequest(addConsignmentClient, addConsignment.document, token, variables)
+      .map(data => data.addConsignment)
   }
 }

--- a/app/services/ConsignmentService.scala
+++ b/app/services/ConsignmentService.scala
@@ -13,8 +13,8 @@ import uk.gov.nationalarchives.tdr.error.NotAuthorisedError
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class GetConsignmentService @Inject()(val graphqlConfiguration: GraphQLConfiguration)
-                                     (implicit val ec: ExecutionContext)  {
+class ConsignmentService @Inject()(val graphqlConfiguration: GraphQLConfiguration)
+                                  (implicit val ec: ExecutionContext)  {
 
   private val getConsignmentClient = graphqlConfiguration.getClient[getConsignment.Data, getConsignment.Variables]()
 

--- a/app/services/GetConsignmentService.scala
+++ b/app/services/GetConsignmentService.scala
@@ -4,9 +4,11 @@ import java.util.UUID
 
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken
 import configuration.GraphQLConfiguration
+import errors.AuthorisationException
 import graphql.codegen.GetConsignment
 import graphql.codegen.GetConsignment.getConsignment
 import javax.inject.{Inject, Singleton}
+import uk.gov.nationalarchives.tdr.error.NotAuthorisedError
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -20,7 +22,11 @@ class GetConsignmentService @Inject()(val graphqlConfiguration: GraphQLConfigura
                         token: BearerAccessToken): Future[Boolean] = {
     val variables: getConsignment.Variables = new GetConsignment.getConsignment.Variables(consignmentId)
     getConsignmentClient.getResult(token, getConsignment.document, Some(variables)).map(data => {
-      data.data.isDefined && data.data.get.getConsignment.isDefined
+      data.errors match {
+        case Nil => data.data.isDefined && data.data.get.getConsignment.isDefined
+        case List(authError: NotAuthorisedError) => throw new AuthorisationException(authError.message)
+        case errors => throw new RuntimeException(errors.map(e => e.message).mkString)
+      }
     })
   }
 }

--- a/app/services/SeriesService.scala
+++ b/app/services/SeriesService.scala
@@ -1,11 +1,13 @@
 package services
 
 import configuration.GraphQLConfiguration
-
-import scala.concurrent.{ExecutionContext, Future}
+import errors.AuthorisationException
 import graphql.codegen.GetSeries.getSeries
 import javax.inject.Inject
+import uk.gov.nationalarchives.tdr.error.NotAuthorisedError
 import uk.gov.nationalarchives.tdr.keycloak.Token
+
+import scala.concurrent.{ExecutionContext, Future}
 
 class SeriesService @Inject()(val graphqlConfiguration: GraphQLConfiguration)(implicit ec: ExecutionContext) {
 
@@ -16,14 +18,12 @@ class SeriesService @Inject()(val graphqlConfiguration: GraphQLConfiguration)(im
       .getOrElse(throw new RuntimeException(s"Transferring body missing from token for user ${token.userId}"))
     val variables: getSeries.Variables = new getSeries.Variables(userTransferringBody)
 
-    getSeriesClient.getResult(token.bearerAccessToken, getSeries.document, Some(variables)).map(data => {
-      // TODO: Use pattern matching
-      if (data.data.isDefined) {
-        data.data.get.getSeries
-      } else {
+    getSeriesClient.getResult(token.bearerAccessToken, getSeries.document, Some(variables)).map(result => {
+      result.errors match {
+        case Nil => result.data.get.getSeries
+        case List(authError: NotAuthorisedError) => throw new AuthorisationException(authError.message)
         // TODO: Create generic exception
-        val errors = data.errors.map(e => e.message).mkString
-        throw new RuntimeException(s"Error getting series for user `${token.userId}`: $errors")
+        case errors => throw new RuntimeException(errors.map(e => e.message).mkString)
       }
     })
   }

--- a/app/services/SeriesService.scala
+++ b/app/services/SeriesService.scala
@@ -1,0 +1,30 @@
+package services
+
+import configuration.GraphQLConfiguration
+
+import scala.concurrent.{ExecutionContext, Future}
+import graphql.codegen.GetSeries.getSeries
+import javax.inject.Inject
+import uk.gov.nationalarchives.tdr.keycloak.Token
+
+class SeriesService @Inject()(val graphqlConfiguration: GraphQLConfiguration)(implicit ec: ExecutionContext) {
+
+  private val getSeriesClient = graphqlConfiguration.getClient[getSeries.Data, getSeries.Variables]()
+
+  def getSeriesForUser(token: Token): Future[List[getSeries.GetSeries]] = {
+    val userTransferringBody: String = token.transferringBody
+      .getOrElse(throw new RuntimeException(s"Transferring body missing from token for user ${token.userId}"))
+    val variables: getSeries.Variables = new getSeries.Variables(userTransferringBody)
+
+    getSeriesClient.getResult(token.bearerAccessToken, getSeries.document, Some(variables)).map(data => {
+      // TODO: Use pattern matching
+      if (data.data.isDefined) {
+        data.data.get.getSeries
+      } else {
+        // TODO: Create generic exception
+        val errors = data.errors.map(e => e.message).mkString
+        throw new RuntimeException(s"Error getting series for user `${token.userId}`: $errors")
+      }
+    })
+  }
+}

--- a/app/services/SeriesService.scala
+++ b/app/services/SeriesService.scala
@@ -1,10 +1,9 @@
 package services
 
 import configuration.GraphQLConfiguration
-import errors.AuthorisationException
 import graphql.codegen.GetSeries.getSeries
 import javax.inject.Inject
-import uk.gov.nationalarchives.tdr.error.NotAuthorisedError
+import services.ApiErrorHandling._
 import uk.gov.nationalarchives.tdr.keycloak.Token
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -18,13 +17,6 @@ class SeriesService @Inject()(val graphqlConfiguration: GraphQLConfiguration)(im
       .getOrElse(throw new RuntimeException(s"Transferring body missing from token for user ${token.userId}"))
     val variables: getSeries.Variables = new getSeries.Variables(userTransferringBody)
 
-    getSeriesClient.getResult(token.bearerAccessToken, getSeries.document, Some(variables)).map(result => {
-      result.errors match {
-        case Nil => result.data.get.getSeries
-        case List(authError: NotAuthorisedError) => throw new AuthorisationException(authError.message)
-        // TODO: Create generic exception
-        case errors => throw new RuntimeException(errors.map(e => e.message).mkString)
-      }
-    })
+    sendApiRequest(getSeriesClient, getSeries.document, token.bearerAccessToken, variables).map(_.getSeries)
   }
 }

--- a/app/services/TransferAgreementService.scala
+++ b/app/services/TransferAgreementService.scala
@@ -4,8 +4,10 @@ import java.util.UUID
 
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken
 import configuration.GraphQLConfiguration
+import errors.AuthorisationException
 import graphql.codegen.IsTransferAgreementComplete.{isTransferAgreementComplete => itac}
 import javax.inject.Inject
+import uk.gov.nationalarchives.tdr.error.NotAuthorisedError
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -17,13 +19,12 @@ class TransferAgreementService @Inject()(val graphqlConfiguration: GraphQLConfig
   def transferAgreementExists(consignmentId: UUID, token: BearerAccessToken): Future[Boolean] = {
     val variables = itac.Variables(consignmentId)
 
-    isTransferAgreementCompleteClient.getResult(token, itac.document, Some(variables)).map(data => {
-      val isComplete: Option[Boolean] = for {
-        dataDefined <- data.data
-        transferAgreement <- dataDefined.getTransferAgreement
-      } yield transferAgreement.isAgreementComplete
-
-      isComplete.isDefined && isComplete.get
+    isTransferAgreementCompleteClient.getResult(token, itac.document, Some(variables)).map(graphQlResponse => {
+      graphQlResponse.errors match {
+        case Nil => graphQlResponse.data.flatMap(_.getTransferAgreement).exists(_.isAgreementComplete)
+        case List(authError: NotAuthorisedError) => throw new AuthorisationException(authError.message)
+        case errors => throw new RuntimeException(errors.map(e => e.message).mkString)
+      }
     })
   }
 }

--- a/app/services/TransferAgreementService.scala
+++ b/app/services/TransferAgreementService.scala
@@ -4,10 +4,9 @@ import java.util.UUID
 
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken
 import configuration.GraphQLConfiguration
-import errors.AuthorisationException
 import graphql.codegen.IsTransferAgreementComplete.{isTransferAgreementComplete => itac}
 import javax.inject.Inject
-import uk.gov.nationalarchives.tdr.error.NotAuthorisedError
+import services.ApiErrorHandling.sendApiRequest
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -19,12 +18,7 @@ class TransferAgreementService @Inject()(val graphqlConfiguration: GraphQLConfig
   def transferAgreementExists(consignmentId: UUID, token: BearerAccessToken): Future[Boolean] = {
     val variables = itac.Variables(consignmentId)
 
-    isTransferAgreementCompleteClient.getResult(token, itac.document, Some(variables)).map(graphQlResponse => {
-      graphQlResponse.errors match {
-        case Nil => graphQlResponse.data.flatMap(_.getTransferAgreement).exists(_.isAgreementComplete)
-        case List(authError: NotAuthorisedError) => throw new AuthorisationException(authError.message)
-        case errors => throw new RuntimeException(errors.map(e => e.message).mkString)
-      }
-    })
+    sendApiRequest(isTransferAgreementCompleteClient, itac.document, token, variables)
+      .map(data => data.getTransferAgreement.exists(_.isAgreementComplete))
   }
 }

--- a/app/services/TransferAgreementService.scala
+++ b/app/services/TransferAgreementService.scala
@@ -1,0 +1,29 @@
+package services
+
+import java.util.UUID
+
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken
+import configuration.GraphQLConfiguration
+import graphql.codegen.IsTransferAgreementComplete.{isTransferAgreementComplete => itac}
+import javax.inject.Inject
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class TransferAgreementService @Inject()(val graphqlConfiguration: GraphQLConfiguration)
+                                        (implicit ec: ExecutionContext) {
+
+  private val isTransferAgreementCompleteClient = graphqlConfiguration.getClient[itac.Data, itac.Variables]()
+
+  def transferAgreementExists(consignmentId: UUID, token: BearerAccessToken): Future[Boolean] = {
+    val variables = itac.Variables(consignmentId)
+
+    isTransferAgreementCompleteClient.getResult(token, itac.document, Some(variables)).map(data => {
+      val isComplete: Option[Boolean] = for {
+        dataDefined <- data.data
+        transferAgreement <- dataDefined.getTransferAgreement
+      } yield transferAgreement.isAgreementComplete
+
+      isComplete.isDefined && isComplete.get
+    })
+  }
+}

--- a/app/validation/ValidatedActions.scala
+++ b/app/validation/ValidatedActions.scala
@@ -7,7 +7,7 @@ import configuration.GraphQLConfiguration
 import controllers.routes
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, Request, Result}
-import services.{GetConsignmentService, TransferAgreementService}
+import services.{ConsignmentService, TransferAgreementService}
 
 import scala.concurrent.ExecutionContext
 
@@ -17,8 +17,8 @@ abstract class ValidatedActions() extends TokenSecurity with I18nSupport {
 
   def consignmentExists(consignmentId: UUID)(f: Request[AnyContent] => Result): Action[AnyContent] = secureAction.async {
     implicit request: Request[AnyContent] =>
-    val getConsignmentService = new GetConsignmentService(graphqlConfiguration)
-    val consignmentExists = getConsignmentService.consignmentExists(consignmentId, request.token.bearerAccessToken)
+    val consignmentService = new ConsignmentService(graphqlConfiguration)
+    val consignmentExists = consignmentService.consignmentExists(consignmentId, request.token.bearerAccessToken)
     consignmentExists.map {
       case true => f(request)
       case false => NotFound(views.html.notFoundError("The consignment you are trying to access does not exist"))

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -26,6 +26,8 @@ akka.actor.warn-about-java-serializer-usage="off"
 play.modules.enabled += "modules.SecurityModule"
 play.modules.enabled += "play.api.cache.redis.RedisCacheModule"
 
+play.http.errorHandler = "errors.ErrorHandler"
+
 play.filters.hosts {
     allowed = [
         "localhost:9000"

--- a/conf/application.intg.conf
+++ b/conf/application.intg.conf
@@ -17,8 +17,11 @@ akka.actor.warn-about-java-serializer-usage="off"
 play.modules.enabled += "modules.SecurityModule"
 play.modules.enabled += "play.api.cache.redis.RedisCacheModule"
 
+play.http.errorHandler = "errors.ErrorHandler"
+
 environment=${ENVIRONMENT}
 region="eu-west-2"
+
 # The load balancer runs the healthcheck using the IP address of the container. If the IPs are not listed below, the healthcheck
 # will fail and the task will be stopped so the app can't start unless all potential IPs are listed.
 # This is a list of all possible IPs in the subnets which the task will run in. These are set in terraform and will not

--- a/conf/application.prod.conf
+++ b/conf/application.prod.conf
@@ -16,6 +16,8 @@ consignmentapi.url="https://api.tdr.nationalarchives.gov.uk/graphql"
 play.modules.enabled += "modules.SecurityModule"
 play.modules.enabled += "play.api.cache.redis.RedisCacheModule"
 
+play.http.errorHandler = "errors.ErrorHandler"
+
 play.i18n.langs = ["en-gb"]
 
 environment=${ENVIRONMENT}

--- a/conf/application.staging.conf
+++ b/conf/application.staging.conf
@@ -16,6 +16,8 @@ cognito.identityProviderName=auth.tdr-staging.nationalarchives.gov.uk/auth/realm
 play.modules.enabled += "modules.SecurityModule"
 play.modules.enabled += "play.api.cache.redis.RedisCacheModule"
 
+play.http.errorHandler = "errors.ErrorHandler"
+
 play.i18n.langs = ["en-gb"]
 
 environment=${ENVIRONMENT}

--- a/test/controllers/SeriesDetailsControllerSpec.scala
+++ b/test/controllers/SeriesDetailsControllerSpec.scala
@@ -5,6 +5,7 @@ import java.util.UUID
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock._
 import configuration.GraphQLConfiguration
+import errors.GraphQlException
 import graphql.codegen.AddConsignment.{addConsignment => ac}
 import graphql.codegen.GetSeries.{getSeries => gs}
 import io.circe.Printer
@@ -146,7 +147,7 @@ class SeriesDetailsControllerSpec extends FrontEndTestHelper {
         seriesService, consignmentService)
       val seriesSubmit = controller.seriesSubmit().apply(FakeRequest(POST, "/series").withFormUrlEncodedBody(("series", seriesId.toString)).withCSRFToken)
 
-      seriesSubmit.failed.futureValue shouldBe a[RuntimeException]
+      seriesSubmit.failed.futureValue shouldBe a[GraphQlException]
     }
 
     "display errors when an invalid form is submitted" in {

--- a/test/controllers/SeriesDetailsControllerSpec.scala
+++ b/test/controllers/SeriesDetailsControllerSpec.scala
@@ -181,7 +181,7 @@ class SeriesDetailsControllerSpec extends FrontEndTestHelper {
 
       val controller = new SeriesDetailsController(getAuthorisedSecurityComponents, getValidKeycloakConfiguration,
         seriesService, consignmentService)
-      controller.seriesDetails().apply(FakeRequest(GET, "/series").withCSRFToken)
+      controller.seriesDetails().apply(FakeRequest(GET, "/series").withCSRFToken).futureValue
 
       val expectedJson = "{\"query\":\"query getSeries($body:String!){getSeries(body:$body){seriesid bodyid name code description}}\",\"variables\":{\"body\":\"Body\"}}"
       wiremockServer.verify(postRequestedFor(urlEqualTo("/graphql")).withRequestBody(equalToJson(expectedJson)))

--- a/test/controllers/SeriesDetailsControllerSpec.scala
+++ b/test/controllers/SeriesDetailsControllerSpec.scala
@@ -25,6 +25,9 @@ import scala.concurrent.ExecutionContext
 class SeriesDetailsControllerSpec extends FrontEndTestHelper {
   implicit val ec: ExecutionContext = ExecutionContext.global
 
+  val seriesId = UUID.fromString("1ebba1f2-5cd9-4379-a26e-f544e6d6f5e3")
+  val bodyId = UUID.fromString("327068c7-a650-4f40-8f7d-c650d5acd7b0")
+
   val wiremockServer = new WireMockServer(9006)
 
   override def beforeEach(): Unit = {
@@ -40,8 +43,8 @@ class SeriesDetailsControllerSpec extends FrontEndTestHelper {
 
     "render the correct series details page with an authenticated user" in {
       val client = new GraphQLConfiguration(app.configuration).getClient[gs.Data, gs.Variables]()
-      val uuid = UUID.fromString("c2efd3e6-6664-4582-8c28-dcf891f60e68")
-      val data: client.GraphqlData = client.GraphqlData(Some(gs.Data(List(gs.GetSeries(uuid, uuid,Option.empty, Some("code"), Option.empty)))))
+      val data: client.GraphqlData = client.GraphqlData(Some(
+        gs.Data(List(gs.GetSeries(seriesId, bodyId, Option.empty, Some("code"), Option.empty)))))
       val dataString: String = data.asJson.printWith(Printer(dropNullValues = false, ""))
       val graphQLConfiguration = new GraphQLConfiguration(app.configuration)
       val seriesService = new SeriesService(graphQLConfiguration)
@@ -59,7 +62,7 @@ class SeriesDetailsControllerSpec extends FrontEndTestHelper {
       contentAsString(seriesDetailsPage) must include ("seriesDetails.title")
       contentAsString(seriesDetailsPage) must include ("seriesDetails.chooseSeries")
       contentAsString(seriesDetailsPage) must include ("id=\"series\"")
-      contentAsString(seriesDetailsPage) must include (s"""<option value="${uuid.toString}">code</option>""")
+      contentAsString(seriesDetailsPage) must include (s"""<option value="${seriesId.toString}">code</option>""")
 
       wiremockServer.verify(postRequestedFor(urlEqualTo("/graphql")))
     }
@@ -152,8 +155,8 @@ class SeriesDetailsControllerSpec extends FrontEndTestHelper {
 
     "display errors when an invalid form is submitted" in {
       val client = new GraphQLConfiguration(app.configuration).getClient[gs.Data, gs.Variables]()
-      val uuid = UUID.fromString("c2efd3e6-6664-4582-8c28-dcf891f60e68")
-      val data: client.GraphqlData = client.GraphqlData(Some(gs.Data(List(gs.GetSeries(uuid, uuid,Option.empty, Some("code"), Option.empty)))))
+      val data: client.GraphqlData = client.GraphqlData(Some(
+        gs.Data(List(gs.GetSeries(seriesId, bodyId, Option.empty, Some("code"), Option.empty)))))
       val dataString: String = data.asJson.printWith(Printer(dropNullValues = false, ""))
       val graphQLConfiguration = new GraphQLConfiguration(app.configuration)
       val seriesService = new SeriesService(graphQLConfiguration)
@@ -171,8 +174,8 @@ class SeriesDetailsControllerSpec extends FrontEndTestHelper {
 
     "will send the correct body if it is present on the user" in {
       val client = new GraphQLConfiguration(app.configuration).getClient[gs.Data, gs.Variables]()
-      val uuid = UUID.fromString("c2efd3e6-6664-4582-8c28-dcf891f60e68")
-      val data: client.GraphqlData = client.GraphqlData(Some(gs.Data(List(gs.GetSeries(uuid, uuid,Option.empty, Some("code"), Option.empty)))))
+      val data: client.GraphqlData = client.GraphqlData(Some(
+        gs.Data(List(gs.GetSeries(seriesId, bodyId, Option.empty, Some("code"), Option.empty)))))
       val dataString: String = data.asJson.printWith(Printer(dropNullValues = false, ""))
       val graphQLConfiguration = new GraphQLConfiguration(app.configuration)
       val seriesService = new SeriesService(graphQLConfiguration)

--- a/test/controllers/SeriesDetailsControllerSpec.scala
+++ b/test/controllers/SeriesDetailsControllerSpec.scala
@@ -16,6 +16,7 @@ import play.api.test.CSRFTokenHelper._
 import play.api.test.FakeRequest
 import play.api.test.Helpers.{status => playStatus, _}
 import uk.gov.nationalarchives.tdr.GraphQLClient
+import uk.gov.nationalarchives.tdr.error.GraphQlError
 import util.FrontEndTestHelper
 
 import scala.concurrent.ExecutionContext

--- a/test/controllers/SeriesDetailsControllerSpec.scala
+++ b/test/controllers/SeriesDetailsControllerSpec.scala
@@ -93,7 +93,7 @@ class SeriesDetailsControllerSpec extends FrontEndTestHelper {
       val seriesDetailsPage = controller.seriesDetails().apply(FakeRequest(GET, "/series"))
 
       val failure = seriesDetailsPage.failed.futureValue
-      failure mustBe an[Exception]
+      failure mustBe an[GraphQlException]
     }
 
     "render the error page if the token is invalid" in {

--- a/test/controllers/TransferAgreementControllerSpec.scala
+++ b/test/controllers/TransferAgreementControllerSpec.scala
@@ -5,12 +5,14 @@ import java.util.UUID
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock.{okJson, post, urlEqualTo}
 import configuration.GraphQLConfiguration
+import errors.AuthorisationException
 import graphql.codegen.AddTransferAgreement.{AddTransferAgreement => ata}
 import graphql.codegen.GetConsignment.{getConsignment => gc}
 import io.circe.Printer
 import io.circe.generic.auto._
 import io.circe.syntax._
 import org.scalatest.Matchers._
+import org.scalatest.concurrent.ScalaFutures._
 import play.api.i18n.Langs
 import play.api.test.CSRFTokenHelper._
 import play.api.test.FakeRequest
@@ -18,6 +20,7 @@ import play.api.test.Helpers.{GET, contentAsString, contentType, redirectLocatio
 import util.FrontEndTestHelper
 import services.GetConsignmentService
 import uk.gov.nationalarchives.tdr.GraphQLClient
+import uk.gov.nationalarchives.tdr.GraphQLClient.Extensions
 import util.{EnglishLang, FrontEndTestHelper}
 
 import scala.concurrent.ExecutionContext
@@ -98,9 +101,9 @@ class TransferAgreementControllerSpec extends FrontEndTestHelper {
     }
 
     "create a transfer agreement when a valid form is submitted and the api response is successful" in {
-      val client = new GraphQLConfiguration(app.configuration).getClient[ata.Data, ata.Variables]()
       val consignmentId = UUID.fromString("c2efd3e6-6664-4582-8c28-dcf891f60e68")
       val transferAgreementId = Some(UUID.fromString("c2efd3e6-6664-4582-8c28-dcf891f60e68"))
+
       val addTransferAgreementResponse: ata.AddTransferAgreement = new ata.AddTransferAgreement(
         consignmentId,
         Some(true),
@@ -111,46 +114,45 @@ class TransferAgreementControllerSpec extends FrontEndTestHelper {
         Some(true),
         transferAgreementId
       )
-
-      val data: client.GraphqlData = client.GraphqlData(Some(ata.Data(addTransferAgreementResponse)), List())
-      val dataString: String = data.asJson.printWith(Printer(dropNullValues = false, ""))
-      wiremockServer.stubFor(post(urlEqualTo("/graphql"))
-        .willReturn(okJson(dataString)))
+      stubTransferAgreementResponse(Some(addTransferAgreementResponse))
 
       val controller = new TransferAgreementController(getAuthorisedSecurityComponents, new GraphQLConfiguration(app.configuration),
         getValidKeycloakConfiguration, new GetConsignmentService(new GraphQLConfiguration(app.configuration)), langs)
       val transferAgreementSubmit = controller.transferAgreementSubmit(consignmentId)
-        .apply(FakeRequest().withFormUrlEncodedBody(
-          ("publicRecord", true.toString),
-          ("crownCopyright", true.toString),
-          ("english", true.toString),
-          ("digital", true.toString),
-          ("droAppraisalSelection", true.toString),
-          ("droSensitivity", true.toString)
-        ).withCSRFToken)
+        .apply(FakeRequest().withFormUrlEncodedBody(completedTransferAgreementForm:_*).withCSRFToken)
       playStatus(transferAgreementSubmit) mustBe SEE_OTHER
       redirectLocation(transferAgreementSubmit) must be(Some("/consignment/c2efd3e6-6664-4582-8c28-dcf891f60e68/upload"))
     }
 
-    "renders an error when a valid form is submitted but there is an error from the api" in {
+    "render an error when a valid form is submitted but there is an error from the api" in {
       val consignmentId = UUID.fromString("c2efd3e6-6664-4582-8c28-dcf891f60e68")
-      val client = new GraphQLConfiguration(app.configuration).getClient[ata.Data, ata.Variables]()
-      val data: client.GraphqlData = client.GraphqlData(Option.empty, List(GraphQLClient.Error("Error", Nil, Nil, None)))
-      val dataString: String = data.asJson.printWith(Printer(dropNullValues = false, ""))
-      wiremockServer.stubFor(post(urlEqualTo("/graphql"))
-        .willReturn(okJson(dataString)))
+      stubTransferAgreementResponse(errors = List(GraphQLClient.Error("Error", Nil, Nil, None)))
 
       val controller = new TransferAgreementController(getAuthorisedSecurityComponents, new GraphQLConfiguration(app.configuration),
         getValidKeycloakConfiguration, new GetConsignmentService(new GraphQLConfiguration(app.configuration)), langs)
       val transferAgreementSubmit = controller.transferAgreementSubmit(consignmentId)
-        .apply(FakeRequest(POST, "/consignment/" + consignmentId.toString + "/transfer-agreement").withFormUrlEncodedBody(
-          ("publicRecord", true.toString),
-          ("crownCopyright", true.toString),
-          ("english", true.toString),
-          ("digital", true.toString),
-          ("droAppraisalSelection", true.toString),
-          ("droSensitivity", true.toString)).withCSRFToken)
-      playStatus(transferAgreementSubmit) mustBe INTERNAL_SERVER_ERROR
+        .apply(FakeRequest(POST, "/consignment/" + consignmentId.toString + "/transfer-agreement")
+          .withFormUrlEncodedBody(completedTransferAgreementForm:_*)
+          .withCSRFToken)
+
+      val failure: Throwable = transferAgreementSubmit.failed.futureValue
+      failure mustBe an[Exception]
+    }
+
+    "throws an authorisation exception when the user does not have permission to save the transfer agreement" in {
+      val consignmentId = UUID.fromString("c2efd3e6-6664-4582-8c28-dcf891f60e68")
+      stubTransferAgreementResponse(errors = List(GraphQLClient.Error("Error", Nil, Nil, Some(Extensions(Some("NOT_AUTHORISED"))))))
+
+      val controller = new TransferAgreementController(getAuthorisedSecurityComponents, new GraphQLConfiguration(app.configuration),
+        getValidKeycloakConfiguration, new GetConsignmentService(new GraphQLConfiguration(app.configuration)), langs)
+      val transferAgreementSubmit = controller.transferAgreementSubmit(consignmentId)
+        .apply(FakeRequest(POST, "/consignment/" + consignmentId.toString + "/transfer-agreement")
+          .withFormUrlEncodedBody(completedTransferAgreementForm:_*)
+          .withCSRFToken)
+
+      val failure: Throwable = transferAgreementSubmit.failed.futureValue
+
+      failure mustBe an[AuthorisationException]
     }
 
     "display errors when an invalid form is submitted" in {
@@ -165,5 +167,25 @@ class TransferAgreementControllerSpec extends FrontEndTestHelper {
       contentAsString(transferAgreementSubmit) must include("govuk-error-message")
       contentAsString(transferAgreementSubmit) must include("error")
     }
+  }
+
+  private def completedTransferAgreementForm: Seq[(String, String)] = {
+    Seq(
+      ("publicRecord", true.toString),
+      ("crownCopyright", true.toString),
+      ("english", true.toString),
+      ("digital", true.toString),
+      ("droAppraisalSelection", true.toString),
+      ("droSensitivity", true.toString)
+    )
+  }
+
+  private def stubTransferAgreementResponse(transferAgreement: Option[ata.AddTransferAgreement] = None, errors: List[GraphQLClient.Error] = Nil): Unit = {
+    val client = new GraphQLConfiguration(app.configuration).getClient[ata.Data, ata.Variables]()
+
+    val data: client.GraphqlData = client.GraphqlData(transferAgreement.map(ta => ata.Data(ta)), errors)
+    val dataString: String = data.asJson.printWith(Printer(dropNullValues = false, ""))
+    wiremockServer.stubFor(post(urlEqualTo("/graphql"))
+      .willReturn(okJson(dataString)))
   }
 }

--- a/test/controllers/TransferAgreementControllerSpec.scala
+++ b/test/controllers/TransferAgreementControllerSpec.scala
@@ -18,7 +18,6 @@ import play.api.test.CSRFTokenHelper._
 import play.api.test.FakeRequest
 import play.api.test.Helpers.{GET, contentAsString, contentType, redirectLocation, status => playStatus, _}
 import util.FrontEndTestHelper
-import services.ConsignmentService
 import uk.gov.nationalarchives.tdr.GraphQLClient
 import uk.gov.nationalarchives.tdr.GraphQLClient.Extensions
 import util.{EnglishLang, FrontEndTestHelper}
@@ -46,8 +45,7 @@ class TransferAgreementControllerSpec extends FrontEndTestHelper {
     "render the transfer agreement page with an authenticated user" in {
       val consignmentId = UUID.fromString("c2efd3e6-6664-4582-8c28-dcf891f60e68")
       val controller = new TransferAgreementController(getAuthorisedSecurityComponents,
-        new GraphQLConfiguration(app.configuration), getValidKeycloakConfiguration,
-        new ConsignmentService(new GraphQLConfiguration(app.configuration)), langs)
+        new GraphQLConfiguration(app.configuration), getValidKeycloakConfiguration, langs)
 
       val client = new GraphQLConfiguration(app.configuration).getClient[gc.Data, gc.Variables]()
       val consignmentResponse: gc.GetConsignment = new gc.GetConsignment(UUID.randomUUID(), UUID.randomUUID())
@@ -75,7 +73,7 @@ class TransferAgreementControllerSpec extends FrontEndTestHelper {
     "return a redirect to the auth server with an unauthenticated user" in {
       val consignmentId = UUID.fromString("c2efd3e6-6664-4582-8c28-dcf891f60e68")
       val controller = new TransferAgreementController(getUnauthorisedSecurityComponents, new GraphQLConfiguration(app.configuration),
-        getValidKeycloakConfiguration, new ConsignmentService(new GraphQLConfiguration(app.configuration)), langs)
+        getValidKeycloakConfiguration, langs)
       val transferAgreementPage = controller.transferAgreement(consignmentId).apply(FakeRequest(GET, "/consignment/123/transfer-agreement"))
 
       redirectLocation(transferAgreementPage).get must startWith("/auth/realms/tdr/protocol/openid-connect/auth")
@@ -91,7 +89,7 @@ class TransferAgreementControllerSpec extends FrontEndTestHelper {
 
       val consignmentId = UUID.randomUUID()
       val controller = new TransferAgreementController(getAuthorisedSecurityComponents, new GraphQLConfiguration(app.configuration),
-        getValidKeycloakConfiguration, new ConsignmentService(new GraphQLConfiguration(app.configuration)), langs)
+        getValidKeycloakConfiguration, langs)
 
       val transferAgreementPage = controller.transferAgreement(consignmentId)
         .apply(FakeRequest(GET, s"/consignment/$consignmentId/transfer-agreement").withCSRFToken)
@@ -109,7 +107,7 @@ class TransferAgreementControllerSpec extends FrontEndTestHelper {
 
       val consignmentId = UUID.randomUUID()
       val controller = new TransferAgreementController(getAuthorisedSecurityComponents, new GraphQLConfiguration(app.configuration),
-        getValidKeycloakConfiguration, new ConsignmentService(new GraphQLConfiguration(app.configuration)), langs)
+        getValidKeycloakConfiguration, langs)
 
       val transferAgreementPage = controller.transferAgreement(consignmentId)
         .apply(FakeRequest(GET, s"/consignment/$consignmentId/transfer-agreement").withCSRFToken)
@@ -136,7 +134,7 @@ class TransferAgreementControllerSpec extends FrontEndTestHelper {
       stubTransferAgreementResponse(Some(addTransferAgreementResponse))
 
       val controller = new TransferAgreementController(getAuthorisedSecurityComponents, new GraphQLConfiguration(app.configuration),
-        getValidKeycloakConfiguration, new ConsignmentService(new GraphQLConfiguration(app.configuration)), langs)
+        getValidKeycloakConfiguration, langs)
       val transferAgreementSubmit = controller.transferAgreementSubmit(consignmentId)
         .apply(FakeRequest().withFormUrlEncodedBody(completedTransferAgreementForm:_*).withCSRFToken)
       playStatus(transferAgreementSubmit) mustBe SEE_OTHER
@@ -148,7 +146,7 @@ class TransferAgreementControllerSpec extends FrontEndTestHelper {
       stubTransferAgreementResponse(errors = List(GraphQLClient.Error("Error", Nil, Nil, None)))
 
       val controller = new TransferAgreementController(getAuthorisedSecurityComponents, new GraphQLConfiguration(app.configuration),
-        getValidKeycloakConfiguration, new ConsignmentService(new GraphQLConfiguration(app.configuration)), langs)
+        getValidKeycloakConfiguration, langs)
       val transferAgreementSubmit = controller.transferAgreementSubmit(consignmentId)
         .apply(FakeRequest(POST, "/consignment/" + consignmentId.toString + "/transfer-agreement")
           .withFormUrlEncodedBody(completedTransferAgreementForm:_*)
@@ -163,7 +161,7 @@ class TransferAgreementControllerSpec extends FrontEndTestHelper {
       stubTransferAgreementResponse(errors = List(GraphQLClient.Error("Error", Nil, Nil, Some(Extensions(Some("NOT_AUTHORISED"))))))
 
       val controller = new TransferAgreementController(getAuthorisedSecurityComponents, new GraphQLConfiguration(app.configuration),
-        getValidKeycloakConfiguration, new ConsignmentService(new GraphQLConfiguration(app.configuration)), langs)
+        getValidKeycloakConfiguration, langs)
       val transferAgreementSubmit = controller.transferAgreementSubmit(consignmentId)
         .apply(FakeRequest(POST, "/consignment/" + consignmentId.toString + "/transfer-agreement")
           .withFormUrlEncodedBody(completedTransferAgreementForm:_*)
@@ -177,7 +175,7 @@ class TransferAgreementControllerSpec extends FrontEndTestHelper {
     "display errors when an invalid form is submitted" in {
       val consignmentId = UUID.fromString("c2efd3e6-6664-4582-8c28-dcf891f60e68")
       val controller = new TransferAgreementController(getAuthorisedSecurityComponents, new GraphQLConfiguration(app.configuration),
-        getValidKeycloakConfiguration, new ConsignmentService(new GraphQLConfiguration(app.configuration)), langs)
+        getValidKeycloakConfiguration, langs)
 
       val transferAgreementSubmit = controller.transferAgreementSubmit(consignmentId)
         .apply(FakeRequest(POST, "/consignment/" + consignmentId.toString + "/transfer-agreement").withCSRFToken)

--- a/test/controllers/TransferAgreementControllerSpec.scala
+++ b/test/controllers/TransferAgreementControllerSpec.scala
@@ -18,7 +18,7 @@ import play.api.test.CSRFTokenHelper._
 import play.api.test.FakeRequest
 import play.api.test.Helpers.{GET, contentAsString, contentType, redirectLocation, status => playStatus, _}
 import util.FrontEndTestHelper
-import services.GetConsignmentService
+import services.ConsignmentService
 import uk.gov.nationalarchives.tdr.GraphQLClient
 import uk.gov.nationalarchives.tdr.GraphQLClient.Extensions
 import util.{EnglishLang, FrontEndTestHelper}
@@ -47,7 +47,7 @@ class TransferAgreementControllerSpec extends FrontEndTestHelper {
       val consignmentId = UUID.fromString("c2efd3e6-6664-4582-8c28-dcf891f60e68")
       val controller = new TransferAgreementController(getAuthorisedSecurityComponents,
         new GraphQLConfiguration(app.configuration), getValidKeycloakConfiguration,
-        new GetConsignmentService(new GraphQLConfiguration(app.configuration)), langs)
+        new ConsignmentService(new GraphQLConfiguration(app.configuration)), langs)
 
       val client = new GraphQLConfiguration(app.configuration).getClient[gc.Data, gc.Variables]()
       val consignmentResponse: gc.GetConsignment = new gc.GetConsignment(UUID.randomUUID(), UUID.randomUUID())
@@ -75,7 +75,7 @@ class TransferAgreementControllerSpec extends FrontEndTestHelper {
     "return a redirect to the auth server with an unauthenticated user" in {
       val consignmentId = UUID.fromString("c2efd3e6-6664-4582-8c28-dcf891f60e68")
       val controller = new TransferAgreementController(getUnauthorisedSecurityComponents, new GraphQLConfiguration(app.configuration),
-        getValidKeycloakConfiguration, new GetConsignmentService(new GraphQLConfiguration(app.configuration)), langs)
+        getValidKeycloakConfiguration, new ConsignmentService(new GraphQLConfiguration(app.configuration)), langs)
       val transferAgreementPage = controller.transferAgreement(consignmentId).apply(FakeRequest(GET, "/consignment/123/transfer-agreement"))
 
       redirectLocation(transferAgreementPage).get must startWith("/auth/realms/tdr/protocol/openid-connect/auth")
@@ -91,7 +91,7 @@ class TransferAgreementControllerSpec extends FrontEndTestHelper {
 
       val consignmentId = UUID.randomUUID()
       val controller = new TransferAgreementController(getAuthorisedSecurityComponents, new GraphQLConfiguration(app.configuration),
-        getValidKeycloakConfiguration, new GetConsignmentService(new GraphQLConfiguration(app.configuration)), langs)
+        getValidKeycloakConfiguration, new ConsignmentService(new GraphQLConfiguration(app.configuration)), langs)
 
       val transferAgreementPage = controller.transferAgreement(consignmentId)
         .apply(FakeRequest(GET, s"/consignment/$consignmentId/transfer-agreement").withCSRFToken)
@@ -109,7 +109,7 @@ class TransferAgreementControllerSpec extends FrontEndTestHelper {
 
       val consignmentId = UUID.randomUUID()
       val controller = new TransferAgreementController(getAuthorisedSecurityComponents, new GraphQLConfiguration(app.configuration),
-        getValidKeycloakConfiguration, new GetConsignmentService(new GraphQLConfiguration(app.configuration)), langs)
+        getValidKeycloakConfiguration, new ConsignmentService(new GraphQLConfiguration(app.configuration)), langs)
 
       val transferAgreementPage = controller.transferAgreement(consignmentId)
         .apply(FakeRequest(GET, s"/consignment/$consignmentId/transfer-agreement").withCSRFToken)
@@ -136,7 +136,7 @@ class TransferAgreementControllerSpec extends FrontEndTestHelper {
       stubTransferAgreementResponse(Some(addTransferAgreementResponse))
 
       val controller = new TransferAgreementController(getAuthorisedSecurityComponents, new GraphQLConfiguration(app.configuration),
-        getValidKeycloakConfiguration, new GetConsignmentService(new GraphQLConfiguration(app.configuration)), langs)
+        getValidKeycloakConfiguration, new ConsignmentService(new GraphQLConfiguration(app.configuration)), langs)
       val transferAgreementSubmit = controller.transferAgreementSubmit(consignmentId)
         .apply(FakeRequest().withFormUrlEncodedBody(completedTransferAgreementForm:_*).withCSRFToken)
       playStatus(transferAgreementSubmit) mustBe SEE_OTHER
@@ -148,7 +148,7 @@ class TransferAgreementControllerSpec extends FrontEndTestHelper {
       stubTransferAgreementResponse(errors = List(GraphQLClient.Error("Error", Nil, Nil, None)))
 
       val controller = new TransferAgreementController(getAuthorisedSecurityComponents, new GraphQLConfiguration(app.configuration),
-        getValidKeycloakConfiguration, new GetConsignmentService(new GraphQLConfiguration(app.configuration)), langs)
+        getValidKeycloakConfiguration, new ConsignmentService(new GraphQLConfiguration(app.configuration)), langs)
       val transferAgreementSubmit = controller.transferAgreementSubmit(consignmentId)
         .apply(FakeRequest(POST, "/consignment/" + consignmentId.toString + "/transfer-agreement")
           .withFormUrlEncodedBody(completedTransferAgreementForm:_*)
@@ -163,7 +163,7 @@ class TransferAgreementControllerSpec extends FrontEndTestHelper {
       stubTransferAgreementResponse(errors = List(GraphQLClient.Error("Error", Nil, Nil, Some(Extensions(Some("NOT_AUTHORISED"))))))
 
       val controller = new TransferAgreementController(getAuthorisedSecurityComponents, new GraphQLConfiguration(app.configuration),
-        getValidKeycloakConfiguration, new GetConsignmentService(new GraphQLConfiguration(app.configuration)), langs)
+        getValidKeycloakConfiguration, new ConsignmentService(new GraphQLConfiguration(app.configuration)), langs)
       val transferAgreementSubmit = controller.transferAgreementSubmit(consignmentId)
         .apply(FakeRequest(POST, "/consignment/" + consignmentId.toString + "/transfer-agreement")
           .withFormUrlEncodedBody(completedTransferAgreementForm:_*)
@@ -177,7 +177,7 @@ class TransferAgreementControllerSpec extends FrontEndTestHelper {
     "display errors when an invalid form is submitted" in {
       val consignmentId = UUID.fromString("c2efd3e6-6664-4582-8c28-dcf891f60e68")
       val controller = new TransferAgreementController(getAuthorisedSecurityComponents, new GraphQLConfiguration(app.configuration),
-        getValidKeycloakConfiguration, new GetConsignmentService(new GraphQLConfiguration(app.configuration)), langs)
+        getValidKeycloakConfiguration, new ConsignmentService(new GraphQLConfiguration(app.configuration)), langs)
 
       val transferAgreementSubmit = controller.transferAgreementSubmit(consignmentId)
         .apply(FakeRequest(POST, "/consignment/" + consignmentId.toString + "/transfer-agreement").withCSRFToken)

--- a/test/errors/ErrorHandlerSpec.scala
+++ b/test/errors/ErrorHandlerSpec.scala
@@ -1,0 +1,30 @@
+package errors
+
+import org.scalatest.concurrent.ScalaFutures._
+import org.scalatest.{FlatSpec, Matchers}
+import play.api.http.Status
+import play.api.i18n.DefaultMessagesApi
+import play.api.test.FakeRequest
+
+class ErrorHandlerSpec extends FlatSpec with Matchers {
+
+  val errorHandler = new ErrorHandler(new DefaultMessagesApi())
+
+  "server error handler" should "return a 403 Forbidden response if an authorisation exception is thrown" in {
+    val request = FakeRequest()
+    val exception = new AuthorisationException("some authorisation error")
+
+    val response = errorHandler.onServerError(request, exception).futureValue
+
+    response.header.status should equal(Status.FORBIDDEN)
+  }
+
+  "server error handler" should "return a 500 Internal Server Error response if an arbitrary exception is thrown" in {
+    val request = FakeRequest()
+    val exception = new Exception("some generic exception")
+
+    val response = errorHandler.onServerError(request, exception).futureValue
+
+    response.header.status should equal(Status.INTERNAL_SERVER_ERROR)
+  }
+}

--- a/test/services/ConsignmentServiceSpec.scala
+++ b/test/services/ConsignmentServiceSpec.scala
@@ -6,6 +6,8 @@ import com.nimbusds.oauth2.sdk.token.BearerAccessToken
 import configuration.GraphQLConfiguration
 import errors.AuthorisationException
 import graphql.codegen.GetConsignment.{getConsignment => gc}
+import graphql.codegen.AddConsignment.addConsignment
+import graphql.codegen.types.AddConsignmentInput
 import org.mockito.Mockito
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures._
@@ -22,8 +24,10 @@ class ConsignmentServiceSpec extends WordSpec with Matchers with MockitoSugar wi
   implicit val ec: ExecutionContext = ExecutionContext.global
 
   private val graphQlConfig = mock[GraphQLConfiguration]
-  private val graphQlClient = mock[GraphQLClient[gc.Data, gc.Variables]]
-  when(graphQlConfig.getClient[gc.Data, gc.Variables]()).thenReturn(graphQlClient)
+  private val getConsignmentClient = mock[GraphQLClient[gc.Data, gc.Variables]]
+  private val addConsignmentClient = mock[GraphQLClient[addConsignment.Data, addConsignment.Variables]]
+  when(graphQlConfig.getClient[gc.Data, gc.Variables]()).thenReturn(getConsignmentClient)
+  when(graphQlConfig.getClient[addConsignment.Data, addConsignment.Variables]()).thenReturn(addConsignmentClient)
 
   private val consignmentService = new ConsignmentService(graphQlConfig)
 
@@ -32,13 +36,13 @@ class ConsignmentServiceSpec extends WordSpec with Matchers with MockitoSugar wi
   private val seriesId = UUID.fromString("d54a5118-33a0-4ba2-8030-d16efcf1d1f4")
 
   override def afterEach(): Unit = {
-    Mockito.reset(graphQlClient)
+    Mockito.reset(getConsignmentClient)
   }
 
   "consignmentExists" should {
     "Return true when given a valid consignment id" in {
       val response = GraphQlResponse(Some(gc.Data(Some(gc.GetConsignment(consignmentId, seriesId)))), Nil)
-      when(graphQlClient.getResult(token, gc.document, Some(gc.Variables(consignmentId))))
+      when(getConsignmentClient.getResult(token, gc.document, Some(gc.Variables(consignmentId))))
         .thenReturn(Future.successful(response))
 
       val getConsignment = consignmentService.consignmentExists(consignmentId, token)
@@ -49,7 +53,7 @@ class ConsignmentServiceSpec extends WordSpec with Matchers with MockitoSugar wi
 
     "Return false if consignment with given id does not exist" in {
       val response = GraphQlResponse(Some(gc.Data(None)), Nil)
-      when(graphQlClient.getResult(token, gc.document, Some(gc.Variables(consignmentId))))
+      when(getConsignmentClient.getResult(token, gc.document, Some(gc.Variables(consignmentId))))
         .thenReturn(Future.successful(response))
 
       val getConsignment = consignmentService.consignmentExists(consignmentId, token)
@@ -59,7 +63,7 @@ class ConsignmentServiceSpec extends WordSpec with Matchers with MockitoSugar wi
     }
 
     "Return an error when the API has an error" in {
-      when(graphQlClient.getResult(token, gc.document, Some(gc.Variables(consignmentId))))
+      when(getConsignmentClient.getResult(token, gc.document, Some(gc.Variables(consignmentId))))
         .thenReturn(Future.failed(HttpError("something went wrong")))
 
       val results = consignmentService.consignmentExists(consignmentId, token)
@@ -68,12 +72,45 @@ class ConsignmentServiceSpec extends WordSpec with Matchers with MockitoSugar wi
 
     "throw an AuthorisationException if the API returns an auth error" in {
       val response = GraphQlResponse[gc.Data](None, List(NotAuthorisedError("some auth error", Nil, Nil)))
-      when(graphQlClient.getResult(token, gc.document, Some(gc.Variables(consignmentId))))
+      when(getConsignmentClient.getResult(token, gc.document, Some(gc.Variables(consignmentId))))
         .thenReturn(Future.successful(response))
 
       val getConsignment = consignmentService.consignmentExists(consignmentId, token)
       val results = getConsignment.failed.futureValue
       results shouldBe a[AuthorisationException]
+    }
+  }
+
+  "createConsignment" should {
+    "create a consignment with the given series" in {
+      val response = GraphQlResponse(Some(new addConsignment.Data(addConsignment.AddConsignment(Some(consignmentId), seriesId))), Nil)
+      val expectedVariables = Some(addConsignment.Variables(AddConsignmentInput(seriesId)))
+      when(addConsignmentClient.getResult(token, addConsignment.document, expectedVariables))
+        .thenReturn(Future.successful(response))
+
+      consignmentService.createConsignment(seriesId, token)
+
+      Mockito.verify(addConsignmentClient).getResult(token, addConsignment.document, expectedVariables)
+    }
+
+
+    "return the created consignment" in {
+      val response = GraphQlResponse(Some(new addConsignment.Data(addConsignment.AddConsignment(Some(consignmentId), seriesId))), Nil)
+      when(addConsignmentClient.getResult(token, addConsignment.document, Some(addConsignment.Variables(AddConsignmentInput(seriesId)))))
+        .thenReturn(Future.successful(response))
+
+      val result = consignmentService.createConsignment(seriesId, token).futureValue
+
+      result.consignmentid should contain(consignmentId)
+    }
+
+    "Return an error when the API has an error" in {
+      when(addConsignmentClient.getResult(token, addConsignment.document, Some(addConsignment.Variables(AddConsignmentInput(seriesId)))))
+        .thenReturn(Future.failed(HttpError("something went wrong")))
+
+      val results = consignmentService.createConsignment(seriesId, token)
+
+      results.failed.futureValue shouldBe a[HttpError]
     }
   }
 }

--- a/test/services/ConsignmentServiceSpec.scala
+++ b/test/services/ConsignmentServiceSpec.scala
@@ -20,7 +20,7 @@ import util.FrontEndTestHelper
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class GetConsignmentServiceSpec extends FrontEndTestHelper {
+class ConsignmentServiceSpec extends FrontEndTestHelper {
 
   implicit val ec: ExecutionContext = ExecutionContext.global
   implicit val patienceConfig: PatienceConfig = PatienceConfig(timeout = scaled(Span(5, Seconds)), interval = scaled(Span(100, Millis)))
@@ -80,7 +80,7 @@ class GetConsignmentServiceSpec extends FrontEndTestHelper {
 
       val captors = mockOkResponse(graphQLClient, Some(gc.Data(Some(consignmentResponse))), List())
 
-      val getConsignment = new GetConsignmentService(graphQLConfig).consignmentExists(consignmentId, new BearerAccessToken("someAccessToken"))
+      val getConsignment = new ConsignmentService(graphQLConfig).consignmentExists(consignmentId, new BearerAccessToken("someAccessToken"))
       val actualResults = getConsignment.futureValue
 
       actualResults should be(true)
@@ -96,7 +96,7 @@ class GetConsignmentServiceSpec extends FrontEndTestHelper {
 
       val captors = mockOkResponse(graphQLClient, Some(gc.Data(None)), List())
 
-      val getConsignment = new GetConsignmentService(graphQLConfig).consignmentExists(consignmentId, new BearerAccessToken("someAccessToken"))
+      val getConsignment = new ConsignmentService(graphQLConfig).consignmentExists(consignmentId, new BearerAccessToken("someAccessToken"))
       val actualResults = getConsignment.futureValue
       actualResults shouldBe false
       verifyCaptors(captors, consignmentId)
@@ -111,7 +111,7 @@ class GetConsignmentServiceSpec extends FrontEndTestHelper {
 
       val captors = mockFailedResponse(graphQLClient)
 
-      val getConsignment = new GetConsignmentService(graphQLConfig).consignmentExists(consignmentId, new BearerAccessToken("someAccessToken"))
+      val getConsignment = new ConsignmentService(graphQLConfig).consignmentExists(consignmentId, new BearerAccessToken("someAccessToken"))
 
       val results = getConsignment.failed.futureValue
 
@@ -130,7 +130,7 @@ class GetConsignmentServiceSpec extends FrontEndTestHelper {
       val error = NotAuthorisedError("some auth error", List(), List())
       mockGraphqlError(graphQLClient, consignmentId, token, error)
 
-      val getConsignment = new GetConsignmentService(graphQLConfig).consignmentExists(consignmentId, token)
+      val getConsignment = new ConsignmentService(graphQLConfig).consignmentExists(consignmentId, token)
 
       val results = getConsignment.failed.futureValue
 

--- a/test/services/ConsignmentServiceSpec.scala
+++ b/test/services/ConsignmentServiceSpec.scala
@@ -112,5 +112,14 @@ class ConsignmentServiceSpec extends WordSpec with Matchers with MockitoSugar wi
 
       results.failed.futureValue shouldBe a[HttpError]
     }
+
+    "throw an AuthorisationException if the API returns an auth error" in {
+      val response = GraphQlResponse[addConsignment.Data](None, List(NotAuthorisedError("some auth error", Nil, Nil)))
+      when(addConsignmentClient.getResult(token, addConsignment.document, Some(addConsignment.Variables(AddConsignmentInput(seriesId)))))
+        .thenReturn(Future.successful(response))
+
+      val results = consignmentService.createConsignment(seriesId, token).failed.futureValue
+      results shouldBe a[AuthorisationException]
+    }
   }
 }

--- a/test/services/SeriesServiceSpec.scala
+++ b/test/services/SeriesServiceSpec.scala
@@ -1,0 +1,60 @@
+package services
+
+import java.util.UUID
+
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken
+import configuration.GraphQLConfiguration
+import graphql.codegen.GetSeries.getSeries
+import graphql.codegen.GetSeries.getSeries.GetSeries
+import org.keycloak.representations.AccessToken
+import org.mockito.Mockito
+import org.mockito.Mockito.when
+import org.scalatest.concurrent.ScalaFutures._
+import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
+import org.scalatestplus.mockito.MockitoSugar
+import uk.gov.nationalarchives.tdr.keycloak.Token
+import uk.gov.nationalarchives.tdr.{GraphQLClient, GraphQlResponse}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class SeriesServiceSpec extends FlatSpec with Matchers with MockitoSugar with BeforeAndAfterEach {
+
+  implicit val ec: ExecutionContext = ExecutionContext.global
+
+  private val graphQlConfig = mock[GraphQLConfiguration]
+  private val graphQlClient = mock[GraphQLClient[getSeries.Data, getSeries.Variables]]
+  when(graphQlConfig.getClient[getSeries.Data, getSeries.Variables]()).thenReturn(graphQlClient)
+
+  private val seriesService: SeriesService = new SeriesService(graphQlConfig)
+
+  private val seriesId = UUID.fromString("8ba6ad4e-546c-4e41-b3ca-72de01513d20")
+  private val bodyName = "some transferring body"
+  private val bodyId = UUID.fromString("d3bbde54-f872-4c92-8623-59acf48a1bbd")
+
+  private val accessToken = new AccessToken()
+  accessToken.setOtherClaims("body", bodyName)
+  private val token = Token(accessToken, new BearerAccessToken("some-token"))
+
+  override def afterEach(): Unit = {
+    Mockito.reset(graphQlClient)
+  }
+
+  "getSeriesForUser" should "get the series from the API" in {
+    val seriesResponse = GetSeries(seriesId, bodyId, Some("some series name"), None, None)
+    val graphQlResponse = GraphQlResponse(Some(getSeries.Data(List(seriesResponse))), Nil)
+    when(graphQlClient.getResult(token.bearerAccessToken, getSeries.document, Some(getSeries.Variables(bodyName))))
+      .thenReturn(Future.successful(graphQlResponse))
+
+    val series = seriesService.getSeriesForUser(token).futureValue
+
+    series.size should equal(1)
+    series.head.seriesid should equal(seriesId)
+  }
+
+  "getSeriesForUser" should "return an error if the API call fails" in {
+    when(graphQlClient.getResult(token.bearerAccessToken, getSeries.document, Some(getSeries.Variables(bodyName))))
+      .thenReturn(Future.failed(new RuntimeException("something went wrong")))
+
+    seriesService.getSeriesForUser(token).failed.futureValue shouldBe a[RuntimeException]
+  }
+}

--- a/test/services/SeriesServiceSpec.scala
+++ b/test/services/SeriesServiceSpec.scala
@@ -13,6 +13,7 @@ import org.mockito.Mockito.when
 import org.scalatest.concurrent.ScalaFutures._
 import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
 import org.scalatestplus.mockito.MockitoSugar
+import sttp.client.HttpError
 import uk.gov.nationalarchives.tdr.error.NotAuthorisedError
 import uk.gov.nationalarchives.tdr.keycloak.Token
 import uk.gov.nationalarchives.tdr.{GraphQLClient, GraphQlResponse}
@@ -55,9 +56,9 @@ class SeriesServiceSpec extends FlatSpec with Matchers with MockitoSugar with Be
 
   "getSeriesForUser" should "return an error if the API call fails" in {
     when(graphQlClient.getResult(token.bearerAccessToken, getSeries.document, Some(getSeries.Variables(bodyName))))
-      .thenReturn(Future.failed(new RuntimeException("something went wrong")))
+      .thenReturn(Future.failed(new HttpError("something went wrong")))
 
-    seriesService.getSeriesForUser(token).failed.futureValue shouldBe a[RuntimeException]
+    seriesService.getSeriesForUser(token).failed.futureValue shouldBe a[HttpError]
   }
 
   "getSeriesForUser" should "throw an AuthorisationException if the API returns an auth error" in {

--- a/test/services/TransferAgreementServiceSpec.scala
+++ b/test/services/TransferAgreementServiceSpec.scala
@@ -1,0 +1,61 @@
+package services
+
+import java.util.UUID
+
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken
+import configuration.GraphQLConfiguration
+import org.mockito.Mockito.when
+import org.scalatest.concurrent.ScalaFutures._
+import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
+import org.scalatestplus.mockito.MockitoSugar
+import graphql.codegen.IsTransferAgreementComplete.{isTransferAgreementComplete => taComplete}
+import graphql.codegen.IsTransferAgreementComplete.isTransferAgreementComplete._
+import org.mockito.Mockito
+import uk.gov.nationalarchives.tdr.{GraphQLClient, GraphQlResponse}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class TransferAgreementServiceSpec extends FlatSpec with Matchers with MockitoSugar with BeforeAndAfterEach {
+
+  implicit val ec: ExecutionContext = ExecutionContext.global
+
+  private val graphQlConfig = mock[GraphQLConfiguration]
+  private val graphQlClient = mock[GraphQLClient[taComplete.Data, taComplete.Variables]]
+
+  // TODO: Inject client rather than creating each time
+  private var transferAgreementService = new TransferAgreementService(graphQlConfig)
+
+  private val consignmentId = UUID.fromString("da84d99f-469d-4893-8c7b-46900cfa1a8f")
+  private val token = new BearerAccessToken("some-token")
+  private val variables = Variables(consignmentId)
+
+  override def beforeEach(): Unit = {
+    when(graphQlConfig.getClient[taComplete.Data, taComplete.Variables]()).thenReturn(graphQlClient)
+
+    transferAgreementService = new TransferAgreementService(graphQlConfig)
+  }
+
+  override def afterEach(): Unit = {
+    Mockito.reset(graphQlClient)
+  }
+
+  "transferAgreementExists" should "be true if the API check returns 'true'" in {
+    val response = GraphQlResponse(Some(Data(Some(GetTransferAgreement(true)))), Nil)
+
+    when(graphQlClient.getResult(token, document, Some(variables)))
+      .thenReturn(Future.successful(response))
+
+    transferAgreementService.transferAgreementExists(consignmentId, token).futureValue should be(true)
+  }
+
+  "transferAgreementExists" should "be false if the API check returns 'false'" in {
+    val response = GraphQlResponse(Some(Data(Some(GetTransferAgreement(false)))), Nil)
+
+    when(graphQlClient.getResult(token, document, Some(variables)))
+      .thenReturn(Future.successful(response))
+
+    transferAgreementService.transferAgreementExists(consignmentId, token).futureValue should be(false)
+  }
+
+
+}

--- a/test/services/TransferAgreementServiceSpec.scala
+++ b/test/services/TransferAgreementServiceSpec.scala
@@ -4,13 +4,15 @@ import java.util.UUID
 
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken
 import configuration.GraphQLConfiguration
+import errors.AuthorisationException
+import graphql.codegen.IsTransferAgreementComplete.isTransferAgreementComplete._
+import graphql.codegen.IsTransferAgreementComplete.{isTransferAgreementComplete => taComplete}
+import org.mockito.Mockito
 import org.mockito.Mockito.when
 import org.scalatest.concurrent.ScalaFutures._
 import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
 import org.scalatestplus.mockito.MockitoSugar
-import graphql.codegen.IsTransferAgreementComplete.{isTransferAgreementComplete => taComplete}
-import graphql.codegen.IsTransferAgreementComplete.isTransferAgreementComplete._
-import org.mockito.Mockito
+import uk.gov.nationalarchives.tdr.error.{NotAuthorisedError, UnknownGraphQlError}
 import uk.gov.nationalarchives.tdr.{GraphQLClient, GraphQlResponse}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -22,7 +24,6 @@ class TransferAgreementServiceSpec extends FlatSpec with Matchers with MockitoSu
   private val graphQlConfig = mock[GraphQLConfiguration]
   private val graphQlClient = mock[GraphQLClient[taComplete.Data, taComplete.Variables]]
 
-  // TODO: Inject client rather than creating each time
   private var transferAgreementService = new TransferAgreementService(graphQlConfig)
 
   private val consignmentId = UUID.fromString("da84d99f-469d-4893-8c7b-46900cfa1a8f")
@@ -57,5 +58,37 @@ class TransferAgreementServiceSpec extends FlatSpec with Matchers with MockitoSu
     transferAgreementService.transferAgreementExists(consignmentId, token).futureValue should be(false)
   }
 
+  "transferAgreementExists" should "be false if the transfer agreement data does not exist" in {
+    val response = GraphQlResponse(Some(Data(None)), Nil)
 
+    when(graphQlClient.getResult(token, document, Some(variables)))
+      .thenReturn(Future.successful(response))
+
+    transferAgreementService.transferAgreementExists(consignmentId, token).futureValue should be(false)
+  }
+
+  "transferAgreementExists" should "throw an error if the API call fails" in {
+    when(graphQlClient.getResult(token, document, Some(variables)))
+      .thenReturn(Future.failed(new RuntimeException("something went wrong")))
+
+    transferAgreementService.transferAgreementExists(consignmentId, token).failed.futureValue shouldBe a[RuntimeException]
+  }
+
+  "transferAgreementExists" should "throw an error if the API call contains a GraphQL error" in {
+    val response = GraphQlResponse[Data](None, List(UnknownGraphQlError("something went wrong", Nil, Nil, None)))
+
+    when(graphQlClient.getResult(token, document, Some(variables)))
+      .thenReturn(Future.successful(response))
+
+    transferAgreementService.transferAgreementExists(consignmentId, token).failed.futureValue shouldBe a[RuntimeException]
+  }
+
+  "transferAgreementExists" should "throw an authorisation exception if the API call is not authorised" in {
+    val response = GraphQlResponse[Data](None, List(NotAuthorisedError("something went wrong", Nil, Nil)))
+
+    when(graphQlClient.getResult(token, document, Some(variables)))
+      .thenReturn(Future.successful(response))
+
+    transferAgreementService.transferAgreementExists(consignmentId, token).failed.futureValue shouldBe a[AuthorisationException]
+  }
 }

--- a/test/services/TransferAgreementServiceSpec.scala
+++ b/test/services/TransferAgreementServiceSpec.scala
@@ -23,18 +23,13 @@ class TransferAgreementServiceSpec extends FlatSpec with Matchers with MockitoSu
 
   private val graphQlConfig = mock[GraphQLConfiguration]
   private val graphQlClient = mock[GraphQLClient[taComplete.Data, taComplete.Variables]]
+  when(graphQlConfig.getClient[taComplete.Data, taComplete.Variables]()).thenReturn(graphQlClient)
 
-  private var transferAgreementService = new TransferAgreementService(graphQlConfig)
+  private val transferAgreementService: TransferAgreementService = new TransferAgreementService(graphQlConfig)
 
   private val consignmentId = UUID.fromString("da84d99f-469d-4893-8c7b-46900cfa1a8f")
   private val token = new BearerAccessToken("some-token")
   private val variables = Variables(consignmentId)
-
-  override def beforeEach(): Unit = {
-    when(graphQlConfig.getClient[taComplete.Data, taComplete.Variables]()).thenReturn(graphQlClient)
-
-    transferAgreementService = new TransferAgreementService(graphQlConfig)
-  }
 
   override def afterEach(): Unit = {
     Mockito.reset(graphQlClient)

--- a/test/services/TransferAgreementServiceSpec.scala
+++ b/test/services/TransferAgreementServiceSpec.scala
@@ -4,7 +4,7 @@ import java.util.UUID
 
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken
 import configuration.GraphQLConfiguration
-import errors.AuthorisationException
+import errors.{AuthorisationException, GraphQlException}
 import graphql.codegen.IsTransferAgreementComplete.isTransferAgreementComplete._
 import graphql.codegen.IsTransferAgreementComplete.{isTransferAgreementComplete => taComplete}
 import org.mockito.Mockito
@@ -12,6 +12,7 @@ import org.mockito.Mockito.when
 import org.scalatest.concurrent.ScalaFutures._
 import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
 import org.scalatestplus.mockito.MockitoSugar
+import sttp.client.HttpError
 import uk.gov.nationalarchives.tdr.error.{NotAuthorisedError, UnknownGraphQlError}
 import uk.gov.nationalarchives.tdr.{GraphQLClient, GraphQlResponse}
 
@@ -64,9 +65,9 @@ class TransferAgreementServiceSpec extends FlatSpec with Matchers with MockitoSu
 
   "transferAgreementExists" should "throw an error if the API call fails" in {
     when(graphQlClient.getResult(token, document, Some(variables)))
-      .thenReturn(Future.failed(new RuntimeException("something went wrong")))
+      .thenReturn(Future.failed(new HttpError("something went wrong")))
 
-    transferAgreementService.transferAgreementExists(consignmentId, token).failed.futureValue shouldBe a[RuntimeException]
+    transferAgreementService.transferAgreementExists(consignmentId, token).failed.futureValue shouldBe a[HttpError]
   }
 
   "transferAgreementExists" should "throw an error if the API call contains a GraphQL error" in {
@@ -75,7 +76,7 @@ class TransferAgreementServiceSpec extends FlatSpec with Matchers with MockitoSu
     when(graphQlClient.getResult(token, document, Some(variables)))
       .thenReturn(Future.successful(response))
 
-    transferAgreementService.transferAgreementExists(consignmentId, token).failed.futureValue shouldBe a[RuntimeException]
+    transferAgreementService.transferAgreementExists(consignmentId, token).failed.futureValue shouldBe a[GraphQlException]
   }
 
   "transferAgreementExists" should "throw an authorisation exception if the API call is not authorised" in {

--- a/test/util/FrontEndTestHelper.scala
+++ b/test/util/FrontEndTestHelper.scala
@@ -27,6 +27,8 @@ import org.pac4j.play.http.PlayHttpActionAdapter
 import org.pac4j.play.scala.SecurityComponents
 import org.pac4j.play.store.{PlayCacheSessionStore, PlaySessionStore}
 import org.scalatest.BeforeAndAfterEach
+import org.scalatest.concurrent.ScalaFutures.{PatienceConfig, scaled}
+import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneAppPerTest
@@ -44,6 +46,8 @@ import scala.concurrent.{Await, Future}
 
 
 trait FrontEndTestHelper extends PlaySpec with MockitoSugar with Injecting with GuiceOneAppPerTest with BeforeAndAfterEach {
+
+  implicit val patienceConfig: PatienceConfig = PatienceConfig(timeout = scaled(Span(5, Seconds)), interval = scaled(Span(100, Millis)))
 
   implicit class AwaitFuture[T](future: Future[T]) {
     def await(timeout: Duration = 2.seconds): T = {


### PR DESCRIPTION
This change:

- Checks for authorisation errors in the GraphQL response, and throws an AuthorisationException if it finds any
- Adds a [custom Play ErrorHandler](https://www.playframework.com/documentation/2.8.x/ScalaErrorHandling), which catches AuthorisationException and converts it to a 403 Forbidden response

The custom error handling will make it easier for us to add branded error pages in future, because we can add them to this file rather than to all of the controllers.

I've extracted services from a few of the controllers, so that I wasn't cluttering up the controllers even more. That makes this change quite large, but hopefully it's worth it - take a look at the SeriesDetailsController, for example. I think it's a bit easier to follow [on this branch](https://github.com/nationalarchives/tdr-transfer-frontend/blob/add-authorisation/app/controllers/SeriesDetailsController.scala) than it does on [master](https://github.com/nationalarchives/tdr-transfer-frontend/blob/02c22f7ce9dea83819001367e5437183fd405731/app/controllers/SeriesDetailsController.scala) - let me know what you think!

I've also tried to simplify the tests where I was adding more setup that would have made them more complicated.