### PR TITLE
Tdr 509 save parent folder

### DIFF
--- a/npm/src/clientfilemetadataupload/index.ts
+++ b/npm/src/clientfilemetadataupload/index.ts
@@ -29,12 +29,14 @@ export class ClientFileMetadataUpload {
 
   async saveFileInformation(
     consignmentId: string,
-    numberOfFiles: number
+    numberOfFiles: number,
+    parentFolder: string
   ): Promise<string[]> {
     const variables: AddFilesMutationVariables = {
       addFilesInput: {
         consignmentId: consignmentId,
-        numberOfFiles: numberOfFiles
+        numberOfFiles: numberOfFiles,
+        parentFolder: parentFolder
       }
     }
 

--- a/npm/src/clientfilemetadataupload/index.ts
+++ b/npm/src/clientfilemetadataupload/index.ts
@@ -12,6 +12,7 @@ import {
 
 import { FetchResult } from "apollo-boost"
 import { ITdrFile } from "../s3upload"
+import { FileUploadInfo } from "../upload/upload-form"
 
 declare var METADATA_UPLOAD_BATCH_SIZE: number
 
@@ -28,15 +29,14 @@ export class ClientFileMetadataUpload {
   }
 
   async saveFileInformation(
-    consignmentId: string,
     numberOfFiles: number,
-    parentFolder: string
+    uploadFilesInfo: FileUploadInfo
   ): Promise<string[]> {
     const variables: AddFilesMutationVariables = {
       addFilesInput: {
-        consignmentId: consignmentId,
+        consignmentId: uploadFilesInfo.consignmentId,
         numberOfFiles: numberOfFiles,
-        parentFolder: parentFolder
+        parentFolder: uploadFilesInfo.parentFolder
       }
     }
 

--- a/npm/src/clientfileprocessing/index.ts
+++ b/npm/src/clientfileprocessing/index.ts
@@ -7,6 +7,7 @@ import {
   IProgressInformation
 } from "@nationalarchives/file-information"
 import { ITdrFile, S3Upload } from "../s3upload"
+import { FileUploadInfo } from "../upload/upload-form"
 
 export class ClientFileProcessing {
   clientFileMetadataUpload: ClientFileMetadataUpload
@@ -58,16 +59,14 @@ export class ClientFileProcessing {
   }
 
   async processClientFiles(
-    consignmentId: string,
     files: TdrFile[],
-    parentFolder: string,
+    uploadFilesInfo: FileUploadInfo,
     stage: string
   ): Promise<void> {
     try {
       const fileIds: string[] = await this.clientFileMetadataUpload.saveFileInformation(
-        consignmentId,
         files.length,
-        parentFolder
+        uploadFilesInfo
       )
       const metadata: IFileMetadata[] = await this.clientFileExtractMetadata.extract(
         files,
@@ -78,7 +77,7 @@ export class ClientFileProcessing {
         metadata
       )
       await this.s3Upload.uploadToS3(
-        consignmentId,
+        uploadFilesInfo.consignmentId,
         tdrFiles,
         this.s3ProgressCallback,
         stage

--- a/npm/src/clientfileprocessing/index.ts
+++ b/npm/src/clientfileprocessing/index.ts
@@ -60,12 +60,14 @@ export class ClientFileProcessing {
   async processClientFiles(
     consignmentId: string,
     files: TdrFile[],
+    parentFolder: string,
     stage: string
   ): Promise<void> {
     try {
       const fileIds: string[] = await this.clientFileMetadataUpload.saveFileInformation(
         consignmentId,
-        files.length
+        files.length,
+        parentFolder
       )
       const metadata: IFileMetadata[] = await this.clientFileExtractMetadata.extract(
         files,

--- a/npm/src/upload/index.ts
+++ b/npm/src/upload/index.ts
@@ -2,7 +2,7 @@ import { TdrFile } from "@nationalarchives/file-information"
 import { ClientFileProcessing } from "../clientfileprocessing"
 import { ClientFileMetadataUpload } from "../clientfilemetadataupload"
 import { S3Upload } from "../s3upload"
-import { UploadForm } from "./upload-form"
+import { FileUploadInfo, UploadForm } from "./upload-form"
 
 export class UploadFiles {
   clientFileProcessing: ClientFileProcessing
@@ -25,12 +25,10 @@ export class UploadFiles {
 
   uploadFiles: (
     files: TdrFile[],
-    consignmentId: string,
-    parentFolder: string
+    uploadFilesInfo: FileUploadInfo
   ) => Promise<void> = async (
     files: TdrFile[],
-    consignmentId: string,
-    parentFolder: string
+    uploadFilesInfo: FileUploadInfo
   ) => {
     const pageUnloadAction: (e: BeforeUnloadEvent) => void = (e) => {
       e.preventDefault()
@@ -40,9 +38,8 @@ export class UploadFiles {
 
     try {
       await this.clientFileProcessing.processClientFiles(
-        consignmentId,
         files,
-        parentFolder,
+        uploadFilesInfo,
         this.stage
       )
       // In order to prevent exit confirmation when page redirects to Records page

--- a/npm/src/upload/index.ts
+++ b/npm/src/upload/index.ts
@@ -25,8 +25,13 @@ export class UploadFiles {
 
   uploadFiles: (
     files: TdrFile[],
-    consignmentId: string
-  ) => Promise<void> = async (files: TdrFile[], consignmentId: string) => {
+    consignmentId: string,
+    parentFolder: string
+  ) => Promise<void> = async (
+    files: TdrFile[],
+    consignmentId: string,
+    parentFolder: string
+  ) => {
     const pageUnloadAction: (e: BeforeUnloadEvent) => void = (e) => {
       e.preventDefault()
       e.returnValue = ""
@@ -37,6 +42,7 @@ export class UploadFiles {
       await this.clientFileProcessing.processClientFiles(
         consignmentId,
         files,
+        parentFolder,
         this.stage
       )
       // In order to prevent exit confirmation when page redirects to Records page

--- a/npm/src/upload/upload-form.ts
+++ b/npm/src/upload/upload-form.ts
@@ -99,13 +99,18 @@ export class UploadForm {
   }
 
   addSubmitListener(
-    uploadFiles: (files: TdrFile[], consignmentId: string) => void
+    uploadFiles: (
+      files: TdrFile[],
+      consignmentId: string,
+      parentFolder: string
+    ) => void
   ) {
     this.formElement.addEventListener("submit", (ev) => {
       ev.preventDefault()
       const target: HTMLInputTarget | null = ev.currentTarget
       const files = this.retrieveFiles(target)
-      uploadFiles(files, this.consignmentId())
+      const parentFolder = this.getParentFolderName(files)
+      uploadFiles(files, this.consignmentId(), parentFolder)
     })
   }
 

--- a/npm/src/upload/upload-form.ts
+++ b/npm/src/upload/upload-form.ts
@@ -4,6 +4,11 @@ export interface InputElement extends EventTarget {
   files?: TdrFile[]
 }
 
+export interface FileUploadInfo {
+  consignmentId: string
+  parentFolder: string
+}
+
 interface HTMLInputTarget extends EventTarget {
   files?: InputElement
 }
@@ -99,18 +104,18 @@ export class UploadForm {
   }
 
   addSubmitListener(
-    uploadFiles: (
-      files: TdrFile[],
-      consignmentId: string,
-      parentFolder: string
-    ) => void
+    uploadFiles: (files: TdrFile[], uploadFilesInfo: FileUploadInfo) => void
   ) {
     this.formElement.addEventListener("submit", (ev) => {
       ev.preventDefault()
       const target: HTMLInputTarget | null = ev.currentTarget
       const files = this.retrieveFiles(target)
       const parentFolder = this.getParentFolderName(files)
-      uploadFiles(files, this.consignmentId(), parentFolder)
+      const uploadFilesInfo: FileUploadInfo = {
+        consignmentId: this.consignmentId(),
+        parentFolder: parentFolder
+      }
+      uploadFiles(files, uploadFilesInfo)
     })
   }
 

--- a/npm/test/clientfilemetataupload.test.ts
+++ b/npm/test/clientfilemetataupload.test.ts
@@ -146,7 +146,11 @@ test("saveFileInformation returns list of file ids", async () => {
 
   const client = new GraphqlClient("https://test.im", mockKeycloakInstance)
   const uploadMetadata = new ClientFileMetadataUpload(client)
-  const result = await uploadMetadata.saveFileInformation("1", 3)
+  const result = await uploadMetadata.saveFileInformation(
+    "1",
+    3,
+    "TEST PARENT FOLDER NAME"
+  )
 
   expect(result).toEqual([1, 2, 3])
 })
@@ -156,7 +160,7 @@ test("saveFileInformation returns error if no data returned", async () => {
   const client = new GraphqlClient("https://test.im", mockKeycloakInstance)
   const uploadMetadata = new ClientFileMetadataUpload(client)
   await expect(
-    uploadMetadata.saveFileInformation("1", 3)
+    uploadMetadata.saveFileInformation("1", 3, "TEST PARENT FOLDER NAME")
   ).rejects.toStrictEqual(Error("Add files failed: no data"))
 })
 
@@ -165,7 +169,7 @@ test("saveFileInformation returns error if returned data contains errors", async
   const client = new GraphqlClient("https://test.im", mockKeycloakInstance)
   const uploadMetadata = new ClientFileMetadataUpload(client)
   await expect(
-    uploadMetadata.saveFileInformation("1", 3)
+    uploadMetadata.saveFileInformation("1", 3, "TEST PARENT FOLDER NAME")
   ).rejects.toStrictEqual(Error("Add files failed: error 1,error 2"))
 })
 

--- a/npm/test/clientfilemetataupload.test.ts
+++ b/npm/test/clientfilemetataupload.test.ts
@@ -146,11 +146,10 @@ test("saveFileInformation returns list of file ids", async () => {
 
   const client = new GraphqlClient("https://test.im", mockKeycloakInstance)
   const uploadMetadata = new ClientFileMetadataUpload(client)
-  const result = await uploadMetadata.saveFileInformation(
-    "1",
-    3,
-    "TEST PARENT FOLDER NAME"
-  )
+  const result = await uploadMetadata.saveFileInformation(3, {
+    consignmentId: "1",
+    parentFolder: "TEST PARENT FOLDER NAME"
+  })
 
   expect(result).toEqual([1, 2, 3])
 })
@@ -160,7 +159,10 @@ test("saveFileInformation returns error if no data returned", async () => {
   const client = new GraphqlClient("https://test.im", mockKeycloakInstance)
   const uploadMetadata = new ClientFileMetadataUpload(client)
   await expect(
-    uploadMetadata.saveFileInformation("1", 3, "TEST PARENT FOLDER NAME")
+    uploadMetadata.saveFileInformation(3, {
+      consignmentId: "1",
+      parentFolder: "TEST PARENT FOLDER NAME"
+    })
   ).rejects.toStrictEqual(Error("Add files failed: no data"))
 })
 
@@ -169,7 +171,10 @@ test("saveFileInformation returns error if returned data contains errors", async
   const client = new GraphqlClient("https://test.im", mockKeycloakInstance)
   const uploadMetadata = new ClientFileMetadataUpload(client)
   await expect(
-    uploadMetadata.saveFileInformation("1", 3, "TEST PARENT FOLDER NAME")
+    uploadMetadata.saveFileInformation(3, {
+      consignmentId: "1",
+      parentFolder: "TEST PARENT FOLDER NAME"
+    })
   ).rejects.toStrictEqual(Error("Add files failed: error 1,error 2"))
 })
 

--- a/npm/test/clientfileprocessing.test.ts
+++ b/npm/test/clientfileprocessing.test.ts
@@ -167,7 +167,7 @@ test("client file metadata successfully uploaded", async () => {
     new S3UploadMock()
   )
   await expect(
-    fileProcessing.processClientFiles("1", [], "")
+    fileProcessing.processClientFiles("1", [], "TEST PARENT FOLDER NAME", "")
   ).resolves.not.toThrow()
 })
 
@@ -254,7 +254,7 @@ test("file successfully uploaded to s3", async () => {
   const s3UploadMock = new S3UploadMock()
   const fileProcessing = new ClientFileProcessing(metadataUpload, s3UploadMock)
   await expect(
-    fileProcessing.processClientFiles("1", [], "")
+    fileProcessing.processClientFiles("1", [], "TEST PARENT FOLDER NAME", "")
   ).resolves.not.toThrow()
 
   expect(s3UploadMock.uploadToS3).toHaveBeenCalledTimes(1)
@@ -346,7 +346,7 @@ test("Error thrown if processing files fails", async () => {
   )
 
   await expect(
-    fileProcessing.processClientFiles("1", [], "")
+    fileProcessing.processClientFiles("1", [], "TEST PARENT FOLDER NAME", "")
   ).rejects.toStrictEqual(
     Error(
       "Processing client files failed: upload client file information error"
@@ -368,7 +368,7 @@ test("Error thrown if processing file metadata fails", async () => {
   )
 
   await expect(
-    fileProcessing.processClientFiles("1", [], "")
+    fileProcessing.processClientFiles("1", [], "TEST PARENT FOLDER NAME", "")
   ).rejects.toStrictEqual(
     Error("Processing client files failed: upload client file metadata error")
   )
@@ -388,7 +388,7 @@ test("Error thrown if extracting file metadata fails", async () => {
   )
 
   await expect(
-    fileProcessing.processClientFiles("1", [], "")
+    fileProcessing.processClientFiles("1", [], "TEST PARENT FOLDER NAME", "")
   ).rejects.toStrictEqual(
     Error(
       "Processing client files failed: client file metadata extraction error"
@@ -409,7 +409,7 @@ test("Error thrown if S3 upload fails", async () => {
   const fileProcessing = new ClientFileProcessing(metadataUpload, s3Upload)
 
   await expect(
-    fileProcessing.processClientFiles("1", [], "")
+    fileProcessing.processClientFiles("1", [], "TEST PARENT FOLDER NAME", "")
   ).rejects.toStrictEqual(
     Error("Processing client files failed: Some S3 error")
   )

--- a/npm/test/clientfileprocessing.test.ts
+++ b/npm/test/clientfileprocessing.test.ts
@@ -167,7 +167,11 @@ test("client file metadata successfully uploaded", async () => {
     new S3UploadMock()
   )
   await expect(
-    fileProcessing.processClientFiles("1", [], "TEST PARENT FOLDER NAME", "")
+    fileProcessing.processClientFiles(
+      [],
+      { consignmentId: "1", parentFolder: "TEST PARENT FOLDER NAME" },
+      ""
+    )
   ).resolves.not.toThrow()
 })
 
@@ -254,7 +258,11 @@ test("file successfully uploaded to s3", async () => {
   const s3UploadMock = new S3UploadMock()
   const fileProcessing = new ClientFileProcessing(metadataUpload, s3UploadMock)
   await expect(
-    fileProcessing.processClientFiles("1", [], "TEST PARENT FOLDER NAME", "")
+    fileProcessing.processClientFiles(
+      [],
+      { consignmentId: "1", parentFolder: "TEST PARENT FOLDER NAME" },
+      ""
+    )
   ).resolves.not.toThrow()
 
   expect(s3UploadMock.uploadToS3).toHaveBeenCalledTimes(1)
@@ -346,7 +354,11 @@ test("Error thrown if processing files fails", async () => {
   )
 
   await expect(
-    fileProcessing.processClientFiles("1", [], "TEST PARENT FOLDER NAME", "")
+    fileProcessing.processClientFiles(
+      [],
+      { consignmentId: "1", parentFolder: "TEST PARENT FOLDER NAME" },
+      ""
+    )
   ).rejects.toStrictEqual(
     Error(
       "Processing client files failed: upload client file information error"
@@ -368,7 +380,11 @@ test("Error thrown if processing file metadata fails", async () => {
   )
 
   await expect(
-    fileProcessing.processClientFiles("1", [], "TEST PARENT FOLDER NAME", "")
+    fileProcessing.processClientFiles(
+      [],
+      { consignmentId: "1", parentFolder: "TEST PARENT FOLDER NAME" },
+      ""
+    )
   ).rejects.toStrictEqual(
     Error("Processing client files failed: upload client file metadata error")
   )
@@ -388,7 +404,11 @@ test("Error thrown if extracting file metadata fails", async () => {
   )
 
   await expect(
-    fileProcessing.processClientFiles("1", [], "TEST PARENT FOLDER NAME", "")
+    fileProcessing.processClientFiles(
+      [],
+      { consignmentId: "1", parentFolder: "TEST PARENT FOLDER NAME" },
+      ""
+    )
   ).rejects.toStrictEqual(
     Error(
       "Processing client files failed: client file metadata extraction error"
@@ -409,7 +429,11 @@ test("Error thrown if S3 upload fails", async () => {
   const fileProcessing = new ClientFileProcessing(metadataUpload, s3Upload)
 
   await expect(
-    fileProcessing.processClientFiles("1", [], "TEST PARENT FOLDER NAME", "")
+    fileProcessing.processClientFiles(
+      [],
+      { consignmentId: "1", parentFolder: "TEST PARENT FOLDER NAME" },
+      ""
+    )
   ).rejects.toStrictEqual(
     Error("Processing client files failed: Some S3 error")
   )

--- a/npm/test/upload.test.ts
+++ b/npm/test/upload.test.ts
@@ -66,7 +66,10 @@ test("upload function submits redirect form on upload files success", async () =
     .spyOn(console, "error")
     .mockImplementation(() => {})
 
-  await uploadFiles.uploadFiles([dummyFile], "12345", "TEST PARENT FOLDER NAME")
+  await uploadFiles.uploadFiles([dummyFile], {
+    consignmentId: "12345",
+    parentFolder: "TEST PARENT FOLDER NAME"
+  })
 
   expect(consoleErrorSpy).not.toHaveBeenCalled()
   expect(mockGoToNextPage).toHaveBeenCalled()
@@ -83,7 +86,10 @@ test("upload function console logs error when upload fails", async () => {
     .spyOn(console, "error")
     .mockImplementation(() => {})
 
-  await uploadFiles.uploadFiles([dummyFile], "12345", "TEST PARENT FOLDER NAME")
+  await uploadFiles.uploadFiles([dummyFile], {
+    consignmentId: "12345",
+    parentFolder: "TEST PARENT FOLDER NAME"
+  })
 
   expect(consoleErrorSpy).toHaveBeenCalled()
   expect(mockGoToNextPage).not.toHaveBeenCalled()

--- a/npm/test/upload.test.ts
+++ b/npm/test/upload.test.ts
@@ -66,7 +66,7 @@ test("upload function submits redirect form on upload files success", async () =
     .spyOn(console, "error")
     .mockImplementation(() => {})
 
-  await uploadFiles.uploadFiles([dummyFile], "12345")
+  await uploadFiles.uploadFiles([dummyFile], "12345", "TEST PARENT FOLDER NAME")
 
   expect(consoleErrorSpy).not.toHaveBeenCalled()
   expect(mockGoToNextPage).toHaveBeenCalled()
@@ -83,7 +83,7 @@ test("upload function console logs error when upload fails", async () => {
     .spyOn(console, "error")
     .mockImplementation(() => {})
 
-  await uploadFiles.uploadFiles([dummyFile], "12345")
+  await uploadFiles.uploadFiles([dummyFile], "12345", "TEST PARENT FOLDER NAME")
 
   expect(consoleErrorSpy).toHaveBeenCalled()
   expect(mockGoToNextPage).not.toHaveBeenCalled()


### PR DESCRIPTION
This change saves the parent folder name to the consignment at the same stage that we are updating the files table. As a function already existed to extract the parent folder name from the files, I used this and passed the variable through from the `upload-form.ts`, to `upload/index.ts`, `clientFileProcessing.ts` to the `clientFileMetadataUpload.ts` file where we have a function that saves files with the appropriate API endpoint. This saves duplicating an existing piece of work.

I also changed some of the existing tests to reflect the change in these functions and their parameters.

This work changes the way we save files (and adds the saving of parent folder name) but does not affect the upload itself.