### PR TITLE
Remove unused Scala dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,8 +25,6 @@ libraryDependencies ++= Seq(
   "org.pac4j" %% "play-pac4j" % playPac4jVersion,
   "org.pac4j" % "pac4j-http" % pac4jVersion exclude("com.fasterxml.jackson.core", "jackson-databind"),
   "org.pac4j" % "pac4j-oidc" % pac4jVersion exclude("commons-io", "commons-io") exclude("com.fasterxml.jackson.core", "jackson-databind"),
-  "org.apache.shiro" % "shiro-core" % "1.4.0",
-  "net.bytebuddy" % "byte-buddy" % "1.9.7",
   "io.circe" %% "circe-core" % "0.13.0",
   "io.circe" %% "circe-generic" % "0.13.0",
   "com.softwaremill.sttp.client" %% "core" % sttpVersion,

--- a/test/controllers/FileChecksResultsControllerSpec.scala
+++ b/test/controllers/FileChecksResultsControllerSpec.scala
@@ -3,18 +3,15 @@ package controllers
 import java.util.UUID
 
 import com.github.tomakehurst.wiremock.WireMockServer
-import com.github.tomakehurst.wiremock.client.WireMock.{aResponse, okJson, post, unauthorized, urlEqualTo}
+import com.github.tomakehurst.wiremock.client.WireMock.{okJson, post, urlEqualTo}
 import configuration.GraphQLConfiguration
-import org.apache.shiro.authz.{AuthorizationException, UnauthorizedException}
+import org.scalatest.concurrent.ScalaFutures.convertScalaFuture
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import services.ConsignmentService
 import util.FrontEndTestHelper
-import org.scalatest.RecoverMethods._
-import org.scalatest.concurrent.ScalaFutures.convertScalaFuture
-import play.api.mvc.Result
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 
 class FileChecksResultsControllerSpec extends FrontEndTestHelper {
   implicit val ec: ExecutionContext = ExecutionContext.global


### PR DESCRIPTION
Remove byte-buddy and shiro. It looks like they were added during a spike and aren't actually being used.