### PR TITLE
Revert Sass compilation step in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,9 @@ You will also need to set the AUTH_URL environment variable for your locally run
 
 * run  `npm install` then `npm run build`
 
+If you're working on the Sass files and just want to regenerate the CSS without rebuilding all the JavaScript code, you
+can run `npm run sass-watch` to monitor and rebuild the CSS files, or run `npm run build-css` to run a single build.
+
 ## Generated GraphQL classes
 
 There is a separate repository which contains the generated case classes needed to query the consignment API. 

--- a/npm/package.json
+++ b/npm/package.json
@@ -9,7 +9,7 @@
     "copy-govuk-js-assets": "copyfiles -f node_modules/govuk-frontend/govuk/all.js ../public/javascripts",
     "copy-assets": "npm-run-all copy-govuk-image-assets copy-govuk-font-assets copy-govuk-js-assets",
     "sass-watch": "node-sass ./css-src/sass/main.scss ../public/stylesheets/main.css --watch",
-    "sass-compile": "node-sass ./css-src/sass/main.scss ../public/stylesheets/main.css",
+    "sass-compile": "node-sass ./css-src/sass/main.scss ./css-src/main.css",
     "add-stylesheet-dir": "mkdir -p ../public/stylesheets",
     "compress-css": "minify ./css-src/main.css > ../public/stylesheets/main.css",
     "build-css": "npm-run-all add-stylesheet-dir sass-compile compress-css",


### PR DESCRIPTION
This was changed based on a misundersanding of the Sass compilation steps.

The actual steps are:

- Sass files are compiled to CSS and saved to npm/css-src/main.css
- The CSS file is minified and saved to public/stylesheets/main.css

Also update the README to make it clearer how to build the CSS files locally without rerunning the whole frontend build.