### PR TITLE
Get consignment reference

### DIFF
--- a/app/controllers/TransferSummaryController.scala
+++ b/app/controllers/TransferSummaryController.scala
@@ -45,7 +45,8 @@ class TransferSummaryController @Inject()(val controllerComponents: SecurityComp
       .map { summary =>
         ConsignmentSummaryData(summary.series.get.code,
           summary.transferringBody.get.name,
-          summary.totalFiles)
+          summary.totalFiles,
+          summary.consignmentReference)
       }
   }
 
@@ -89,7 +90,8 @@ class TransferSummaryController @Inject()(val controllerComponents: SecurityComp
 
 case class ConsignmentSummaryData(seriesCode: Option[String],
                                   transferringBody: Option[String],
-                                  totalFiles: Int)
+                                  totalFiles: Int,
+                                  consignmentReference: Option[String])
 
 case class FinalTransferConfirmationData(openRecords: Boolean,
                                          transferLegalOwnership: Boolean)

--- a/app/views/transferSummary.scala.html
+++ b/app/views/transferSummary.scala.html
@@ -39,6 +39,14 @@
                         @summary.totalFiles @if(summary.totalFiles == 1) {file} else {files} uploaded
                     </dd>
                 </div>
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                        @Messages("transferSummary.consignmentReference")
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                        @summary.consignmentReference
+                    </dd>
+                </div>
             </dl>
             @form(
             routes.TransferSummaryController.finalTransferConfirmationSubmit(consignmentId),

--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ libraryDependencies ++= Seq(
   "com.softwaremill.sttp.client" %% "async-http-client-backend-future" % sttpVersion,
   "uk.gov.nationalarchives" %% "tdr-graphql-client" % "0.0.15",
   "uk.gov.nationalarchives" %% "tdr-auth-utils" % "0.0.12",
-  "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.78",
+  "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.79",
   ws,
   "com.github.tomakehurst" % "wiremock-jre8" % "2.26.0" % Test,
   "org.mockito" % "mockito-core" % "3.3.0" % Test

--- a/conf/messages
+++ b/conf/messages
@@ -68,6 +68,7 @@ transferSummary.seriesReference=Series reference
 transferSummary.transferringBody=Transferring body
 transferSummary.download=Download
 transferSummary.filesUploadedForTransfer=Files uploaded for transfer
+transferSummary.consignmentReference=Consignment reference
 transferSummary.openRecords=I confirm that in this version of TDR, all records that I transfer are open
 transferSummary.openRecords.error=All records must be confirmed as open before proceeding
 transferSummary.transferLegalOwnership=I confirm that I am transferring legal ownership of these records to The National Archives

--- a/test/controllers/TransferSummaryControllerSpec.scala
+++ b/test/controllers/TransferSummaryControllerSpec.scala
@@ -68,7 +68,7 @@ class TransferSummaryControllerSpec extends FrontEndTestHelper {
       val seriesCode = Some(gcs.GetConsignment.Series(Some("Mock Series")))
       val transferringBodyName = Some(gcs.GetConsignment.TransferringBody(Some("MockBody")))
       val totalFiles: Int = 3
-      val consignmentReference = Option("TEST-TDR-2021-MTB")
+      val consignmentReference = Some("TEST-TDR-2021-MTB")
 
       val consignmentResponse: gcs.GetConsignment = new gcs.GetConsignment(seriesCode, transferringBodyName, totalFiles, consignmentReference)
       val data: client.GraphqlData = client.GraphqlData(Some(gcs.Data(Some(consignmentResponse))), List())

--- a/test/controllers/TransferSummaryControllerSpec.scala
+++ b/test/controllers/TransferSummaryControllerSpec.scala
@@ -68,8 +68,9 @@ class TransferSummaryControllerSpec extends FrontEndTestHelper {
       val seriesCode = Some(gcs.GetConsignment.Series(Some("Mock Series")))
       val transferringBodyName = Some(gcs.GetConsignment.TransferringBody(Some("MockBody")))
       val totalFiles: Int = 3
+      val consignmentReference = Option("TEST-TDR-2021-MTB")
 
-      val consignmentResponse: gcs.GetConsignment = new gcs.GetConsignment(seriesCode, transferringBodyName, totalFiles)
+      val consignmentResponse: gcs.GetConsignment = new gcs.GetConsignment(seriesCode, transferringBodyName, totalFiles, consignmentReference)
       val data: client.GraphqlData = client.GraphqlData(Some(gcs.Data(Some(consignmentResponse))), List())
       val dataString: String = data.asJson.printWith(Printer(dropNullValues = false, ""))
       wiremockServer.stubFor(post(urlEqualTo("/graphql"))
@@ -90,6 +91,9 @@ class TransferSummaryControllerSpec extends FrontEndTestHelper {
 
       contentAsString(transferSummaryPage) must include("transferSummary.filesUploadedForTransfer")
       contentAsString(transferSummaryPage) must include(s"$totalFiles files uploaded")
+
+      contentAsString(transferSummaryPage) must include("transferSummary.consignmentReference")
+      contentAsString(transferSummaryPage) must include(consignmentReference.get)
 
       contentAsString(transferSummaryPage) must include("transferSummary.openRecords")
       contentAsString(transferSummaryPage) must include("transferSummary.transferLegalOwnership")
@@ -133,8 +137,9 @@ class TransferSummaryControllerSpec extends FrontEndTestHelper {
       val seriesCode = Some(gcs.GetConsignment.Series(Some("Mock Series 2")))
       val transferringBodyName = Some(gcs.GetConsignment.TransferringBody(Some("MockBody 2")))
       val totalFiles: Int = 4
+      val consignmentReference = Option("TEST-TDR-2021-GB")
 
-      val consignmentResponse: gcs.GetConsignment = new gcs.GetConsignment(seriesCode, transferringBodyName, totalFiles)
+      val consignmentResponse: gcs.GetConsignment = new gcs.GetConsignment(seriesCode, transferringBodyName, totalFiles, consignmentReference)
       val data: client.GraphqlData = client.GraphqlData(Some(gcs.Data(Some(consignmentResponse))), List())
       val dataString: String = data.asJson.printWith(Printer(dropNullValues = false, ""))
       wiremockServer.stubFor(post(urlEqualTo("/graphql"))


### PR DESCRIPTION
These changes get the consignment reference and render on the transfer summary page. Existing methods within the `TransferSummaryController` have been edited to retreive the consignment reference and pass it to the view so it can be rendered for the user. 

I have also updated the relevant tests to include the consignment reference and updated the generated graphql version.