### PR TITLE
Return the correct action to allow stored form posts to be re-run

### DIFF
--- a/app/modules/FrontendHttpActionAdaptor.scala
+++ b/app/modules/FrontendHttpActionAdaptor.scala
@@ -1,22 +1,28 @@
 package modules
 
 import org.pac4j.core.context.HttpConstants
-import org.pac4j.core.exception.http.HttpAction
+import org.pac4j.core.exception.http.{HttpAction, OkAction}
 import org.pac4j.play.PlayWebContext
 import org.pac4j.play.http.PlayHttpActionAdapter
 import play.mvc.{Result, Results}
+import play.twirl.api.Html
 
 class FrontendHttpActionAdaptor extends PlayHttpActionAdapter {
 
   override def adapt(action: HttpAction, context: PlayWebContext): Result = {
-    val code = action.getCode
-    if (code == HttpConstants.UNAUTHORIZED) {
-      Results.redirect("/")
-    } else if (code == HttpConstants.FORBIDDEN) {
-      Results.redirect("/")
-    } else {
-      super.adapt(action, context)
+    action match {
+      case a: OkAction =>
+        Results.ok(Html(Option(a.getContent)))
+      case _ => val code = action.getCode
+        if (code == HttpConstants.UNAUTHORIZED) {
+          Results.redirect("/")
+        } else if (code == HttpConstants.FORBIDDEN) {
+          Results.redirect("/")
+        } else {
+          super.adapt(action, context)
+        }
     }
+
   }
 
 

--- a/app/modules/SecurityModule.scala
+++ b/app/modules/SecurityModule.scala
@@ -1,15 +1,23 @@
 package modules
 
+import java.lang
+
 import com.google.inject.{AbstractModule, Provides}
 import org.pac4j.core.client.Clients
 import org.pac4j.core.config.Config
+import org.pac4j.core.engine.{AbstractExceptionAwareLogic, CallbackLogic, DefaultSecurityLogic, SecurityGrantedAccessAdapter}
+import org.pac4j.core.http.adapter.HttpActionAdapter
 import org.pac4j.core.profile.CommonProfile
 import org.pac4j.oidc.client.OidcClient
 import org.pac4j.oidc.config.OidcConfiguration
 import org.pac4j.play.scala.{DefaultSecurityComponents, Pac4jScalaTemplateHelper, SecurityComponents}
 import org.pac4j.play.store.{PlayCacheSessionStore, PlaySessionStore}
-import org.pac4j.play.{CallbackController, LogoutController}
+import org.pac4j.play.{CallbackController, LogoutController, PlayWebContext}
+import play.mvc.Result
 import play.api.{Configuration, Environment}
+
+import scala.jdk.OptionConverters.RichOptional
+import scala.util.Try
 
 
 class SecurityModule extends AbstractModule {
@@ -56,6 +64,7 @@ class SecurityModule extends AbstractModule {
   def provideConfig(oidcClient: OidcClient[OidcConfiguration]): Config = {
     val clients = new Clients(oidcClient)
     val config = new Config(clients)
+
     config.setHttpActionAdapter(new FrontendHttpActionAdaptor())
     config
   }

--- a/app/modules/SecurityModule.scala
+++ b/app/modules/SecurityModule.scala
@@ -1,23 +1,15 @@
 package modules
 
-import java.lang
-
 import com.google.inject.{AbstractModule, Provides}
 import org.pac4j.core.client.Clients
 import org.pac4j.core.config.Config
-import org.pac4j.core.engine.{AbstractExceptionAwareLogic, CallbackLogic, DefaultSecurityLogic, SecurityGrantedAccessAdapter}
-import org.pac4j.core.http.adapter.HttpActionAdapter
 import org.pac4j.core.profile.CommonProfile
 import org.pac4j.oidc.client.OidcClient
 import org.pac4j.oidc.config.OidcConfiguration
 import org.pac4j.play.scala.{DefaultSecurityComponents, Pac4jScalaTemplateHelper, SecurityComponents}
 import org.pac4j.play.store.{PlayCacheSessionStore, PlaySessionStore}
-import org.pac4j.play.{CallbackController, LogoutController, PlayWebContext}
-import play.mvc.Result
+import org.pac4j.play.{CallbackController, LogoutController}
 import play.api.{Configuration, Environment}
-
-import scala.jdk.OptionConverters.RichOptional
-import scala.util.Try
 
 
 class SecurityModule extends AbstractModule {
@@ -64,7 +56,6 @@ class SecurityModule extends AbstractModule {
   def provideConfig(oidcClient: OidcClient[OidcConfiguration]): Config = {
     val clients = new Clients(oidcClient)
     val config = new Config(clients)
-
     config.setHttpActionAdapter(new FrontendHttpActionAdaptor())
     config
   }

--- a/build.sbt
+++ b/build.sbt
@@ -16,15 +16,15 @@ scalaVersion := "2.13.3"
 libraryDependencies += guice
 libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "4.0.3" % Test
 
-val playPac4jVersion = "9.0.0-RC3"
-val pac4jVersion = "4.0.0-RC3"
+val playPac4jVersion = "10.0.2"
+val pac4jVersion = "4.2.0"
 val akkaVersion = "2.6.3"
 val sttpVersion = "2.2.4"
 
 libraryDependencies ++= Seq(
   "org.pac4j" %% "play-pac4j" % playPac4jVersion,
-  "org.pac4j" % "pac4j-http" % pac4jVersion,
-  "org.pac4j" % "pac4j-oidc" % pac4jVersion exclude("commons-io", "commons-io"),
+  "org.pac4j" % "pac4j-http" % pac4jVersion exclude("com.fasterxml.jackson.core", "jackson-databind"),
+  "org.pac4j" % "pac4j-oidc" % pac4jVersion exclude("commons-io", "commons-io") exclude("com.fasterxml.jackson.core", "jackson-databind"),
   "org.apache.shiro" % "shiro-core" % "1.4.0",
   "net.bytebuddy" % "byte-buddy" % "1.9.7",
   "io.circe" %% "circe-core" % "0.13.0",

--- a/test/util/FrontEndTestHelper.scala
+++ b/test/util/FrontEndTestHelper.scala
@@ -11,9 +11,11 @@ import org.keycloak.representations.AccessToken
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
 import org.pac4j.core.authorization.authorizer.Authorizer
-import org.pac4j.core.client.Clients
+import org.pac4j.core.authorization.checker.AuthorizationChecker
+import org.pac4j.core.client.{Client, Clients}
 import org.pac4j.core.config.Config
 import org.pac4j.core.context.WebContext
+import org.pac4j.core.credentials.Credentials
 import org.pac4j.core.engine.DefaultSecurityLogic
 import org.pac4j.core.http.ajax.AjaxRequestResolver
 import org.pac4j.core.profile.UserProfile
@@ -43,6 +45,7 @@ import viewsapi.FrontEndInfo
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
+import scala.language.existentials
 
 
 trait FrontEndTestHelper extends PlaySpec with MockitoSugar with Injecting with GuiceOneAppPerTest with BeforeAndAfterEach {
@@ -123,7 +126,7 @@ trait FrontEndTestHelper extends PlaySpec with MockitoSugar with Injecting with 
 
     //Return true on the isAuthorized method
     val logic = DefaultSecurityLogic.INSTANCE
-    logic.setAuthorizationChecker((_: WebContext, _: util.List[UserProfile], _: String, _: util.Map[String, Authorizer[_ <: UserProfile]]) => true)
+    logic.setAuthorizationChecker((_: WebContext, _: util.List[UserProfile], _: String, _: util.Map[String, Authorizer[_ <: UserProfile]], _: util.List[Client[_$1]] forSome {type _$1 <: Credentials}) => true)
     testConfig.setSecurityLogic(logic)
 
     //There is a null check for the action adaptor.
@@ -153,7 +156,7 @@ trait FrontEndTestHelper extends PlaySpec with MockitoSugar with Injecting with 
 
     val testConfig = new Config()
     val logic = DefaultSecurityLogic.INSTANCE
-    logic setAuthorizationChecker ((_: WebContext, _: util.List[UserProfile], _: String, _: util.Map[String, Authorizer[_ <: UserProfile]]) => false)
+    logic setAuthorizationChecker((_: WebContext, _: util.List[UserProfile], _: String, _: util.Map[String, Authorizer[_ <: UserProfile]], _: util.List[Client[_$1]] forSome {type _$1 <: Credentials}) => false)
     testConfig.setSecurityLogic(logic)
 
     //There is a null check for the action adaptor.

--- a/test/util/FrontEndTestHelper.scala
+++ b/test/util/FrontEndTestHelper.scala
@@ -2,7 +2,9 @@ package util
 
 import java.io.File
 import java.net.URI
+import java.time.{LocalDateTime, ZoneOffset}
 import java.util
+import java.util.Date
 
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken
 import com.nimbusds.openid.connect.sdk.op.OIDCProviderMetadata
@@ -21,7 +23,7 @@ import org.pac4j.core.profile.UserProfile
 import org.pac4j.core.util.Pac4jConstants
 import org.pac4j.oidc.client.OidcClient
 import org.pac4j.oidc.config.OidcConfiguration
-import org.pac4j.oidc.profile.OidcProfile
+import org.pac4j.oidc.profile.{OidcProfile, OidcProfileDefinition}
 import org.pac4j.oidc.redirect.OidcRedirectionActionBuilder
 import org.pac4j.play.PlayWebContext
 import org.pac4j.play.http.PlayHttpActionAdapter
@@ -112,6 +114,7 @@ trait FrontEndTestHelper extends PlaySpec with MockitoSugar with Injecting with 
     //Create the profile and add to the map
     val profile: OidcProfile = new OidcProfile()
     profile.setAccessToken(new BearerAccessToken("faketoken"))
+    profile.addAttribute(OidcProfileDefinition.EXPIRATION, Date.from(LocalDateTime.now().plusDays(10).toInstant(ZoneOffset.UTC)))
 
     val profileMap: java.util.LinkedHashMap[String, OidcProfile] = new java.util.LinkedHashMap[String, OidcProfile]
     profileMap.put("OidcClient", profile)

--- a/test/util/FrontEndTestHelper.scala
+++ b/test/util/FrontEndTestHelper.scala
@@ -11,7 +11,6 @@ import org.keycloak.representations.AccessToken
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
 import org.pac4j.core.authorization.authorizer.Authorizer
-import org.pac4j.core.authorization.checker.AuthorizationChecker
 import org.pac4j.core.client.{Client, Clients}
 import org.pac4j.core.config.Config
 import org.pac4j.core.context.WebContext
@@ -34,7 +33,7 @@ import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneAppPerTest
-import play.api.{Application, Configuration}
+import play.api.Application
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.mvc.{BodyParsers, ControllerComponents}


### PR DESCRIPTION
The problem causing [TDR-244](https://national-archives.atlassian.net/browse/TDR-244) happens if the refresh token expires while you're still logged into the session and then try to submit a form post. These are the code snippets from pac4j of roughly what happens.

The refresh token is expired which causes this to be run 
```
if (startAuthentication(context, currentClients)) {
  LOGGER.debug("Starting authentication");
  saveRequestedUrl(context, currentClients, config.getClients().getAjaxRequestResolver());
  action = redirectToIdentityProvider(context, currentClients);
}
```
`saveRequestedUrl` eventually does this.
```
final String requestedUrl = getRequestedUrl(context);
if (ContextHelper.isPost(context)) {
  LOGGER.debug("requestedUrl with data: {}", requestedUrl);
  final String formPost = RedirectionActionHelper.buildFormPostContent(context);
  context.getSessionStore().set(context, Pac4jConstants.REQUESTED_URL, new OkAction(formPost));
} 
```
You can see that it's saving an `OkAction` with the form post data, i.e. the form html

Next, `action = redirectToIdentityProvider(context, currentClients);` is run which authenticates successfully because your play/keycloak session is still active. To authenticate, it redirects to keycloak and then back again. Once keycloak has redirected back to pac4j's CallbackController, the original request is retrieved from the session.

```
if (requestedAction instanceof FoundAction) {
  return RedirectionActionHelper.buildRedirectUrlAction(context, ((FoundAction) requestedAction).getLocation());
} else {
  return RedirectionActionHelper.buildFormPostContentAction(context, ((OkAction) requestedAction).getContent());
}
```

As you can see from above, the `requestedAction` is an `OkAction` so it hits the else branch. As the method name suggests, this rebuilds the form post html and the default behaviour for pac4j is just to render this in a `<pre>` block on the page. Which is a little odd but there you are. That's why we're seeing html.

Now the only time you get these `OkAction` classes as far as I can see is in this instance where we save and restore a post request. So I've changed the `FrontendHttpActionAdaptor` class to check for them:

```
override def adapt(action: HttpAction, context: PlayWebContext): Result = {
    action match {
      case a: OkAction =>
        Results.ok(Html(Option(a.getContent)))
      case _ => val code = action.getCode
      // ... the existing code in this class

```
Now the call to `Results.ok(Html(Option(a.getContent)))` resubmits the original post request using the html stored in `getContent` and play then treats this as it would any other post request.

I've also taken the opportunity to upgrade pac4j. It hasn't helped at all but it's good to keep these things at the latest versions.