### PR TITLE
Remove GDS transport font

### DIFF
--- a/npm/css-src/sass/main.scss
+++ b/npm/css-src/sass/main.scss
@@ -1,5 +1,5 @@
-@import 'node_modules/govuk-frontend/govuk/all';
 @import 'overrides/all';
+@import 'node_modules/govuk-frontend/govuk/all';
 
 @import 'header';
 @import 'drag-and-drop';

--- a/npm/css-src/sass/overrides/_typography.scss
+++ b/npm/css-src/sass/overrides/_typography.scss
@@ -4,3 +4,5 @@
 body {
   font-family: Arial, sans-serif;
 }
+
+$govuk-font-family: Arial, sans-serif;

--- a/npm/package.json
+++ b/npm/package.json
@@ -5,9 +5,8 @@
   "private": true,
   "scripts": {
     "copy-govuk-image-assets": "copyfiles -f node_modules/govuk-frontend/govuk/assets/images/* ../public/images -e node_modules/govuk-frontend/govuk/assets/images/favicon*",
-    "copy-govuk-font-assets": "copyfiles -f node_modules/govuk-frontend/govuk/assets/fonts/* ../public/fonts",
     "copy-govuk-js-assets": "copyfiles -f node_modules/govuk-frontend/govuk/all.js ../public/javascripts",
-    "copy-assets": "npm-run-all copy-govuk-image-assets copy-govuk-font-assets copy-govuk-js-assets",
+    "copy-assets": "npm-run-all copy-govuk-image-assets copy-govuk-js-assets",
     "sass-watch": "node-sass ./css-src/sass/main.scss ../public/stylesheets/main.css --watch",
     "sass-compile": "node-sass ./css-src/sass/main.scss ./css-src/main.css",
     "add-stylesheet-dir": "mkdir -p ../public/stylesheets",


### PR DESCRIPTION
- Don't copy GDS font to the resources directory.
- Override the govuk font family.
- Move the override import above the gov uk import.
