### PR TITLE
Update progress bar with S3 upload progress

### DIFF
--- a/app/views/upload.scala.html
+++ b/app/views/upload.scala.html
@@ -54,7 +54,7 @@
         <h1 class="govuk-heading-xl">@Messages("fileProgress.header")</h1>
         <p class="govuk-body">@Messages("fileProgress.title")</p>
         <div>
-            <progress class="progress-display" value="" max="50"></progress>
+            <progress class="progress-display" value="" max="100"></progress>
         </div>
     </div>
 </div>

--- a/npm/src/clientfileprocessing/index.ts
+++ b/npm/src/clientfileprocessing/index.ts
@@ -24,6 +24,8 @@ export class ClientFileProcessing {
   }
 
   progressMetadataCallback(progressInformation: IProgressInformation) {
+    const weightedPercent = progressInformation.percentageProcessed / 2
+
     const fileUpload: HTMLDivElement | null = document.querySelector(
       "#file-upload"
     )
@@ -39,21 +41,20 @@ export class ClientFileProcessing {
       progressBar.classList.remove("hide")
     }
 
-    if (progressBarElement && progressInformation.percentageProcessed < 50) {
-      progressBarElement.setAttribute(
-        "value",
-        progressInformation.percentageProcessed.toString()
-      )
+    if (progressBarElement) {
+      progressBarElement.setAttribute("value", weightedPercent.toString())
     }
   }
 
-  progressS3Callback() {
+  s3ProgressCallback(progressInformation: IProgressInformation) {
+    const weightedPercent = 50 + progressInformation.percentageProcessed / 2
+
     const progressBarElement: HTMLDivElement | null = document.querySelector(
       ".progress-display"
     )
 
     if (progressBarElement) {
-      progressBarElement.setAttribute("value", "100")
+      progressBarElement.setAttribute("value", weightedPercent.toString())
     }
   }
 
@@ -79,7 +80,7 @@ export class ClientFileProcessing {
       await this.s3Upload.uploadToS3(
         consignmentId,
         tdrFiles,
-        this.progressS3Callback,
+        this.s3ProgressCallback,
         stage
       )
     } catch (e) {

--- a/npm/src/clientfileprocessing/index.ts
+++ b/npm/src/clientfileprocessing/index.ts
@@ -23,31 +23,15 @@ export class ClientFileProcessing {
     this.s3Upload = s3Upload
   }
 
-  /**
-   * Updates a progress bar with a given percentage
-   * @param percent The percentage to update the progress bar with  of type {@link Number}
-   */
-  updateProgressBarPercentage(percent: Number) {
-    const progressBarElement: HTMLDivElement | null = document.querySelector(
-      ".progress-display"
-    )
-
-    if (progressBarElement) {
-      progressBarElement.setAttribute("value", percent.toString())
-    }
-  }
-
-  progressBarSwitcher = (progressInformation: IProgressInformation) => {
-    console.log(
-      "Percent of metadata extracted: " +
-        progressInformation.percentageProcessed
-    )
-
+  progressMetadataCallback(progressInformation: IProgressInformation) {
     const fileUpload: HTMLDivElement | null = document.querySelector(
       "#file-upload"
     )
     const progressBar: HTMLDivElement | null = document.querySelector(
       "#progress-bar"
+    )
+    const progressBarElement: HTMLDivElement | null = document.querySelector(
+      ".progress-display"
     )
 
     if (fileUpload && progressBar) {
@@ -55,8 +39,21 @@ export class ClientFileProcessing {
       progressBar.classList.remove("hide")
     }
 
-    if (progressInformation.percentageProcessed < 50) {
-      this.updateProgressBarPercentage(progressInformation.percentageProcessed)
+    if (progressBarElement && progressInformation.percentageProcessed < 50) {
+      progressBarElement.setAttribute(
+        "value",
+        progressInformation.percentageProcessed.toString()
+      )
+    }
+  }
+
+  progressS3Callback() {
+    const progressBarElement: HTMLDivElement | null = document.querySelector(
+      ".progress-display"
+    )
+
+    if (progressBarElement) {
+      progressBarElement.setAttribute("value", "100")
     }
   }
 
@@ -73,7 +70,7 @@ export class ClientFileProcessing {
       )
       const metadata: IFileMetadata[] = await this.clientFileExtractMetadata.extract(
         files,
-        this.progressBarSwitcher
+        this.progressMetadataCallback
       )
       const tdrFiles = await this.clientFileMetadataUpload.saveClientFileMetadata(
         fileIds,
@@ -82,7 +79,7 @@ export class ClientFileProcessing {
       this.s3Upload.uploadToS3(
         consignmentId,
         tdrFiles,
-        () => this.updateProgressBarPercentage(100), // Update to 100 as we have finished at this point.
+        this.progressS3Callback,
         stage
       )
     } catch (e) {

--- a/npm/src/clientfileprocessing/index.ts
+++ b/npm/src/clientfileprocessing/index.ts
@@ -23,7 +23,7 @@ export class ClientFileProcessing {
     this.s3Upload = s3Upload
   }
 
-  progressMetadataCallback(progressInformation: IProgressInformation) {
+  metadataProgressCallback(progressInformation: IProgressInformation) {
     const weightedPercent = progressInformation.percentageProcessed / 2
 
     const fileUpload: HTMLDivElement | null = document.querySelector(
@@ -71,7 +71,7 @@ export class ClientFileProcessing {
       )
       const metadata: IFileMetadata[] = await this.clientFileExtractMetadata.extract(
         files,
-        this.progressMetadataCallback
+        this.metadataProgressCallback
       )
       const tdrFiles = await this.clientFileMetadataUpload.saveClientFileMetadata(
         fileIds,

--- a/npm/src/clientfileprocessing/index.ts
+++ b/npm/src/clientfileprocessing/index.ts
@@ -52,6 +52,16 @@ export class ClientFileProcessing {
     }
   }
 
+  progressS3Callback() {
+    const progressBarElement: HTMLDivElement | null = document.querySelector(
+      ".progress-display"
+    )
+
+    if (progressBarElement) {
+      progressBarElement.setAttribute("value", "100")
+    }
+  }
+
   async processClientFiles(
     consignmentId: string,
     files: TdrFile[],
@@ -72,7 +82,12 @@ export class ClientFileProcessing {
         fileIds,
         metadata
       )
-      this.s3Upload.uploadToS3(consignmentId, tdrFiles, callback, stage)
+      this.s3Upload.uploadToS3(
+        consignmentId,
+        tdrFiles,
+        this.progressS3Callback,
+        stage
+      )
     } catch (e) {
       handleUploadError(e, "Processing client files failed")
     }

--- a/npm/src/clientfileprocessing/index.ts
+++ b/npm/src/clientfileprocessing/index.ts
@@ -4,7 +4,6 @@ import { handleUploadError } from "../errorhandling"
 import {
   IFileMetadata,
   TdrFile,
-  TProgressFunction,
   IProgressInformation
 } from "@nationalarchives/file-information"
 import { ITdrFile, S3Upload } from "../s3upload"
@@ -61,7 +60,6 @@ export class ClientFileProcessing {
   async processClientFiles(
     consignmentId: string,
     files: TdrFile[],
-    callback: TProgressFunction,
     stage: string
   ): Promise<void> {
     try {

--- a/npm/src/upload/index.ts
+++ b/npm/src/upload/index.ts
@@ -71,7 +71,6 @@ export class UploadFiles {
           await this.clientFileProcessing.processClientFiles(
             consignmentId,
             files,
-            progress => console.log(progress.percentageProcessed),
             this.stage
           )
           this.uploadFilesSuccess()

--- a/npm/test/clientfileprocessing.test.ts
+++ b/npm/test/clientfileprocessing.test.ts
@@ -196,7 +196,7 @@ test("metadataProgressBarCallback function updates the progress bar to a maximum
   checkExpectedPageState("50")
 })
 
-test("metadataProgress function does not change the HTML state if no progress bar present", () => {
+test("metadataProgressCallback function does not change the HTML state if no progress bar present", () => {
   setupUploadPageHTMLWithoutProgressBar()
 
   const progressInformation: IProgressInformation = {
@@ -266,7 +266,7 @@ test("s3ProgressBarCallback function updates the progress bar with the percentag
 
   const progressInformation: IProgressInformation = {
     totalFiles: 1,
-    percentageProcessed: 100,
+    percentageProcessed: 75,
     processedFiles: 0
   }
 
@@ -282,7 +282,7 @@ test("s3ProgressBarCallback function updates the progress bar with the percentag
 
   fileProcessing.s3ProgressCallback(progressInformation)
 
-  checkS3ExpectedPageState("100")
+  checkS3UploadProgressBarState("87.5")
 })
 
 test("s3ProgressBarCallback function updates progress bar from a minimum of 50 percent", () => {
@@ -306,7 +306,7 @@ test("s3ProgressBarCallback function updates progress bar from a minimum of 50 p
 
   fileProcessing.s3ProgressCallback(progressInformation)
 
-  checkS3ExpectedPageState("50")
+  checkS3UploadProgressBarState("50")
 })
 
 test("s3ProgressBarCallback function updates the progress bar to a maximum of 100 percent", () => {
@@ -330,7 +330,7 @@ test("s3ProgressBarCallback function updates the progress bar to a maximum of 10
 
   fileProcessing.s3ProgressCallback(progressInformation)
 
-  checkS3ExpectedPageState("100")
+  checkS3UploadProgressBarState("100")
 })
 
 test("Error thrown if processing files fails", async () => {
@@ -466,7 +466,7 @@ function checkExpectedPageState(percentage: String) {
   ).toEqual(percentage)
 }
 
-function checkS3ExpectedPageState(percentage: String) {
+function checkS3UploadProgressBarState(percentage: String) {
   const progressBarElement: HTMLDivElement | null = document.querySelector(
     ".progress-display"
   )

--- a/npm/test/clientfileprocessing.test.ts
+++ b/npm/test/clientfileprocessing.test.ts
@@ -172,7 +172,7 @@ test("client file metadata successfully uploaded", async () => {
   ).resolves.not.toThrow()
 })
 
-test("progressBarSwitcher function updates the progress bar with the percentage processed", () => {
+test("progressBarSwitcher function updates the progress bar with the percentage processed / 2", () => {
   setupUploadPageHTML()
 
   const progressInformation: IProgressInformation = {
@@ -193,31 +193,7 @@ test("progressBarSwitcher function updates the progress bar with the percentage 
 
   fileProcessing.progressMetadataCallback(progressInformation)
 
-  checkExpectedPageState("30")
-})
-
-test("progressBarSwitcher function does not update progress bar if percentage processed is over 50", () => {
-  setupUploadPageHTML()
-
-  const progressInformation: IProgressInformation = {
-    totalFiles: 1,
-    percentageProcessed: 51,
-    processedFiles: 0
-  }
-
-  const client = new GraphqlClient("test", mockKeycloakInstance)
-  const metadataUpload: ClientFileMetadataUpload = new ClientFileMetadataUpload(
-    client
-  )
-
-  const fileProcessing = new ClientFileProcessing(
-    metadataUpload,
-    new S3UploadMock()
-  )
-
-  fileProcessing.progressMetadataCallback(progressInformation)
-
-  checkExpectedPageState("") // this field is not populated because % > 50
+  checkExpectedPageState("15")
 })
 
 test("progressBarSwitcher function does not change the HTML state if no progress bar present", () => {

--- a/npm/test/clientfileprocessing.test.ts
+++ b/npm/test/clientfileprocessing.test.ts
@@ -151,7 +151,7 @@ test("client file metadata successfully uploaded", async () => {
   ).resolves.not.toThrow()
 })
 
-test("progressCallback function updates the progress bar with the percentage processed", () => {
+test("progressBarSwitcher function updates the progress bar with the percentage processed", () => {
   setupUploadPageHTML()
 
   const progressInformation: IProgressInformation = {
@@ -170,12 +170,12 @@ test("progressCallback function updates the progress bar with the percentage pro
     new S3UploadMock("")
   )
 
-  fileProcessing.progressCallback(progressInformation)
+  fileProcessing.progressBarSwitcher(progressInformation)
 
   checkExpectedPageState("30")
 })
 
-test("progressCallback function does not update progress bar if percentage processed is over 50", () => {
+test("progressBarSwitcher function does not update progress bar if percentage processed is over 50", () => {
   setupUploadPageHTML()
 
   const progressInformation: IProgressInformation = {
@@ -194,12 +194,12 @@ test("progressCallback function does not update progress bar if percentage proce
     new S3UploadMock("")
   )
 
-  fileProcessing.progressCallback(progressInformation)
+  fileProcessing.progressBarSwitcher(progressInformation)
 
   checkExpectedPageState("") // this field is not populated because % > 50
 })
 
-test("progressCallback function does not change the HTML state if no progress bar present", () => {
+test("progressBarSwitcher function does not change the HTML state if no progress bar present", () => {
   setupUploadPageHTMLWithoutProgressBar()
 
   const progressInformation: IProgressInformation = {
@@ -218,7 +218,7 @@ test("progressCallback function does not change the HTML state if no progress ba
     new S3UploadMock("")
   )
 
-  fileProcessing.progressCallback(progressInformation)
+  fileProcessing.progressBarSwitcher(progressInformation)
 
   checkNoPageStateChangeExpected()
 })

--- a/npm/test/clientfileprocessing.test.ts
+++ b/npm/test/clientfileprocessing.test.ts
@@ -171,7 +171,7 @@ test("client file metadata successfully uploaded", async () => {
   ).resolves.not.toThrow()
 })
 
-test("metadataProgressBarCallback function updates the progress bar to a maximum of 50 percent", () => {
+test("metadataProgressCallback function updates the progress bar to a maximum of 50 percent", () => {
   setupUploadPageHTML()
 
   const progressInformation: IProgressInformation = {
@@ -219,7 +219,7 @@ test("metadataProgressCallback function does not change the HTML state if no pro
   checkNoPageStateChangeExpected()
 })
 
-test("metadataProgressBarCallback function updates the progress bar with the percentage processed", () => {
+test("metadataProgressCallback function updates the progress bar with the percentage processed", () => {
   setupUploadPageHTML()
 
   const progressInformation: IProgressInformation = {
@@ -260,7 +260,7 @@ test("file successfully uploaded to s3", async () => {
   expect(s3UploadMock.uploadToS3).toHaveBeenCalledTimes(1)
 })
 
-test("s3ProgressBarCallback function updates the progress bar with the percentage processed", () => {
+test("s3ProgressCallback function updates the progress bar with the percentage processed", () => {
   setupUploadPageHTML()
 
   const progressInformation: IProgressInformation = {
@@ -284,7 +284,7 @@ test("s3ProgressBarCallback function updates the progress bar with the percentag
   checkS3UploadProgressBarState("87.5")
 })
 
-test("s3ProgressBarCallback function updates progress bar from a minimum of 50 percent", () => {
+test("s3ProgressCallback function updates progress bar from a minimum of 50 percent", () => {
   setupUploadPageHTML()
 
   const progressInformation: IProgressInformation = {
@@ -308,7 +308,7 @@ test("s3ProgressBarCallback function updates progress bar from a minimum of 50 p
   checkS3UploadProgressBarState("50")
 })
 
-test("s3ProgressBarCallback function updates the progress bar to a maximum of 100 percent", () => {
+test("s3ProgressCallback function updates the progress bar to a maximum of 100 percent", () => {
   setupUploadPageHTML()
 
   const progressInformation: IProgressInformation = {

--- a/npm/test/clientfileprocessing.test.ts
+++ b/npm/test/clientfileprocessing.test.ts
@@ -144,7 +144,6 @@ const mockS3UploadFailure: (message: string) => void = (message: string) => {
       uploadToS3: (
         consignmentId: string,
         files: ITdrFile[],
-        callback: TProgressFunction,
         stage: string,
         chunkSize?: number
       ) => {
@@ -168,7 +167,7 @@ test("client file metadata successfully uploaded", async () => {
     new S3UploadMock()
   )
   await expect(
-    fileProcessing.processClientFiles("1", [], jest.fn(), "")
+    fileProcessing.processClientFiles("1", [], "")
   ).resolves.not.toThrow()
 })
 
@@ -255,7 +254,7 @@ test("file successfully uploaded to s3", async () => {
   const s3UploadMock = new S3UploadMock()
   const fileProcessing = new ClientFileProcessing(metadataUpload, s3UploadMock)
   await expect(
-    fileProcessing.processClientFiles("1", [], jest.fn(), "")
+    fileProcessing.processClientFiles("1", [], "")
   ).resolves.not.toThrow()
 
   expect(s3UploadMock.uploadToS3).toHaveBeenCalledTimes(1)
@@ -347,7 +346,7 @@ test("Error thrown if processing files fails", async () => {
   )
 
   await expect(
-    fileProcessing.processClientFiles("1", [], jest.fn(), "")
+    fileProcessing.processClientFiles("1", [], "")
   ).rejects.toStrictEqual(
     Error(
       "Processing client files failed: upload client file information error"
@@ -369,7 +368,7 @@ test("Error thrown if processing file metadata fails", async () => {
   )
 
   await expect(
-    fileProcessing.processClientFiles("1", [], jest.fn(), "")
+    fileProcessing.processClientFiles("1", [], "")
   ).rejects.toStrictEqual(
     Error("Processing client files failed: upload client file metadata error")
   )
@@ -389,7 +388,7 @@ test("Error thrown if extracting file metadata fails", async () => {
   )
 
   await expect(
-    fileProcessing.processClientFiles("1", [], jest.fn(), "")
+    fileProcessing.processClientFiles("1", [], "")
   ).rejects.toStrictEqual(
     Error(
       "Processing client files failed: client file metadata extraction error"
@@ -410,7 +409,7 @@ test("Error thrown if S3 upload fails", async () => {
   const fileProcessing = new ClientFileProcessing(metadataUpload, s3Upload)
 
   await expect(
-    fileProcessing.processClientFiles("1", [], jest.fn(), "")
+    fileProcessing.processClientFiles("1", [], "")
   ).rejects.toStrictEqual(
     Error("Processing client files failed: Some S3 error")
   )


### PR DESCRIPTION
This PR is for the progress bar on the upload page. What it does is extract metadata until 50% and then extract s3 uploads until it reaches 100%. Once it reaches completion, the page is then redirected to the records placeholder page. 

The progress bar now does not reset to 0% nor does it reach completion immediately, it shows a seamless process and looks exactly like the wireframes.

[TDR-22]: https://national-archives.atlassian.net/browse/TDR-22