### PR TITLE
Revert "Bump openjdk from 15-alpine to 16-alpine"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:16-alpine
+FROM openjdk:15-alpine
 #For alpine versions need to create a group before adding a user to the image
 RUN addgroup --system frontendgroup && adduser --system frontenduser -G frontendgroup
 WORKDIR play


### PR DESCRIPTION
This reverts commit 5fea67965daacec1e530a67ad15d18f02e1b03c1.

JDK 16 still causes an error on server startup:

```
Oops, cannot start the server. com.google.common.util.concurrent.UncheckedExecutionException: java.lang.IllegalStateException: Unable to load cache item at
com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2051) at
com.google.common.cache.LocalCache.get(LocalCache.java:3951) at
...
```

This is the same error that we saw in the pre-release version of OpenJDK 16: https://github.com/nationalarchives/tdr-transfer-frontend/pull/393