### PR TITLE
Upload files to to local S3 emulator in dev environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ You will also need to set the AUTH_URL environment variable for your locally run
   public client as the configuration is available publicly in the browser. This means there are no client credentials.
   - Set "Valid redirect URIs" to `http://localhost:9000/*`
   - Set "Web Origins" to `http://localhost:9000`
+  - Configure a mapping for `user_id` as you did for the tdr client above
   - Leave everything else on the defaults
 
 #### Frontend project

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ When you log into the site, you will need to log in as a user from the Integrati
 Follow these instructions if you want to make changes to the API, database and/or auth system at the same time as
 updating the frontend.
 
-#### Auth server
+#### Local auth server
 
 -  Start the auth server
   ```
@@ -95,15 +95,6 @@ updating the frontend.
   ```
   AUTH_SECRET=[secret value]
   ```
-  
-If you want to upload to the aws s3 bucket, you can no longer use your local keycloak instance so you'll have to set at least these environment variables
-- API_URL=http://localhost:8080/graphql
-- AUTH_URL=https://auth.tdr-integration.nationalarchives.gov.uk
-- AUTH_SECRET=\<insert the secret for the tdr client in the integration account\>
-- IDENTITY_POOL_ID=secret-from-/mgmt/identitypoolid_intg in the management account
-
-You will also need to set the AUTH_URL environment variable for your locally running API project to:
--  AUTH_URL=https://auth.tdr-integration.nationalarchives.gov.uk/auth
 
 - Set up another [client](https://www.keycloak.org/docs/latest/server_admin/#oidc-clients) called tdr-fe. This will be a
   public client as the configuration is available publicly in the browser. This means there are no client credentials.
@@ -111,6 +102,39 @@ You will also need to set the AUTH_URL environment variable for your locally run
   - Set "Web Origins" to `http://localhost:9000`
   - Configure a mapping for `user_id` as you did for the tdr client above
   - Leave everything else on the defaults
+
+#### Local API
+
+Clone and run the [tdr-consignment-api] project.
+
+[tdr-consignment-api]: https://github.com/nationalarchives/tdr-consignment-api
+
+#### Local S3 emulator
+
+Run an [S3 ninja] Docker container, specifying a local directory in which to save the files:
+
+```
+docker run -d -p 9444:9000 -v <some directory path>:/home/sirius/data --name=s3ninja scireum/s3-ninja:6.4
+```
+
+Set the `S3_ENDPOINT_OVERRIDE` environment variable to the upload URL of the emulator, in this case
+`http://localhost:9444/s3`.
+
+Requests to S3 ninja need to be authenticated with a Cognito token. To emulate this endpoint, clone the
+[tdr-local-aws] project and follow the instructions there to run the `FakeCognitoServer` application.
+
+Set the `COGNITO_ENDPOINT_OVERRIDE` environment variable to the URL of the fake Cognito token provider.
+The default is `http://localhost:4600`.
+
+[S3 ninja]: https://s3ninja.net/
+[tdr-local-aws]: https://github.com/nationalarchives/tdr-local-aws
+
+#### Local backend checks
+
+Follow the instructions in [tdr-local-aws] to run the `FakeBackendChecker` application, making sure you set
+the environment variable for the monitored folder to the same path as the mount directory that you set in
+the `docker run` command when you started the S3 ninja container. This lets the fake backend checker detect
+and scan files as they are uploaded to the S3 emulator.
 
 #### Frontend project
 

--- a/README.md
+++ b/README.md
@@ -105,11 +105,13 @@ If you want to upload to the aws s3 bucket, you can no longer use your local key
 You will also need to set the AUTH_URL environment variable for your locally running API project to:
 -  AUTH_URL=https://auth.tdr-integration.nationalarchives.gov.uk/auth
 
