### PR TITLE
Delete base.scss file

### DIFF
--- a/npm/css-src/sass/overrides/_all.scss
+++ b/npm/css-src/sass/overrides/_all.scss
@@ -1,2 +1,1 @@
 @import "typography";
-@import "base";

--- a/npm/css-src/sass/overrides/_base.scss
+++ b/npm/css-src/sass/overrides/_base.scss
@@ -1,8 +1,0 @@
-html {
-    box-sizing: border-box;
-}
-*,
-*:before,
-*:after {
-    box-sizing: inherit;
-}


### PR DESCRIPTION
Remove CSS overrides because they were breaking the layout of the checkboxes of the Gov.uk design system.
The overrides were added when we added the TNA logo to the header but it doesn't look like it actually affects the logo, so they are safe to delete.