### PR TITLE
Add the calls to focus back in.

### DIFF
--- a/npm/src/upload/upload-form.ts
+++ b/npm/src/upload/upload-form.ts
@@ -223,6 +223,7 @@ export class UploadForm {
       ".drag-and-drop__failure"
     )
     warningMessage?.removeAttribute("hidden")
+    warningMessage?.focus()
     throw new Error("No files selected")
   }
 
@@ -247,6 +248,7 @@ export class UploadForm {
         ".drag-and-drop__success"
       )
       successMessage?.removeAttribute("hidden")
+      successMessage?.focus()
       this.dropzone.classList.remove("drag-and-drop__dropzone--dragover")
     }
   }


### PR DESCRIPTION
As part of the accessibility changes, I added in a call to focus on the error and success messages which allowed the screen reader to read them but somwhere along the line I deleted them. They need adding back in.
