### PR TITLE
Upgrade STTP to latest version (2.2.4)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,6 +19,7 @@ libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "4.0.3
 val playPac4jVersion = "9.0.0-RC3"
 val pac4jVersion = "4.0.0-RC3"
 val akkaVersion = "2.6.3"
+val sttpVersion = "2.2.4"
 
 libraryDependencies ++= Seq(
   "org.pac4j" %% "play-pac4j" % playPac4jVersion,
@@ -28,9 +29,9 @@ libraryDependencies ++= Seq(
   "net.bytebuddy" % "byte-buddy" % "1.9.7",
   "io.circe" %% "circe-core" % "0.13.0",
   "io.circe" %% "circe-generic" % "0.13.0",
-  "com.softwaremill.sttp.client" %% "core" % "2.0.0-RC9",
-  "com.softwaremill.sttp.client" %% "circe" % "2.0.0-RC9",
-  "com.softwaremill.sttp.client" %% "async-http-client-backend-future" % "2.0.0-RC9",
+  "com.softwaremill.sttp.client" %% "core" % sttpVersion,
+  "com.softwaremill.sttp.client" %% "circe" % sttpVersion,
+  "com.softwaremill.sttp.client" %% "async-http-client-backend-future" % sttpVersion,
   "uk.gov.nationalarchives" %% "tdr-graphql-client" % "0.0.12",
   "uk.gov.nationalarchives" %% "tdr-auth-utils" % "0.0.12",
   "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.55",

--- a/test/services/ConsignmentServiceSpec.scala
+++ b/test/services/ConsignmentServiceSpec.scala
@@ -14,6 +14,7 @@ import org.scalatest.concurrent.ScalaFutures._
 import org.scalatest.{BeforeAndAfterEach, Matchers, WordSpec}
 import org.scalatestplus.mockito.MockitoSugar
 import sttp.client.HttpError
+import sttp.model.StatusCode
 import uk.gov.nationalarchives.tdr.error.NotAuthorisedError
 import uk.gov.nationalarchives.tdr.{GraphQLClient, GraphQlResponse}
 
@@ -64,7 +65,7 @@ class ConsignmentServiceSpec extends WordSpec with Matchers with MockitoSugar wi
 
     "Return an error when the API has an error" in {
       when(getConsignmentClient.getResult(token, gc.document, Some(gc.Variables(consignmentId))))
-        .thenReturn(Future.failed(HttpError("something went wrong")))
+        .thenReturn(Future.failed(HttpError("something went wrong", StatusCode.InternalServerError)))
 
       val results = consignmentService.consignmentExists(consignmentId, token)
       results.failed.futureValue shouldBe a[HttpError]
@@ -106,7 +107,7 @@ class ConsignmentServiceSpec extends WordSpec with Matchers with MockitoSugar wi
 
     "Return an error when the API has an error" in {
       when(addConsignmentClient.getResult(token, addConsignment.document, Some(addConsignment.Variables(AddConsignmentInput(seriesId)))))
-        .thenReturn(Future.failed(HttpError("something went wrong")))
+        .thenReturn(Future.failed(HttpError("something went wrong", StatusCode.InternalServerError)))
 
       val results = consignmentService.createConsignment(seriesId, token)
 

--- a/test/services/SeriesServiceSpec.scala
+++ b/test/services/SeriesServiceSpec.scala
@@ -14,6 +14,7 @@ import org.scalatest.concurrent.ScalaFutures._
 import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
 import org.scalatestplus.mockito.MockitoSugar
 import sttp.client.HttpError
+import sttp.model.StatusCode
 import uk.gov.nationalarchives.tdr.error.NotAuthorisedError
 import uk.gov.nationalarchives.tdr.keycloak.Token
 import uk.gov.nationalarchives.tdr.{GraphQLClient, GraphQlResponse}
@@ -56,7 +57,7 @@ class SeriesServiceSpec extends FlatSpec with Matchers with MockitoSugar with Be
 
   "getSeriesForUser" should "return an error if the API call fails" in {
     when(graphQlClient.getResult(token.bearerAccessToken, getSeries.document, Some(getSeries.Variables(bodyName))))
-      .thenReturn(Future.failed(new HttpError("something went wrong")))
+      .thenReturn(Future.failed(new HttpError("something went wrong", StatusCode.InternalServerError)))
 
     seriesService.getSeriesForUser(token).failed.futureValue shouldBe a[HttpError]
   }

--- a/test/services/TransferAgreementServiceSpec.scala
+++ b/test/services/TransferAgreementServiceSpec.scala
@@ -13,6 +13,7 @@ import org.scalatest.concurrent.ScalaFutures._
 import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
 import org.scalatestplus.mockito.MockitoSugar
 import sttp.client.HttpError
+import sttp.model.StatusCode
 import uk.gov.nationalarchives.tdr.error.{NotAuthorisedError, UnknownGraphQlError}
 import uk.gov.nationalarchives.tdr.{GraphQLClient, GraphQlResponse}
 
@@ -65,7 +66,7 @@ class TransferAgreementServiceSpec extends FlatSpec with Matchers with MockitoSu
 
   "transferAgreementExists" should "throw an error if the API call fails" in {
     when(graphQlClient.getResult(token, document, Some(variables)))
-      .thenReturn(Future.failed(new HttpError("something went wrong")))
+      .thenReturn(Future.failed(new HttpError("something went wrong", StatusCode.InternalServerError)))
 
     transferAgreementService.transferAgreementExists(consignmentId, token).failed.futureValue shouldBe a[HttpError]
   }


### PR DESCRIPTION
This fixes a dependency incompatibility on Circe. This project depends directly on Circe 0.13, but the previous version of STTP required Circe 0.12. Now both projects require Circe 0.13.