### PR TITLE
Replace | with ||

### DIFF
--- a/npm/webpack.config.js
+++ b/npm/webpack.config.js
@@ -26,8 +26,8 @@ module.exports = {
           "auth.tdr-integration.nationalarchives.gov.uk/auth/realms/tdr"
       ),
       TDR_IDENTITY_POOL_ID: JSON.stringify(process.env.TDR_IDENTITY_POOL_ID),
-      REGION: JSON.stringify(process.env.REGION | "eu-west-2"),
-      STAGE: JSON.stringify(process.env.STAGE | "intg")
+      REGION: JSON.stringify(process.env.REGION || "eu-west-2"),
+      STAGE: JSON.stringify(process.env.STAGE || "intg")
     })
   ],
   output: {


### PR DESCRIPTION
The webpack config is supposed to have defaults. So you have `process.env.API_URL || "http://localhost:8080"`
The problem with the two latest variables is that I used | instead of || which through the wonders of javascript logic evaluates to "0" which is not a valid AWS region. 