### PR TITLE
Configure Redis cache to cause a failure if Redis is unavailable

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -10,7 +10,14 @@ auth.secret=${?AUTH_SECRET}
 cognito.identitypool=${?IDENTITY_POOL_ID}
 cognito.identityProviderName=auth.tdr-integration.nationalarchives.gov.uk/auth/realms/tdr
 
-play.cache.redis.timeout=20s
+play.cache.redis {
+    timeout=20s
+
+    # TDR depends on the Redis cache being available because it is used to store Keycloak parameters like the state
+    # parameter during login, so return an error rather than ignoring any cache errors
+    recovery=log-and-fail
+}
+
 play.i18n.langs = ["en-gb"]
 
 consignmentapi.url="http://localhost:8080/graphql"

--- a/conf/application.intg.conf
+++ b/conf/application.intg.conf
@@ -9,6 +9,8 @@ cognito.identityProviderName=auth.tdr-integration.nationalarchives.gov.uk/auth/r
 
 consignmentapi.url="https://api.tdr-integration.nationalarchives.gov.uk/graphql"
 
+play.cache.redis.recovery=log-and-fail
+
 play.i18n.langs = ["en-gb"]
 
 akka.actor.allow-java-serialization="on"

--- a/conf/application.prod.conf
+++ b/conf/application.prod.conf
@@ -18,6 +18,8 @@ play.modules.enabled += "play.api.cache.redis.RedisCacheModule"
 
 play.http.errorHandler = "errors.ErrorHandler"
 
+play.cache.redis.recovery=log-and-fail
+
 play.i18n.langs = ["en-gb"]
 
 environment=${ENVIRONMENT}

--- a/conf/application.staging.conf
+++ b/conf/application.staging.conf
@@ -18,6 +18,8 @@ play.modules.enabled += "play.api.cache.redis.RedisCacheModule"
 
 play.http.errorHandler = "errors.ErrorHandler"
 
+play.cache.redis.recovery=log-and-fail
+
 play.i18n.langs = ["en-gb"]
 
 environment=${ENVIRONMENT}


### PR DESCRIPTION
By default, the play-redis module is configured to log any errors and then continue and ignore the error: https://github.com/KarelCemus/play-redis/blob/2.6.1/src/main/resources/reference.conf#L247

This is because the Play cache is normally just a cache, so it should be safe (if not performant) for the application to ignore any cache failures.

However, Keycloak uses the Play cache to store OAuth2 state parameters, so login will not work if the cache is unavailable.

Configuring the cache module to actually fail if it hits an error means that we get more meaningful error messages. Before, if you tried to log in while Redis was down, you would get a confusing "State parameter is different from the one sent in the authentication request" error when you submitted the login form.

Now, you can't even get to the login page if Redis is down, and the stack trace is clearer because one of the causes is `redis.actors.NoConnectionException$: No Connection established`.