### PR TITLE
Step indicator on progress bar page

### DIFF
--- a/app/views/upload.scala.html
+++ b/app/views/upload.scala.html
@@ -48,12 +48,14 @@
                 </button>
             </div>
         </form>
-<!--        Form to redirect user once upload has completed. It sends consignmentId to record processing placeholder page -->
+        <!--        Form to redirect user once upload has completed. It sends consignmentId to record processing placeholder page -->
         @form(routes.RecordsController.recordsPage(consignmentId), Symbol("id") -> "upload-data-form") { }
     </div>
 </div>
 <div id="progress-bar" class="govuk-grid-row hide">
     <div class="govuk-grid-column-two-thirds">
+        <a href="@routes.DashboardController.dashboard" class="govuk-back-link">Back</a>
+        @progressIndicator(Messages("upload.progress"))
         <h1 class="govuk-heading-xl">@Messages("fileProgress.header")</h1>
         <p class="govuk-body">@Messages("fileProgress.title")</p>
         <div>

--- a/app/views/upload.scala.html
+++ b/app/views/upload.scala.html
@@ -55,7 +55,7 @@
 <div id="progress-bar" class="govuk-grid-row hide">
     <div class="govuk-grid-column-two-thirds">
         <a href="@routes.DashboardController.dashboard" class="govuk-back-link">Back</a>
-        @progressIndicator(Messages("fileProgress.progress"))
+        @progressIndicator(Messages("upload.progress"))
         <h1 class="govuk-heading-xl">@Messages("fileProgress.header")</h1>
         <p class="govuk-body">@Messages("fileProgress.title")</p>
         <div>

--- a/app/views/upload.scala.html
+++ b/app/views/upload.scala.html
@@ -55,7 +55,7 @@
 <div id="progress-bar" class="govuk-grid-row hide">
     <div class="govuk-grid-column-two-thirds">
         <a href="@routes.DashboardController.dashboard" class="govuk-back-link">Back</a>
-        @progressIndicator(Messages("upload.progress"))
+        @progressIndicator(Messages("fileProgress.progress"))
         <h1 class="govuk-heading-xl">@Messages("fileProgress.header")</h1>
         <p class="govuk-body">@Messages("fileProgress.title")</p>
         <div>


### PR DESCRIPTION
This PR consists of un-hiding the step indicator when the progress bar element becomes visible. It is to stay consistent with the wireframes however instead of saying "Step 4 of Y" it stays as "Step 3 of Y", as the upload form and the upload progress bar are really part of the same step, and we don’t want to overwhelm users with an apparently long list of steps.