### PR TITLE
Ensure p11-kit version updated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM openjdk:16-alpine
 RUN addgroup --system frontendgroup && adduser --system frontenduser -G frontendgroup
 WORKDIR play
 COPY target/universal/tdr-transfer-frontend*.zip .
-RUN apk update && apk add bash unzip && unzip -qq tdr-transfer-frontend-*.zip
+RUN apk update && apk upgrade p11-kit && apk add bash unzip && unzip -qq tdr-transfer-frontend-*.zip
 RUN chown -R frontenduser /play
 
 USER frontenduser


### PR DESCRIPTION
Fix for a number of security vulnerabilities identified with an older version of the p11-kit: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-29363; https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-29362; https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-29361