### PR TITLE
Add error summary to transfer agreement page.

### DIFF
--- a/app/views/errorSummary.scala.html
+++ b/app/views/errorSummary.scala.html
@@ -1,26 +1,27 @@
-@(field: Field,
-        args: (Symbol, Any)*
-)(implicit messages: Messages)
+@(fields: Field*)(implicit messages: Messages)
 
 @import views.html.helper._
-@import viewsapi.FormFunctions._
 
 @elements = @{
-    FieldElements(field.id, field, null, args.toMap, messages)
+    fields.toList.map(field => FieldElements(field.id, field, null, Map(), messages))
 }
 
-@if(elements.hasErrors) {
+
+@if(elements.exists(element => element.hasErrors)) {
     <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
         <h2 class="govuk-error-summary__title" id="error-summary-title">
             There is a problem
         </h2>
         <div class="govuk-error-summary__body">
             <ul class="govuk-list govuk-error-summary__list">
-            @for(error <- elements.errors) {
-                <li>
-                    <a href="#error-@elements.id">@error</a>
-                </li>
+            @for(element <- elements) {
+                @for(error <- element.errors) {
+                    <li>
+                        <a href="#error-@element.id">@error</a>
+                    </li>
+                }
             }
+
             </ul>
         </div>
     </div>

--- a/app/views/transferAgreement.scala.html
+++ b/app/views/transferAgreement.scala.html
@@ -12,6 +12,14 @@
         @progressIndicator(Messages("transferAgreement.progress"))
 
         <h1 class="govuk-heading-xl">@Messages("transferAgreement.title")</h1>
+        @errorSummary(
+            transferAgreementForm("publicRecord"),
+            transferAgreementForm("crownCopyright"),
+            transferAgreementForm("english"),
+            transferAgreementForm("droAppraisalSelection"),
+            transferAgreementForm("droSensitivity"),
+            transferAgreementForm("openRecords"),
+        )
         @form(
             routes.TransferAgreementController.transferAgreementSubmit(consignmentId),
             (Symbol("novalidate"), "")


### PR DESCRIPTION
This is because if there are a lot of options to choose from, the form error may be hidden down the bottom of the page.

I've refactored the errorSummary page to take in any number of fields which then shows all the errors in a single summary box.
