### PR TITLE
Redirect to records page after successful upload

### DIFF
--- a/app/controllers/RecordsController.scala
+++ b/app/controllers/RecordsController.scala
@@ -16,6 +16,6 @@ class RecordsController @Inject()(val controllerComponents: SecurityComponents,
                                  ) extends OidcSecurity with I18nSupport {
 
   def recordsPage(consignmentId: UUID): Action[AnyContent] = secureAction { implicit request: Request[AnyContent] =>
-    Ok(views.html.records())
+    Ok(views.html.records(consignmentId))
   }
 }

--- a/app/controllers/UploadController.scala
+++ b/app/controllers/UploadController.scala
@@ -5,8 +5,6 @@ import java.util.UUID
 import configuration.{FrontEndInfoConfiguration, GraphQLConfiguration, KeycloakConfiguration}
 import javax.inject.{Inject, Singleton}
 import org.pac4j.play.scala.SecurityComponents
-import play.api.data.Form
-import play.api.data.Forms._
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, Request}
 import validation.ValidatedActions
@@ -24,10 +22,4 @@ class UploadController @Inject()(val controllerComponents: SecurityComponents,
     Ok(views.html.upload(consignmentId, frontEndInfoConfiguration.frontEndInfo))
   }
 
-  def uploadRedirect(consignmentId: UUID): Action[AnyContent] = secureAction { implicit request: Request[AnyContent] =>
-    Redirect(routes.RecordsController.recordsPage(consignmentId))
-  }
-
 }
-
-case class UploadData(consignmentId: UUID)

--- a/app/controllers/UploadController.scala
+++ b/app/controllers/UploadController.scala
@@ -5,7 +5,8 @@ import java.util.UUID
 import configuration.{FrontEndInfoConfiguration, GraphQLConfiguration, KeycloakConfiguration}
 import javax.inject.{Inject, Singleton}
 import org.pac4j.play.scala.SecurityComponents
-import play.api.Configuration
+import play.api.data.Form
+import play.api.data.Forms._
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, Request}
 import validation.ValidatedActions
@@ -22,4 +23,11 @@ class UploadController @Inject()(val controllerComponents: SecurityComponents,
   def uploadPage(consignmentId: UUID): Action[AnyContent] = transferAgreementExistsAction(consignmentId) { implicit request: Request[AnyContent] =>
     Ok(views.html.upload(consignmentId, frontEndInfoConfiguration.frontEndInfo))
   }
+
+  def uploadRedirect(consignmentId: UUID): Action[AnyContent] = secureAction { implicit request: Request[AnyContent] =>
+    Redirect(routes.RecordsController.recordsPage(consignmentId))
+  }
+
 }
+
+case class UploadData(consignmentId: UUID)

