### PR TITLE
Create groovy function to post jenkins build status to github

### DIFF
--- a/Jenkinsfile-testing
+++ b/Jenkinsfile-testing
@@ -1,8 +1,15 @@
 def versionTag = "v${env.BUILD_NUMBER}"
 
+def setBuildStatus(String status, String desc) {
+  withCredentials([string(credentialsId: 'github-jenkins-access-token', variable: 'GITHUB_ACCESS_TOKEN')]) {
+    String sha = sh(script: 'git rev-parse HEAD', returnStdout: true).trim()
+    String url = "https://api.github.com/repos/nationalarchives/tdr-transfer-frontend/statuses/${sha}"
+    sh "curl -XPOST '${url}' -H 'Authorization: bearer ${env.GITHUB_ACCESS_TOKEN}' --data '{\"state\":\"${status}\",\"target_url\":\"${env.BUILD_URL}\",\"description\":\"${desc}\",\"context\":\"Jenkins TDR Front end test\"}'"
+  }
+}
+
 pipeline {
   agent none
-
   stages {
     stage('Test') {
       agent {
@@ -11,6 +18,7 @@ pipeline {
         }
       }
       steps {
+        setBuildStatus("pending", "Jenkins build has started")
         checkout scm
         sh 'sbt -no-colors test scalastyle'
       }
@@ -71,6 +79,18 @@ pipeline {
                 wait: false)
           }
         }
+      }
+    }
+  }
+  post {
+    failure {
+      node('master') {
+        setBuildStatus("failure", "Jenkins build has failed")
+      }
+    }
+    success {
+      node('master') {
+        setBuildStatus("success", "Jenkins build has completed successfully")
       }
     }
   }

--- a/Jenkinsfile-testing
+++ b/Jenkinsfile-testing
@@ -1,7 +1,7 @@
 def versionTag = "v${env.BUILD_NUMBER}"
 
 def setBuildStatus(String status, String desc) {
-  withCredentials([string(credentialsId: 'github-jenkins-access-token', variable: 'GITHUB_ACCESS_TOKEN')]) {
+  withCredentials([string(credentialsId: 'github-jenkins-api-key', variable: 'GITHUB_ACCESS_TOKEN')]) {
     String sha = sh(script: 'git rev-parse HEAD', returnStdout: true).trim()
     String url = "https://api.github.com/repos/nationalarchives/tdr-transfer-frontend/statuses/${sha}"
     sh "curl -XPOST '${url}' -H 'Authorization: bearer ${env.GITHUB_ACCESS_TOKEN}' --data '{\"state\":\"${status}\",\"target_url\":\"${env.BUILD_URL}\",\"description\":\"${desc}\",\"context\":\"Jenkins TDR Front end test\"}'"


### PR DESCRIPTION
This function utilises the GitHub webhooks API to post Jenkins status information to Github for all branches/commits.

After the change from GitHub branch source plugin to the git branch source plugin,
we lost previous functionality that enabled up to push Jenkins build status to Github. Rather than add another plugin which would require a lot of set up (e.g. verifying which users can trigger build post), I decided to use the GitHub API as we already pull information from GitHub with other plugins, meaning adding another plugin may have resulted in multiple plugins which do very similar actions and could lead to confusion.

This function currently uses a temporary GitHub personal access key, which will need to be changed to make the process more secure and safe.