### PR TITLE
Set the upload error to show on error.

### DIFF
--- a/npm/src/errorhandling/index.ts
+++ b/npm/src/errorhandling/index.ts
@@ -25,7 +25,7 @@ export function handleUploadError(
     }
 
     if (uploadFormError) {
-      uploadFormError.setAttribute("hidden", "true")
+      uploadFormError.removeAttribute("hidden")
       renderErrorMessage(error.message)
     }
   }


### PR DESCRIPTION
At the moment, when we get into the handleUploadError function, we're hiding the error message instead of showing it which is less than helpful.
