### PR TITLE
Update generated-graphql version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,7 @@ libraryDependencies ++= Seq(
   "com.softwaremill.sttp.client" %% "async-http-client-backend-future" % sttpVersion,
   "uk.gov.nationalarchives" %% "tdr-graphql-client" % "0.0.15",
   "uk.gov.nationalarchives" %% "tdr-auth-utils" % "0.0.12",
-  "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.70",
+  "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.71",
   ws,
   "com.github.tomakehurst" % "wiremock-jre8" % "2.26.0" % Test,
   "org.mockito" % "mockito-core" % "3.3.0" % Test

--- a/test/controllers/TransferAgreementControllerSpec.scala
+++ b/test/controllers/TransferAgreementControllerSpec.scala
@@ -118,16 +118,14 @@ class TransferAgreementControllerSpec extends FrontEndTestHelper {
 
     "create a transfer agreement when a valid form is submitted and the api response is successful" in {
       val consignmentId = UUID.fromString("c2efd3e6-6664-4582-8c28-dcf891f60e68")
-      val transferAgreementId = Some(UUID.fromString("c2efd3e6-6664-4582-8c28-dcf891f60e68"))
-
+      
       val addTransferAgreementResponse: ata.AddTransferAgreement = new ata.AddTransferAgreement(
         consignmentId,
         Some(true),
         Some(true),
         Some(true),
         Some(true),
-        Some(true),
-        transferAgreementId
+        Some(true)
       )
       stubTransferAgreementResponse(Some(addTransferAgreementResponse))
 


### PR DESCRIPTION
Updated version no longer requires a Transfer Agreement Id as this is not needed

Will be dropped following the migration of Transfer Agreement values to Consignment Metadata properties