### PR TITLE
Add post build action to Jenkinsfile to run e2e tests.

### DIFF
--- a/Jenkinsfile-deploy
+++ b/Jenkinsfile-deploy
@@ -54,15 +54,15 @@ pipeline {
   }
   post {
     success {
-        script {
-            if (params.STAGE == "intg"){
-                build(
-                    job: "TDRAcceptanceTest",
-                    parameters: [ string(name: "STAGE", value: "intg") ],
-                    wait: false
-                )
-            }
+      script {
+        if (params.STAGE == "intg"){
+          build(
+            job: "TDRAcceptanceTest",
+            parameters: [ string(name: "STAGE", value: "intg") ],
+            wait: false
+          )
         }
+      }
     }
   }
 }

--- a/Jenkinsfile-deploy
+++ b/Jenkinsfile-deploy
@@ -52,6 +52,19 @@ pipeline {
       }
     }
   }
+  post {
+    success {
+        script {
+            if (params.STAGE == "intg"){
+                build(
+                    job: "TDRAcceptanceTest",
+                    parameters: [ string(name: "STAGE", value: "intg") ],
+                    wait: false
+                )
+            }
+        }
+    }
+  }
 }
 
 def getAccountNumberFromStage() {

--- a/Jenkinsfile-deploy
+++ b/Jenkinsfile-deploy
@@ -59,6 +59,7 @@ pipeline {
           build(
             job: "TDRAcceptanceTest",
             parameters: [ string(name: "STAGE", value: "intg") ],
+            quietPeriod: 300,
             wait: false
           )
         }


### PR DESCRIPTION
This change triggers the e2e tests to run on intg after an intg deployment has been started successfully. There is a potential issue in that the deployment may not have finished and the load balancer may not be sending traffic to the newly deployed version yet. As a small workaround to this, the e2e tests Jenkinsfile will be modified to include a 'quietPeriod' in which it waits a pre-configured amount of time to start building after a build is initially triggered.

A more sophisticated solution to this problem may exist, and I will look into it to see what can be done to fix it.