### PR TITLE
Extend the connection timeout.

### DIFF
--- a/npm/src/s3upload/index.ts
+++ b/npm/src/s3upload/index.ts
@@ -17,7 +17,9 @@ export class S3Upload {
   s3: TdrS3
   identityId: string
   constructor(identityId: string) {
-    this.s3 = new S3()
+    const timeout = 20 * 60 * 1000
+    const connectTimeout = 20 * 60 * 1000
+    this.s3 = new S3({ httpOptions: { timeout, connectTimeout } })
     this.identityId = identityId
   }
   private uploadSingleFile: (


### PR DESCRIPTION
It looks like the connection timeout is causing the problems with large
file uploads. At least, when I make it very short, I can reliably make
the problem happen and Tom is getting errors after 2 minutes which is
the default timeout. I've upped this to 20 minutes to see if this will
help. It's a bit trial and error at the moment so we'll see.
