### PR TITLE
Add redirect functionality for once upload is complete

### DIFF
--- a/app/controllers/UploadController.scala
+++ b/app/controllers/UploadController.scala
@@ -5,7 +5,8 @@ import java.util.UUID
 import configuration.{FrontEndInfoConfiguration, GraphQLConfiguration, KeycloakConfiguration}
 import javax.inject.{Inject, Singleton}
 import org.pac4j.play.scala.SecurityComponents
-import play.api.Configuration
+import play.api.data.Form
+import play.api.data.Forms._
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, Request}
 import validation.ValidatedActions
@@ -22,4 +23,11 @@ class UploadController @Inject()(val controllerComponents: SecurityComponents,
   def uploadPage(consignmentId: UUID): Action[AnyContent] = transferAgreementExistsAction(consignmentId) { implicit request: Request[AnyContent] =>
     Ok(views.html.upload(consignmentId, frontEndInfoConfiguration.frontEndInfo))
   }
+
+  def uploadRedirect(consignmentId: UUID): Action[AnyContent] = secureAction { implicit request: Request[AnyContent] =>
+    Redirect(routes.RecordsController.recordsPage(consignmentId))
+  }
+
 }
+
+case class UploadData(consignmentId: UUID)

--- a/app/views/upload.scala.html
+++ b/app/views/upload.scala.html
@@ -1,6 +1,7 @@
 @import java.util.UUID
 @import viewsapi.FrontEndInfo
-@(consignmentId: UUID, frontEndInfo: FrontEndInfo)(implicit messages: Messages)
+@import helper._
+@(consignmentId: UUID, frontEndInfo: FrontEndInfo)(implicit request: RequestHeader, messages: Messages)
 
 @main(Messages("upload.header")) {
 <div id="file-upload" class="govuk-grid-row">
@@ -24,6 +25,9 @@
                 </ul>
             </div>
         </div>
+        @form(routes.UploadController.uploadRedirect(consignmentId), Symbol("id") -> "upload-data-form") {
+            @CSRF.formField
+        }
         <form id="file-upload-form" data-consignment-id="@consignmentId">
             <div class="govuk-form-group">
                 <label class="govuk-label" for="file-selection">

--- a/conf/routes
+++ b/conf/routes
@@ -11,6 +11,7 @@ POST    /series                                            controllers.SeriesDet
 GET     /consignment/:consignmentId/transfer-agreement     controllers.TransferAgreementController.transferAgreement(consignmentId: java.util.UUID)
 POST    /consignment/:consignmentId/transfer-agreement     controllers.TransferAgreementController.transferAgreementSubmit(consignmentId: java.util.UUID)
 GET     /consignment/:consignmentId/upload                 controllers.UploadController.uploadPage(consignmentId: java.util.UUID)
+POST    /consignment/:consignmentId/upload                controllers.UploadController.uploadRedirect(consignmentId: java.util.UUID)
 GET     /consignment/:consignmentId/records                controllers.RecordsController.recordsPage(consignmentId: java.util.UUID)
 GET     /keycloak.json                                     controllers.KeycloakConfigurationController.keycloak
 

--- a/npm/src/upload/index.ts
+++ b/npm/src/upload/index.ts
@@ -31,8 +31,12 @@ export class UploadFiles {
       "#file-upload-form"
     )
 
+    const uploadDataFormRedirect: HTMLFormElement | null = document.querySelector(
+      "#upload-data-form"
+    )
+
     if (uploadForm) {
-      uploadForm.addEventListener("submit", ev => {
+      uploadForm.addEventListener("submit", async ev => {
         ev.preventDefault()
         const consignmentId: string | null = uploadForm.getAttribute(
           "data-consignment-id"
@@ -51,12 +55,15 @@ export class UploadFiles {
             throw Error("No files selected")
           }
 
-          this.clientFileProcessing.processClientFiles(
+          await this.clientFileProcessing.processClientFiles(
             consignmentId,
             files,
             progress => console.log(progress.percentageProcessed),
             this.stage
           )
+          if (uploadDataFormRedirect) {
+            uploadDataFormRedirect.submit()
+          }
         } catch (e) {
           //For now console log errors
           console.error("Client file upload failed: " + e.message)


### PR DESCRIPTION
This change redirects the user to the 'processing your records' placeholder page once the s3 upload has completed. It is done using a second hidden form on the upload page, the action of which is to render the page that the user is redirected to. This hidden form is only submitted once the upload has completed.

This change still needs tests to be added to it.