### PR TITLE
Downgrade the JDK from version 16 to 15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:16-alpine
+FROM openjdk:15-alpine
 #For alpine versions need to create a group before adding a user to the image
 RUN addgroup --system frontendgroup && adduser --system frontenduser -G frontendgroup
 WORKDIR play


### PR DESCRIPTION
Version 15 is the latest stable version. 16 was a pre-release version, and has started to cause errors on deployment:

```
com.google.common.util.concurrent.UncheckedExecutionException: java.lang.IllegalStateException: Unable to load cache item
```