### PR TITLE
Remove the colours and add a date.

### DIFF
--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -1,8 +1,6 @@
 <!-- https://www.playframework.com/documentation/latest/SettingsLogger -->
 <configuration>
 
-  <conversionRule conversionWord="coloredLevel" converterClass="play.api.libs.logback.ColoredLevel" />
-
   <appender name="FILE" class="ch.qos.logback.core.FileAppender">
     <file>${application.home:-.}/logs/application.log</file>
     <encoder>
@@ -12,7 +10,7 @@
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%coloredLevel %logger{15} - %message%n%xException{10}</pattern>
+      <pattern>%date [%level] %logger{15} - %message%n%xException{10}</pattern>
     </encoder>
   </appender>
 


### PR DESCRIPTION
I've added in the date so that the dateformat parameter set here https://github.com/nationalarchives/tdr-terraform-environments/pull/111 will work and we'll get stack traces in the same event.

I've also removed the colours because you can't see them in cloudwatch anyway and it stops the date formatter working.
