### PR TITLE
Add DB parameter to local Keycloak instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ updating the frontend.
   ```
   export MANAGEMENT_ACCOUNT=management_account_number
   aws ecr get-login-password --region eu-west-2 --profile management | docker login --username AWS --password-stdin $MANAGEMENT_ACCOUNT.dkr.ecr.eu-west-2.amazonaws.com
-  docker run -d --name keycloak -p 8081:8080 -e KEYCLOAK_USER=admin -e KEYCLOAK_PASSWORD=admin -e KEYCLOAK_IMPORT=/tmp/tdr-realm.json -e CLIENT_SECRET=[some value] -e BACKEND_CHECKS_CLIENT_SECRET=[some value] -e REALM_ADMIN_CLIENT_SECRET=[some value] -e KEYCLOAK_CONFIGURATION_PROPERTIES=intg_properties.json -e USER_ADMIN_CLIENT_SECRET=[some value] $MANAGEMENT_ACCOUNT.dkr.ecr.eu-west-2.amazonaws.com/auth-server:intg
+  docker run -d --name keycloak -p 8081:8080 -e KEYCLOAK_USER=admin -e KEYCLOAK_PASSWORD=admin -e KEYCLOAK_IMPORT=/tmp/tdr-realm.json -e CLIENT_SECRET=[some value] -e BACKEND_CHECKS_CLIENT_SECRET=[some value] -e REALM_ADMIN_CLIENT_SECRET=[some value] -e KEYCLOAK_CONFIGURATION_PROPERTIES=intg_properties.json -e USER_ADMIN_CLIENT_SECRET=[some value] -e DB_VENDOR=h2 $MANAGEMENT_ACCOUNT.dkr.ecr.eu-west-2.amazonaws.com/auth-server:intg
   ```
 - Go to `http://localhost:8081/auth/admin` and log in with username *admin* and password *admin*.  
 - Create a transferring body user:


### PR DESCRIPTION
Add `-e DB_VENDOR=h2` to the local Keycloak startup script. By default, the TDR Keycloak tries to connect to a real Postgres DB. This overrides the DB config so that Keycloak uses an internal H2 DB in the dev environment.