### PR TITLE
Hide the upload form rather than the whole container.

### DIFF
--- a/npm/src/errorhandling/index.ts
+++ b/npm/src/errorhandling/index.ts
@@ -13,13 +13,16 @@ export function handleUploadError(
   if (error instanceof LoggedOutError) {
     showLoggedOutError(error.loginUrl)
   } else {
-    const uploadForm: HTMLFormElement | null = document.querySelector(
+    const uploadFormContainer: HTMLFormElement | null = document.querySelector(
       "#file-upload"
     )
     //User is still on upload form
-    if (uploadForm && !uploadForm.hasAttribute("hidden")) {
+    if (uploadFormContainer && !uploadFormContainer.hasAttribute("hidden")) {
       const uploadFormError: HTMLDivElement | null = document.querySelector(
         ".govuk-error-summary.upload-error"
+      )
+      const uploadForm: HTMLDivElement | null = document.querySelector(
+        "#file-upload-form"
       )
 
       if (uploadForm) {

--- a/npm/test/errorhandling.test.ts
+++ b/npm/test/errorhandling.test.ts
@@ -42,7 +42,7 @@ test("handleUploadError function throws error and does not display error message
 
 function checkExpectedErrorHtmlState(expectedRenderedErrorMessage: string) {
   const formElement: HTMLFormElement | null = document.querySelector(
-    "#file-upload"
+    "#file-upload-form"
   )
   const errorElement: HTMLDivElement | null = document.querySelector(
     ".govuk-error-summary.upload-error"


### PR DESCRIPTION
If an upload had already occurred for the consignment, it was hitting the handleUploadError function. This was hiding the entire container for the upload form including the error message so we were just seeing a blank page.
I've changed it to hide the <form> element and show the error and this is now working as it used to.