### PR TITLE
Add id to AVMetadata Progress bar to differentiate for tests

### DIFF
--- a/app/views/fileChecksProgress.scala.html
+++ b/app/views/fileChecksProgress.scala.html
@@ -10,7 +10,7 @@
             <h1 class="govuk-heading-xl">@Messages("checkingRecords.title")</h1>
             <p class="govuk-body">@Messages("checkingRecords.description")</p>
             <p class="govuk-body">@Messages("checkingRecords.antivirus")</p>
-            <progress class="progress-display" value="@avMetadataPercentage" max="100"></progress>
+            <progress id="av-metadata-progress" class="progress-display" value="@avMetadataPercentage" max="100"></progress>
         </div>
     </div>
     }

--- a/app/views/fileChecksProgress.scala.html
+++ b/app/views/fileChecksProgress.scala.html
@@ -10,7 +10,7 @@
             <h1 class="govuk-heading-xl">@Messages("checkingRecords.title")</h1>
             <p class="govuk-body">@Messages("checkingRecords.description")</p>
             <p class="govuk-body">@Messages("checkingRecords.antivirus")</p>
-            <progress id="av-metadata-progress" class="progress-display" value="@avMetadataPercentage" max="100"></progress>
+            <progress id="av-metadata-progress-bar" class="progress-display" value="@avMetadataPercentage" max="100"></progress>
         </div>
     </div>
     }

--- a/test/controllers/FileChecksControllerSpec.scala
+++ b/test/controllers/FileChecksControllerSpec.scala
@@ -34,9 +34,9 @@ class FileChecksControllerSpec extends FrontEndTestHelper {
     wiremockServer.stop()
   }
 
-  "RecordsController GET" should {
+  "FileChecksController GET" should {
 
-    "render the records page with progress bar" in {
+    "render the fileChecks page with progress bar" in {
       val graphQLConfiguration = new GraphQLConfiguration(app.configuration)
       val consignmentService = new ConsignmentService(graphQLConfiguration)
       val client = new GraphQLConfiguration(app.configuration).getClient[fileCheck.Data, fileCheck.Variables]()
@@ -64,7 +64,7 @@ class FileChecksControllerSpec extends FrontEndTestHelper {
       contentAsString(recordsPage) must include("checkingRecords.header")
       contentAsString(recordsPage) must include("checkingRecords.title")
       contentAsString(recordsPage) must include("progress")
-      contentAsString(recordsPage) must include("<progress class=\"progress-display\" value=\"15\" max=\"100\"></progress>")
+      contentAsString(recordsPage) must include("<progress id=\"av-metadata-progress-bar\" class=\"progress-display\" value=\"15\" max=\"100\"></progress>")
     }
 
 


### PR DESCRIPTION
An ID has been added to the html element for the AVMetatadata progress bar so that when other bars are created with checksum/FFID checks that we are able to tell them apart for both tests and JS code.