+- Set up another [client](https://www.keycloak.org/docs/latest/server_admin/#oidc-clients) called tdr-fe. This will be a
+  public client as the configuration is available publicly in the browser. This means there are no client credentials.
+  - Set "Valid redirect URIs" to `http://localhost:9000/*`
+  - Set "Web Origins" to `http://localhost:9000`
+  - Leave everything else on the defaults
+
 #### Frontend project
-
-* Set up another [client](https://www.keycloak.org/docs/latest/server_admin/#oidc-clients) called tdr-fe. This will be a public client as the configuration is available publicly in the browser. This means there are no client credentials.
-
-* Set "Valid redirect URIs" to `http://localhost:9000/*` Leave everything else on the defaults.
 
 * Start redis locally.
 

--- a/app/configuration/FrontEndInfoConfiguration.scala
+++ b/app/configuration/FrontEndInfoConfiguration.scala
@@ -5,7 +5,17 @@ import play.api.Configuration
 import viewsapi.FrontEndInfo
 
 class FrontEndInfoConfiguration @Inject ()(configuration: Configuration) {
+
   private def get(location: String) = configuration.get[String](location)
-  def frontEndInfo: FrontEndInfo = FrontEndInfo(get("consignmentapi.url"), get("cognito.identityProviderName"),
-    get("cognito.identitypool"), get("environment"), get("region"))
+  private def getOptional(location: String) = configuration.getOptional[String](location)
+
+  def frontEndInfo: FrontEndInfo = FrontEndInfo(
+    get("consignmentapi.url"),
+    getOptional("s3.endpointOverride"),
+    get("cognito.identityProviderName"),
+    get("cognito.identitypool"),
+    getOptional("cognito.endpointOverride"),
+    get("environment"),
+    get("region")
+  )
 }

--- a/app/views/frontEndInputs.scala.html
+++ b/app/views/frontEndInputs.scala.html
@@ -6,3 +6,11 @@
 <input type="hidden" class="identity-pool-id" value="@frontEndInfo.identityPoolId">
 <input type="hidden" class="stage" value="@frontEndInfo.stage">
 <input type="hidden" class="region" value="@frontEndInfo.region">
+
+@if(frontEndInfo.cognitoEndpointOverride.isDefined) {
+    <input type="hidden" class="cognito-endpoint-override" value="@frontEndInfo.cognitoEndpointOverride">
+}
+
+@if(frontEndInfo.s3EndpointOverride.isDefined) {
+    <input type="hidden" class="s3-endpoint-override" value="@frontEndInfo.s3EndpointOverride">
+}

--- a/app/viewsapi/FrontEndInfo.scala
+++ b/app/viewsapi/FrontEndInfo.scala
@@ -1,3 +1,11 @@
 package viewsapi
 
-case class FrontEndInfo(apiUrl: String, identityProviderName: String, identityPoolId: String, stage: String, region: String)
+case class FrontEndInfo(
+                         apiUrl: String,
+                         s3EndpointOverride: Option[String],
+                         identityProviderName: String,
+                         identityPoolId: String,
+                         cognitoEndpointOverride: Option[String],
+                         stage: String,
+                         region: String
+                       )

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ watchSources ++= (baseDirectory.value / "npm/src" ** "*").get
 
 resolvers += "TDR Releases" at "s3://tdr-releases-mgmt"
 
-scalaVersion := "2.13.0"
+scalaVersion := "2.13.3"
 
 libraryDependencies += guice
 libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "4.0.3" % Test

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -7,8 +7,13 @@ auth.callback="http://localhost:9000/callback"
 auth.secret="placeholderSecretValue"
 auth.secret=${?AUTH_SECRET}
 
+s3.endpointOverride=null
+s3.endpointOverride=${?S3_ENDPOINT_OVERRIDE}
+
 cognito.identitypool=${?IDENTITY_POOL_ID}
 cognito.identityProviderName=auth.tdr-integration.nationalarchives.gov.uk/auth/realms/tdr
+cognito.endpointOverride=null
+cognito.endpointOverride=${?COGNITO_ENDPOINT_OVERRIDE}
 
 play.cache.redis {
     timeout=20s

--- a/npm/src/auth/index.ts
+++ b/npm/src/auth/index.ts
@@ -48,12 +48,23 @@ export const authenticateAndGetIdentityId: (
   const token = await refreshOrReturnToken(keycloak)
   const { identityProviderName, identityPoolId, region } = frontEndInfo
 
-  console.log("Setting cognito endpoint 4600")
-  AWS.config.cognitoidentity = { endpoint: "http://localhost:4600" }
-  console.log("Setting S3 endpoint to 9444/s3 and only s3ForcePathStyle")
-  AWS.config.s3 = {
-    endpoint: "http://localhost:9444/s3",
-    s3ForcePathStyle: true
+  // TODO: Should S3 and Cognito override be done elsewhere?
+  if (frontEndInfo.s3EndpointOverride) {
+    console.log(
+      `Overriding S3 endpoint with '${frontEndInfo.s3EndpointOverride}'`
+    )
+    AWS.config.s3 = {
+      endpoint: frontEndInfo.s3EndpointOverride,
+      s3ForcePathStyle: true
+    }
+  }
+  if (frontEndInfo.cognitoEndpointOverride) {
+    console.log(
+      `Overriding Cognito endpoint with '${frontEndInfo.cognitoEndpointOverride}'`
+    )
+    AWS.config.cognitoidentity = {
+      endpoint: frontEndInfo.cognitoEndpointOverride
+    }
   }
 
   const credentials = new CognitoIdentityCredentials({

--- a/npm/src/auth/index.ts
+++ b/npm/src/auth/index.ts
@@ -48,6 +48,14 @@ export const authenticateAndGetIdentityId: (
   const token = await refreshOrReturnToken(keycloak)
   const { identityProviderName, identityPoolId, region } = frontEndInfo
 
+  console.log("Setting cognito endpoint 4600")
+  AWS.config.cognitoidentity = { endpoint: "http://localhost:4600" }
+  console.log("Setting S3 endpoint to 9444/s3 and only s3ForcePathStyle")
+  AWS.config.s3 = {
+    endpoint: "http://localhost:9444/s3",
+    s3ForcePathStyle: true
+  }
+
   const credentials = new CognitoIdentityCredentials({
     IdentityPoolId: identityPoolId,
     Logins: {

--- a/npm/src/auth/index.ts
+++ b/npm/src/auth/index.ts
@@ -48,25 +48,6 @@ export const authenticateAndGetIdentityId: (
   const token = await refreshOrReturnToken(keycloak)
   const { identityProviderName, identityPoolId, region } = frontEndInfo
 
-  // TODO: Should S3 and Cognito override be done elsewhere?
-  if (frontEndInfo.s3EndpointOverride) {
-    console.log(
-      `Overriding S3 endpoint with '${frontEndInfo.s3EndpointOverride}'`
-    )
-    AWS.config.s3 = {
-      endpoint: frontEndInfo.s3EndpointOverride,
-      s3ForcePathStyle: true
-    }
-  }
-  if (frontEndInfo.cognitoEndpointOverride) {
-    console.log(
-      `Overriding Cognito endpoint with '${frontEndInfo.cognitoEndpointOverride}'`
-    )
-    AWS.config.cognitoidentity = {
-      endpoint: frontEndInfo.cognitoEndpointOverride
-    }
-  }
-
   const credentials = new CognitoIdentityCredentials({
     IdentityPoolId: identityPoolId,
     Logins: {

--- a/npm/src/aws-config.ts
+++ b/npm/src/aws-config.ts
@@ -1,0 +1,32 @@
+import AWS from "aws-sdk"
+import { IFrontEndInfo } from "."
+
+export const configureAws: (frontEndInfo: IFrontEndInfo) => void = (
+  frontEndInfo: IFrontEndInfo
+) => {
+  if (frontEndInfo.cognitoEndpointOverride) {
+    overrideCognitoEndpoint(frontEndInfo.cognitoEndpointOverride)
+  }
+  if (frontEndInfo.s3EndpointOverride) {
+    overrideS3Endpoint(frontEndInfo.s3EndpointOverride)
+  }
+}
+
+const overrideCognitoEndpoint: (cognitoEndpointOverride: string) => void = (
+  cognitoEndpointOverride: string
+) => {
+  console.log(`Overriding Cognito endpoint with '${cognitoEndpointOverride}'`)
+  AWS.config.cognitoidentity = {
+    endpoint: cognitoEndpointOverride
+  }
+}
+
+const overrideS3Endpoint: (s3EndpointOverride: string) => void = (
+  s3EndpointOverride: string
+) => {
+  console.log(`Overriding S3 endpoint with '${s3EndpointOverride}'`)
+  AWS.config.s3 = {
+    endpoint: s3EndpointOverride,
+    s3ForcePathStyle: true
+  }
+}

--- a/npm/src/index.ts
+++ b/npm/src/index.ts
@@ -1,3 +1,4 @@
+import { configureAws } from "./aws-config"
 import { GraphqlClient } from "./graphql"
 import { getKeycloakInstance, authenticateAndGetIdentityId } from "./auth"
 import { UploadFiles } from "./upload"
@@ -65,6 +66,9 @@ export const renderModules = () => {
   )
   if (uploadContainer) {
     const frontEndInfo = getFrontEndInfo()
+
+    configureAws(frontEndInfo)
+
     getKeycloakInstance().then(keycloak => {
       const graphqlClient = new GraphqlClient(frontEndInfo.apiUrl, keycloak)
       authenticateAndGetIdentityId(keycloak, frontEndInfo).then(identityId => {

--- a/npm/src/index.ts
+++ b/npm/src/index.ts
@@ -13,6 +13,8 @@ export interface IFrontEndInfo {
   identityPoolId: string
   stage: string
   region: string
+  cognitoEndpointOverride?: string
+  s3EndpointOverride?: string
 }
 
 const getFrontEndInfo: () => IFrontEndInfo = () => {
@@ -29,11 +31,17 @@ const getFrontEndInfo: () => IFrontEndInfo = () => {
   const regionElement: HTMLInputElement | null = document.querySelector(
     ".region"
   )
+  const cognitoEndpointOverrideElement: HTMLInputElement | null = document.querySelector(
+    ".cognito-endpoint-override"
+  )
+  const s3EndpointOverrideElement: HTMLInputElement | null = document.querySelector(
+    ".s3-endpoint-override"
+  )
 
   if (
-    identityPoolElement &&
     apiUrlElement &&
     identityProviderNameElement &&
+    identityPoolElement &&
     stageElement &&
     regionElement
   ) {
@@ -42,7 +50,9 @@ const getFrontEndInfo: () => IFrontEndInfo = () => {
       identityProviderName: identityProviderNameElement.value,
       identityPoolId: identityPoolElement.value,
       stage: stageElement.value,
-      region: regionElement.value
+      region: regionElement.value,
+      cognitoEndpointOverride: cognitoEndpointOverrideElement?.value,
+      s3EndpointOverride: s3EndpointOverrideElement?.value
     }
   } else {
     throw "The front end information is missing"

--- a/test/util/FrontEndTestHelper.scala
+++ b/test/util/FrontEndTestHelper.scala
@@ -55,9 +55,18 @@ trait FrontEndTestHelper extends PlaySpec with MockitoSugar with Injecting with 
     }
   }
 
-  def frontEndInfoConfiguration = {
+  def frontEndInfoConfiguration: FrontEndInfoConfiguration = {
     val frontEndInfoConfiguration: FrontEndInfoConfiguration = mock[FrontEndInfoConfiguration]
-    when(frontEndInfoConfiguration.frontEndInfo).thenReturn(new FrontEndInfo("", "", "", "", ""))
+    when(frontEndInfoConfiguration.frontEndInfo).thenReturn(
+      new FrontEndInfo(
+        "",
+        None,
+        "",
+        "",
+        None,
+        "",
+        ""
+      ))
     frontEndInfoConfiguration
   }
 


### PR DESCRIPTION
Add configuration options to allow developers to run a purely local development environment.

This requires the [tdr-local-aws](https://github.com/nationalarchives/tdr-local-aws) project and an S3 emulator like [S3 ninja](https://s3ninja.net/).

At the moment, you have to configure these new dependencies manually, but I'm planning to look into setting up all the local dependencies with docker-compose once we've got everything working locally. We should be able to simplify some of the local frontend config too, so that you can switch config files rather than setting all the environment variables individually.