### PR TITLE
Pass None instead of allDigital form value

### DIFF
--- a/app/controllers/TransferAgreementController.scala
+++ b/app/controllers/TransferAgreementController.scala
@@ -58,7 +58,7 @@ class TransferAgreementController @Inject()(val controllerComponents: SecurityCo
         Some(formData.publicRecord),
         Some(formData.crownCopyright),
         Some(formData.english),
-        Some(formData.digital),
+        None,
         Some(formData.droAppraisalSelection),
         Some(formData.droSensitivity)
       )


### PR DESCRIPTION
Requires: https://github.com/nationalarchives/tdr-consignment-api/pull/101

To safely remve allDigital need to pass in None value first

This will then allow the allDigital parameter to be removed from the API, whilst not breaking the frontend before removal of the parameter from the front end