### PR TITLE
Replace logo <image> tag with <img>

### DIFF
--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -25,7 +25,7 @@
 
             <div class="govuk-header__tna-logo">
                 <a href="/" class="govuk-header__tna_link govuk-header__tna_link--homepage">
-                        <image src="/assets/images/tna-horizontal-white-logo.svg" class="govuk-header__tna-logo-image" alt="TNA horizontal logo"></image>
+                        <img src="/assets/images/tna-horizontal-white-logo.svg" class="govuk-header__tna-logo-image" alt="TNA horizontal logo" />
                 </a>
             </div>
 


### PR DESCRIPTION
The `<image>` tag is a synonym for `<img>`, but it is not standard HTML and is only supported for legacy reasons.

It was being rendered correctly in all browsers that we've tried, but it was causing a warning in the console in Edge.