### PR TITLE
PROTOTYPE Progress bars accessibility - numbers

### DIFF
--- a/app/views/fileChecksProgress.scala.html
+++ b/app/views/fileChecksProgress.scala.html
@@ -13,15 +13,15 @@
             <p class="govuk-body">@Messages("checkingRecords.description")</p>
             <input id="consignmentId" type="hidden" value="@consignmentId">
             <div class="file-check-progress">
-                <label for="av-metadata-progress-bar" class="govuk-label">@Messages("checkingRecords.antivirus")<span id="av-status-screen-reader"></span></label>
+                <label for="av-metadata-progress-bar" class="govuk-label">@Messages("checkingRecords.antivirus")<span id="av-status-screen-reader" role="status" aria-live="polite"></span></label>
                 <progress id="av-metadata-progress-bar" class="file-check-progress__progress-bar" value="@fileChecks.avMetadataProgressPercentage" max="100"></progress>
             </div>
             <div class="file-check-progress">
-                <label for="ffid-progress-bar" class="govuk-label">@Messages("checkingRecords.ffid")<span id="ffid-status-screen-reader"></span></label>
+                <label for="ffid-progress-bar" class="govuk-label">@Messages("checkingRecords.ffid")<span id="ffid-status-screen-reader" role="status" aria-live="polite"></span></label>
                 <progress id="ffid-progress-bar" class="file-check-progress__progress-bar" value="@fileChecks.ffidMetadataProgressPercentage" max="100"></progress>
             </div>
             <div class="file-check-progress">
-                <label for="checksum-progress-bar" class="govuk-label">@Messages("checkingRecords.checksum")<span id="checksum-status-screen-reader"></span></label>
+                <label for="checksum-progress-bar" class="govuk-label">@Messages("checkingRecords.checksum")<span id="checksum-status-screen-reader" role="status" aria-live="polite"></span></label>
                 <progress id="checksum-progress-bar" class="file-check-progress__progress-bar" value="@fileChecks.checksumProgressPercentage" max="100"></progress>
             </div>
         </div>

--- a/app/views/fileChecksProgress.scala.html
+++ b/app/views/fileChecksProgress.scala.html
@@ -13,15 +13,15 @@
             <p class="govuk-body">@Messages("checkingRecords.description")</p>
             <input id="consignmentId" type="hidden" value="@consignmentId">
             <div class="file-check-progress">
-                <label for="av-metadata-progress-bar" class="govuk-label">@Messages("checkingRecords.antivirus")</label>
+                <label for="av-metadata-progress-bar" class="govuk-label">@Messages("checkingRecords.antivirus")<span id="av-status-screen-reader"></span></label>
                 <progress id="av-metadata-progress-bar" class="file-check-progress__progress-bar" value="@fileChecks.avMetadataProgressPercentage" max="100"></progress>
             </div>
             <div class="file-check-progress">
-                <label for="ffid-progress-bar" class="govuk-label">@Messages("checkingRecords.ffid")</label>
+                <label for="ffid-progress-bar" class="govuk-label">@Messages("checkingRecords.ffid")<span id="ffid-status-screen-reader"></span></label>
                 <progress id="ffid-progress-bar" class="file-check-progress__progress-bar" value="@fileChecks.ffidMetadataProgressPercentage" max="100"></progress>
             </div>
             <div class="file-check-progress">
-                <label for="checksum-progress-bar" class="govuk-label">@Messages("checkingRecords.checksum")</label>
+                <label for="checksum-progress-bar" class="govuk-label">@Messages("checkingRecords.checksum")<span id="checksum-status-screen-reader"></span></label>
                 <progress id="checksum-progress-bar" class="file-check-progress__progress-bar" value="@fileChecks.checksumProgressPercentage" max="100"></progress>
             </div>
         </div>

--- a/npm/src/filechecks/file-check-processing.ts
+++ b/npm/src/filechecks/file-check-processing.ts
@@ -83,3 +83,14 @@ export const updateProgressBar: (
     progressBar.value = progress
   }
 }
+
+export const updateProgressSpan: (
+  processed: number,
+  total: number,
+  selector: string
+) => void = (processed, total, selector) => {
+  const progressSpan: HTMLSpanElement | null = document.querySelector(selector)
+  if (progressSpan) {
+    progressSpan.innerText = ` ${processed}/${total} files processed`
+  }
+}

--- a/npm/src/filechecks/index.ts
+++ b/npm/src/filechecks/index.ts
@@ -2,6 +2,7 @@ import { GraphqlClient } from "../graphql"
 import {
   getConsignmentData,
   updateProgressBar,
+  updateProgressSpan,
   IFileCheckProcessed,
   getConsignmentId
 } from "./file-check-processing"
@@ -30,6 +31,22 @@ export class FileChecks {
       )
       updateProgressBar(checksumProcessed, totalFiles, "#checksum-progress-bar")
       updateProgressBar(ffidProcessed, totalFiles, "#ffid-progress-bar")
+
+      updateProgressSpan(
+        antivirusProcessed,
+        totalFiles,
+        "#av-status-screen-reader"
+      )
+      updateProgressSpan(
+        checksumProcessed,
+        totalFiles,
+        "#checksum-status-screen-reader"
+      )
+      updateProgressSpan(
+        ffidProcessed,
+        totalFiles,
+        "#ffid-status-screen-reader"
+      )
 
       if (
         antivirusProcessed == totalFiles &&


### PR DESCRIPTION
This is a very simple prototype to see if adding a textual representation of fileChecks progress makes it easier to make the page accessibile to screen readers - this one shows progress numerically based on the processed files vs total files.