### PR TITLE
Add placeholder transfer confirmation page

### DIFF
--- a/app/views/transferConfirmation.scala.html
+++ b/app/views/transferConfirmation.scala.html
@@ -1,0 +1,53 @@
+@()(implicit messages: Messages)
+@main(Messages("transferConfirmation.header")) {
+    @defining(play.core.PlayVersion.current) { version =>
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+                <a href="@routes.DashboardController.dashboard()" class="govuk-back-link">Back</a>
+                @progressIndicator(Messages("transferConfirmation.progress"))
+                <h1 class="govuk-heading-xl">@Messages("transferConfirmation.title")</h1>
+                <table class="govuk-table">
+                <!--        Should we add a caption and header?    -->
+                <!--    <caption class="govuk-table__caption">Dates and amounts</caption>-->
+                <!--    <thead class="govuk-table__head">-->
+                <!--    <tr class="govuk-table__row">-->
+                <!--        <th scope="col" class="govuk-table__header">Date</th>-->
+                <!--        <th scope="col" class="govuk-table__header">Amount</th>-->
+                <!--    </tr>-->
+                <!--    </thead>-->
+                    <tbody class="govuk-table__body">
+                    <tr class="govuk-table__row">
+                        <th scope="row" class="govuk-table__header">Series reference</th>
+                        <td class="govuk-table__cell"></td>
+                    </tr>
+                    <tr class="govuk-table__row">
+                        <th scope="row" class="govuk-table__header">Consignment reference</th>
+                        <td class="govuk-table__cell"></td>
+                    </tr>
+                    <tr class="govuk-table__row">
+                        <th scope="row" class="govuk-table__header">Transferring body</th>
+                        <td class="govuk-table__cell"></td>
+                    </tr>
+                    <tr class="govuk-table__row">
+                        <th scope="row" class="govuk-table__header">Records Officer</th>
+                        <td class="govuk-table__cell"></td>
+                    </tr>
+                    <tr class="govuk-table__row">
+                        <th scope="row" class="govuk-table__header">Files uploaded for transfer</th>
+                        <td class="govuk-table__cell"></td>
+                    </tr>
+                    </tbody>
+                </table>
+                <fieldset class="govuk-fieldset" aria-describedby="transfer-confirmation">
+                    <!-- Open records & transfer legal ownership -->
+                </fieldset>
+                <div>
+                    <!-- Transfer -->
+                    <button class="govuk-button" type="submit" data-module="govuk-button" role="button">
+                        @Messages("transferConfirmation.transferLink")
+                    </button>
+                </div>
+            </div>
+        </div>
+    }
+}

--- a/conf/messages
+++ b/conf/messages
@@ -55,6 +55,9 @@ checkingRecords.ffid=Identifying file formats
 fileChecksResults.header=Record check results
 fileChecksResults.title=Record check results
 fileChecksResults.description=Here are your results
+transferConfirmation.header=Review and Confirm
+transferConfirmation.title=Review and Confirm
+transferConfirmation.transferLink=Transfer
 
 # Upload.error messages placeholder wording
 upload.error.title=There is a problem
@@ -69,4 +72,5 @@ transferAgreement.progress=2
 upload.progress=3
 uploadProgress.progress=4
 checkingRecords.progress=5
-progress.totalSteps=5
+transferConfirmation.progress=8
+progress.totalSteps=8


### PR DESCRIPTION
Wasn't sure if the `<caption>` and `<thead>` should be kept in the table and left blank, removed or filled in with something. [This page](https://design-system.service.gov.uk/components/table/ )  utilises them both; not sure if they apply to our table.