### PR TITLE
Make the integration backend the default when running locally

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,49 +1,10 @@
-# https://www.playframework.com/documentation/latest/Configuration
-play.http.port=9000
+# This is the default configuration file for local development. It connects to the integration backend.
+
+include "application.local-base"
 
 auth.url="https://auth.tdr-integration.nationalarchives.gov.uk"
-auth.url=${?AUTH_URL}
-auth.callback="http://localhost:9000/callback"
-auth.secret="placeholderSecretValue"
-auth.secret=${?AUTH_SECRET}
 
-s3.endpointOverride=null
-s3.endpointOverride=${?S3_ENDPOINT_OVERRIDE}
-
-cognito.identitypool=${?IDENTITY_POOL_ID}
+cognito.identitypool=${IDENTITY_POOL_ID}
 cognito.identityProviderName=auth.tdr-integration.nationalarchives.gov.uk/auth/realms/tdr
-cognito.endpointOverride=null
-cognito.endpointOverride=${?COGNITO_ENDPOINT_OVERRIDE}
 
-play.cache.redis {
-    timeout=20s
-
-    # TDR depends on the Redis cache being available because it is used to store Keycloak parameters like the state
-    # parameter during login, so return an error rather than ignoring any cache errors
-    recovery=log-and-fail
-}
-
-play.i18n.langs = ["en-gb"]
-
-consignmentapi.url="http://localhost:8080/graphql"
-consignmentapi.url=${?API_URL}
-
-environment=intg
-region="eu-west-2"
-
-# This is needed for the play-redis library. Without it, it won't store auth information in the cache and you can't log in.
-akka.actor.allow-java-serialization="on"
-akka.actor.warn-about-java-serializer-usage="off"
-
-play.modules.enabled += "modules.SecurityModule"
-play.modules.enabled += "play.api.cache.redis.RedisCacheModule"
-
-play.http.errorHandler = "errors.ErrorHandler"
-
-play.filters.headers.frameOptions = "SAMEORIGIN"
-
-play.filters.hosts {
-    allowed = [
-        "localhost:9000"
-    ]
-}
+consignmentapi.url="https://api.tdr-integration.nationalarchives.gov.uk/graphql"

--- a/conf/application.local-base.conf
+++ b/conf/application.local-base.conf
@@ -1,0 +1,38 @@
+# This base configuration file that contains values used in local development, regardless of which backend
+# is being used (local or integration).
+
+# https://www.playframework.com/documentation/latest/Configuration
+play.http.port=9000
+
+auth.callback="http://localhost:9000/callback"
+auth.secret=${AUTH_SECRET}
+
+play.cache.redis {
+    timeout=20s
+
+    # TDR depends on the Redis cache being available because it is used to store Keycloak parameters like the state
+    # parameter during login, so return an error rather than ignoring any cache errors
+    recovery=log-and-fail
+}
+
+play.i18n.langs = ["en-gb"]
+
+environment=intg
+region="eu-west-2"
+
+# This is needed for the play-redis library. Without it, it won't store auth information in the cache and you can't log in.
+akka.actor.allow-java-serialization="on"
+akka.actor.warn-about-java-serializer-usage="off"
+
+play.modules.enabled += "modules.SecurityModule"
+play.modules.enabled += "play.api.cache.redis.RedisCacheModule"
+
+play.http.errorHandler = "errors.ErrorHandler"
+
+play.filters.headers.frameOptions = "SAMEORIGIN"
+
+play.filters.hosts {
+    allowed = [
+        "localhost:9000"
+    ]
+}

--- a/conf/application.local-full-stack.conf
+++ b/conf/application.local-full-stack.conf
@@ -1,0 +1,16 @@
+# This is the configuraiton file to use when running a completely local development environment, including a local API,
+# local Keycloak server and local backend checks
+
+include "application.local-base"
+
+auth.url="http://localhost:8081"
+
+s3.endpointOverride="http://localhost:9444/s3"
+
+# The local Cognito server does not use these values, so they are arbitrary
+cognito.identitypool="placeholder-identity-pool-id"
+cognito.identityProviderName="placeholder-identity-provider"
+
+cognito.endpointOverride="http://localhost:4600"
+
+consignmentapi.url="http://localhost:8080/graphql"

--- a/test/resources/application.conf
+++ b/test/resources/application.conf
@@ -6,6 +6,8 @@ auth.callback="http://localhost:9000/callback"
 auth.secret="f5d12779-2927-4992-a7cf-77358cf42e20"
 play.cache.redis.timeout=20s
 
+cognito.identitypool="fake-identity-pool-id"
+
 consignmentapi.url="http://localhost:9006/graphql"
 
 play.modules.enabled += "modules.SecurityModule"


### PR DESCRIPTION
Split the local dev config files into two:

- application.conf: This is the default, and is the one that will be used when you run `sbt run`. It connects to the integration backend. You still need to set the `AUTH_SECRET` and `IDENTITY_POOL_ID` environment variables, because they're not safe to store in the config file.
- application.local-full-stack.conf: This can be selected if you run `sbt  -Dconfig.file=conf/application.local-full-stack.conf run`, and will connect to the local Keycloak, API, etc.