--- a/app/views/records.scala.html
+++ b/app/views/records.scala.html
@@ -1,4 +1,5 @@
-@()(implicit messages: Messages)
+@import java.util.UUID
+@(consignmentId: UUID)(implicit messages: Messages)
 
 @main(Messages("records.header")) {
 <h1 class="govuk-heading-xl">@Messages("records.title")</h1>

--- a/app/views/upload.scala.html
+++ b/app/views/upload.scala.html
@@ -25,9 +25,6 @@
                 </ul>
             </div>
         </div>
-        @form(routes.UploadController.uploadRedirect(consignmentId), Symbol("id") -> "upload-data-form") {
-            @CSRF.formField
-        }
         <form id="file-upload-form" data-consignment-id="@consignmentId">
             <div class="govuk-form-group">
                 <label class="govuk-label" for="file-selection">
@@ -51,6 +48,8 @@
                 </button>
             </div>
         </form>
+<!--        Form to redirect user once upload has completed. It sends consignmentId to record processing placeholder page -->
+        @form(routes.RecordsController.recordsPage(consignmentId), Symbol("id") -> "upload-data-form") { }
     </div>
 </div>
 <div id="progress-bar" class="govuk-grid-row hide">

--- a/app/views/upload.scala.html
+++ b/app/views/upload.scala.html
@@ -1,6 +1,7 @@
 @import java.util.UUID
 @import viewsapi.FrontEndInfo
-@(consignmentId: UUID, frontEndInfo: FrontEndInfo)(implicit messages: Messages)
+@import helper._
+@(consignmentId: UUID, frontEndInfo: FrontEndInfo)(implicit request: RequestHeader, messages: Messages)
 
 @main(Messages("upload.header")) {
 <div id="file-upload" class="govuk-grid-row">
@@ -24,6 +25,9 @@
                 </ul>
             </div>
         </div>
+        @form(routes.UploadController.uploadRedirect(consignmentId), Symbol("id") -> "upload-data-form") {
+            @CSRF.formField
+        }
         <form id="file-upload-form" data-consignment-id="@consignmentId">
             <div class="govuk-form-group">
                 <label class="govuk-label" for="file-selection">

--- a/conf/routes
+++ b/conf/routes
@@ -11,6 +11,7 @@ POST    /series                                            controllers.SeriesDet
 GET     /consignment/:consignmentId/transfer-agreement     controllers.TransferAgreementController.transferAgreement(consignmentId: java.util.UUID)
 POST    /consignment/:consignmentId/transfer-agreement     controllers.TransferAgreementController.transferAgreementSubmit(consignmentId: java.util.UUID)
 GET     /consignment/:consignmentId/upload                 controllers.UploadController.uploadPage(consignmentId: java.util.UUID)
+POST    /consignment/:consignmentId/upload                controllers.UploadController.uploadRedirect(consignmentId: java.util.UUID)
 GET     /consignment/:consignmentId/records                controllers.RecordsController.recordsPage(consignmentId: java.util.UUID)
 GET     /keycloak.json                                     controllers.KeycloakConfigurationController.keycloak
 

--- a/conf/routes
+++ b/conf/routes
@@ -11,7 +11,6 @@ POST    /series                                            controllers.SeriesDet
 GET     /consignment/:consignmentId/transfer-agreement     controllers.TransferAgreementController.transferAgreement(consignmentId: java.util.UUID)
 POST    /consignment/:consignmentId/transfer-agreement     controllers.TransferAgreementController.transferAgreementSubmit(consignmentId: java.util.UUID)
 GET     /consignment/:consignmentId/upload                 controllers.UploadController.uploadPage(consignmentId: java.util.UUID)
-POST    /consignment/:consignmentId/upload                controllers.UploadController.uploadRedirect(consignmentId: java.util.UUID)
 GET     /consignment/:consignmentId/records                controllers.RecordsController.recordsPage(consignmentId: java.util.UUID)
 GET     /keycloak.json                                     controllers.KeycloakConfigurationController.keycloak
 

--- a/npm/src/upload/index.ts
+++ b/npm/src/upload/index.ts
@@ -26,6 +26,24 @@ export class UploadFiles {
     )
     this.stage = stage
   }
+
+  retrieveFiles(target: HTMLInputTarget | null): TdrFile[] {
+    const files: TdrFile[] = target!.files!.files!
+    if (files === null || files.length === 0) {
+      throw Error("No files selected")
+    }
+    return files
+  }
+
+  uploadFilesSuccess(): void {
+    const uploadDataFormRedirect: HTMLFormElement | null = document.querySelector(
+      "#upload-data-form"
+    )
+    if (uploadDataFormRedirect) {
+      uploadDataFormRedirect.submit()
+    }
+  }
+
   upload(): void {
     const uploadForm: HTMLFormElement | null = document.querySelector(
       "#file-upload-form"
@@ -48,12 +66,7 @@ export class UploadFiles {
           if (!consignmentId) {
             throw Error("No consignment provided")
           }
-
-          const files: TdrFile[] = target!.files!.files!
-
-          if (files === null || files.length === 0) {
-            throw Error("No files selected")
-          }
+          const files = this.retrieveFiles(target)
 
           await this.clientFileProcessing.processClientFiles(
             consignmentId,
@@ -61,9 +74,7 @@ export class UploadFiles {
             progress => console.log(progress.percentageProcessed),
             this.stage
           )
-          if (uploadDataFormRedirect) {
-            uploadDataFormRedirect.submit()
-          }
+          this.uploadFilesSuccess()
         } catch (e) {
           //For now console log errors
           console.error("Client file upload failed: " + e.message)

--- a/npm/src/upload/index.ts
+++ b/npm/src/upload/index.ts
@@ -31,8 +31,12 @@ export class UploadFiles {
       "#file-upload-form"
     )
 
+    const uploadDataFormRedirect: HTMLFormElement | null = document.querySelector(
+      "#upload-data-form"
+    )
+
     if (uploadForm) {
-      uploadForm.addEventListener("submit", ev => {
+      uploadForm.addEventListener("submit", async ev => {
         ev.preventDefault()
         const consignmentId: string | null = uploadForm.getAttribute(
           "data-consignment-id"
@@ -51,12 +55,15 @@ export class UploadFiles {
             throw Error("No files selected")
           }
 
-          this.clientFileProcessing.processClientFiles(
+          await this.clientFileProcessing.processClientFiles(
             consignmentId,
             files,
             progress => console.log(progress.percentageProcessed),
             this.stage
           )
+          if (uploadDataFormRedirect) {
+            uploadDataFormRedirect.submit()
+          }
         } catch (e) {
           //For now console log errors
           console.error("Client file upload failed: " + e.message)

--- a/npm/test/upload.test.ts
+++ b/npm/test/upload.test.ts
@@ -1,27 +1,156 @@
+import { ClientFileProcessing } from "../src/clientfileprocessing"
+import { TdrFile, TProgressFunction } from "@nationalarchives/file-information"
+import { UploadFiles } from "../src/upload"
+import { mockKeycloakInstance } from "./utils"
+import { GraphqlClient } from "../src/graphql"
+import { ClientFileMetadataUpload } from "../src/clientfilemetadataupload"
+jest.mock("../src/clientfileprocessing")
+
 beforeEach(() => jest.resetModules())
 
-test("upload console logs error when upload fails", () => {
-  const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {})
-  document.body.innerHTML =
-    '<div class="govuk-file-upload">' +
-    '<form id="file-upload-form" data-consignment-id="12345">' +
-    '<button class="govuk-button" type="submit" data-module="govuk-button" role="button" />' +
-    "</form>" +
-    "</div>"
+const dummyFile = {
+  webkitRelativePath: "relativePath"
+} as TdrFile
+
+class ClientFileProcessingSuccess {
+  processClientFiles: (
+    consignmentId: string,
+    files: TdrFile[],
+    callback: TProgressFunction,
+    stage: string
+  ) => Promise<void> = async (
+    consignmentId: string,
+    files: TdrFile[],
+    callback: TProgressFunction,
+    stage: string
+  ) => {}
+}
+
+class ClientFileProcessingFailure {
+  processClientFiles: (
+    consignmentId: string,
+    files: TdrFile[],
+    callback: TProgressFunction,
+    stage: string
+  ) => Promise<void> = async (
+    consignmentId: string,
+    files: TdrFile[],
+    callback: TProgressFunction,
+    stage: string
+  ) => {
+    throw Error("Some error")
+  }
+}
+
+const mockUploadSuccess: () => void = () => {
+  const mock = ClientFileProcessing as jest.Mock
+  mock.mockImplementation(() => {
+    return new ClientFileProcessingSuccess()
+  })
+}
+
+const mockUploadFailure: () => void = () => {
+  const mock = ClientFileProcessing as jest.Mock
+  mock.mockImplementation(() => {
+    return new ClientFileProcessingFailure()
+  })
+}
+
+test("upload function submits redirect form on upload files success", async () => {
+  mockUploadSuccess()
+  setUpUploadHTML()
+
+  const uploadFiles = setUpUploadFiles()
+  const consoleErrorSpy = jest
+    .spyOn(console, "error")
+    .mockImplementation(() => {})
+
+  const mockRetrieveFiles = jest
+    .spyOn(uploadFiles, "retrieveFiles")
+    .mockImplementation(() => {
+      return [dummyFile]
+    })
+
+  const mockUploadFilesSuccess = jest
+    .spyOn(uploadFiles, "uploadFilesSuccess")
+    .mockImplementation(() => {})
+  uploadFiles.upload()
+
+  const uploadForm: HTMLFormElement | null = document.querySelector(
+    "#file-upload-form"
+  )
+  const uploadDataForm: HTMLFormElement | null = document.querySelector(
+    "#upload-data-form"
+  )
+
+  if (uploadForm && uploadDataForm) {
+    await uploadForm.submit()
+    expect(mockRetrieveFiles).toBeCalledTimes(1)
+    expect(mockUploadFilesSuccess).toBeCalledTimes(1)
+  }
+
+  expect(consoleErrorSpy).not.toHaveBeenCalled()
+
+  mockRetrieveFiles.mockRestore()
+  mockUploadFilesSuccess.mockRestore()
+  consoleErrorSpy.mockRestore()
+})
+
+test("upload function console logs error when upload fails", async () => {
+  mockUploadFailure()
+  setUpUploadHTML()
+
+  const uploadFiles = setUpUploadFiles()
+  const consoleErrorSpy = jest
+    .spyOn(console, "error")
+    .mockImplementation(() => {})
+
+  const mockRetrieveFiles = jest
+    .spyOn(uploadFiles, "retrieveFiles")
+    .mockImplementation(() => {
+      return [dummyFile]
+    })
+
+  const mockUploadFilesSuccess = jest
+    .spyOn(uploadFiles, "uploadFilesSuccess")
+    .mockImplementation(() => {})
 
   const uploadForm: HTMLFormElement | null = document.querySelector(
     "#file-upload-form"
   )
 
-  if (uploadForm) {
-    uploadForm.submit()
+  const uploadDataForm: HTMLFormElement | null = document.querySelector(
+    "#upload-data-form"
+  )
+  uploadFiles.upload()
+  if (uploadForm && uploadDataForm) {
+    await uploadForm.submit()
+    expect(mockRetrieveFiles).toBeCalledTimes(1)
+    expect(mockUploadFilesSuccess).toBeCalledTimes(0)
   }
 
-  expect(consoleSpy).toHaveBeenCalled()
+  expect(consoleErrorSpy).toHaveBeenCalled()
+
+  mockRetrieveFiles.mockRestore()
+  mockUploadFilesSuccess.mockRestore()
+  consoleErrorSpy.mockRestore()
 })
 
-test("upload console logs error no consignment id provided", () => {
-  const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {})
+test("upload function console logs error when no consignment id provided", async () => {
+  const consoleErrorSpy = jest
+    .spyOn(console, "error")
+    .mockImplementation(() => {})
+  const uploadFiles = setUpUploadFiles()
+
+  const mockRetrieveFiles = jest
+    .spyOn(uploadFiles, "retrieveFiles")
+    .mockImplementation(() => {
+      return [dummyFile]
+    })
+
+  const mockUploadFilesSuccess = jest
+    .spyOn(uploadFiles, "uploadFilesSuccess")
+    .mockImplementation(() => {})
   document.body.innerHTML =
     '<div class="govuk-file-upload">' +
     '<form id="file-upload-form">' +
@@ -32,10 +161,32 @@ test("upload console logs error no consignment id provided", () => {
   const uploadForm: HTMLFormElement | null = document.querySelector(
     "#file-upload-form"
   )
-
+  uploadFiles.upload()
   if (uploadForm) {
-    uploadForm.submit()
+    await uploadForm.submit()
+    expect(mockRetrieveFiles).toBeCalledTimes(0)
+    expect(mockUploadFilesSuccess).toBeCalledTimes(0)
   }
 
-  expect(consoleSpy).toHaveBeenCalled()
+  expect(consoleErrorSpy).toHaveBeenCalled()
+
+  mockRetrieveFiles.mockRestore()
+  mockUploadFilesSuccess.mockRestore()
+  consoleErrorSpy.mockRestore()
 })
+
+function setUpUploadFiles(): UploadFiles {
+  const client = new GraphqlClient("https://test.im", mockKeycloakInstance)
+  const uploadMetadata = new ClientFileMetadataUpload(client)
+  return new UploadFiles(uploadMetadata, "identityId", "test")
+}
+
+function setUpUploadHTML() {
+  document.body.innerHTML =
+    '<div class="govuk-file-upload">' +
+    '<form id="file-upload-form" data-consignment-id="12345">' +
+    '<button class="govuk-button" type="submit" data-module="govuk-button" role="button" />' +
+    "</form>" +
+    '<form id="upload-data-form"></form>'
+  "</div>"
+}


### PR DESCRIPTION
This change makes the file upload asynchronous so that we can wait until
it is completed, then redirect the user to the 'processing records' placeholder page.

**As the upload does not fully work yet, this code is untested and I'm happy to leave it
as a WIP if recommended to.**

Rather than utilising an additional form submission in the browser as the alpha version does.
This change uses the existing uploading JS functions to redirect the user to the right page, as these functions already hold the information about the progress of the upload.