### PR TITLE
Remove iconify JavaScript library

### DIFF
--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -19,7 +19,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" media="screen" href="@routes.Assets.versioned("stylesheets/main.css")">
     <link rel="shortcut icon" type="image/ico" href="@routes.Assets.versioned("images/favicon.ico")">
-    <script src="https://code.iconify.design/1/1.0.3/iconify.min.js"></script>
     <script src="@routes.Assets.versioned("javascripts/all.js")" type="text/javascript"></script>
     <script src="@routes.Assets.versioned("javascripts/main.js")" type="text/javascript"></script>
 


### PR DESCRIPTION
This icon library is not being used. We think it was copied from the prototype repo accidentally.