### PR TITLE
Upgrade file-information dependency

### DIFF
--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -978,9 +978,9 @@
       }
     },
     "@nationalarchives/file-information": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@nationalarchives/file-information/-/file-information-1.0.4.tgz",
-      "integrity": "sha512-/7Z/8GiuUK1FrUN52swYxyPRd6zByJx9jXI07CUJ5lCY1sGk2e7iqouDn5AtyUy19TtctjGz8nftYJp2o6rVkQ==",
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@nationalarchives/file-information/-/file-information-1.0.16.tgz",
+      "integrity": "sha512-Rc1ArE1ZgwTz0Y45typjMSt+uPYfeasb7Kb8OTWUl4LIkI2Cg4iZ4iC8V1nR75M0lGDzcx3XcEfUiqwc1TxWzQ==",
       "requires": {
         "asmcrypto.js": "^2.3.2"
       }

--- a/npm/package.json
+++ b/npm/package.json
@@ -39,7 +39,7 @@
   },
   "homepage": "https://github.com/nationalarchives/tdr-transfer-frontend#readme",
   "dependencies": {
-    "@nationalarchives/file-information": "1.0.4",
+    "@nationalarchives/file-information": "1.0.16",
     "@nationalarchives/tdr-generated-graphql": "1.0.12",
     "apollo-boost": "^0.4.7",
     "aws-sdk": "^2.656.0",


### PR DESCRIPTION
The main reason is the incorporate this fix to file-information: https://github.com/nationalarchives/tdr-file-metadata/pull/24