### PR TITLE
Remove local API setup instructions that we no longer use

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,6 @@ If you want to upload to the aws s3 bucket, you can no longer use your local key
 - AUTH_SECRET=\<insert the secret for the tdr client in the integration account\>
 - IDENTITY_POOL_ID=secret-from-/mgmt/identitypoolid_intg in the management account
 
-You will also need to set the AUTH_URL environment variable for your locally running API project to:
--  AUTH_URL=https://auth.tdr-integration.nationalarchives.gov.uk/auth
-
 #### Frontend project
 
 * Set up another [client](https://www.keycloak.org/docs/latest/server_admin/#oidc-clients) called tdr-fe. This will be a public client as the configuration is available publicly in the browser. This means there are no client credentials.


### PR DESCRIPTION
When running the consignment API locally, the environment variable AUTH_URL no longer needs to be set as it is defined in the application.conf files.