### PR TITLE
Add cryptographic nonce

### DIFF
--- a/app/errors/ErrorHandler.scala
+++ b/app/errors/ErrorHandler.scala
@@ -16,13 +16,13 @@ class ErrorHandler @Inject() (val messagesApi: MessagesApi) extends HttpErrorHan
 
     val response = statusCode match {
       case 401 =>
-        Unauthorized(views.html.unauthenticatedError()(request2Messages(request)))
+        Unauthorized(views.html.unauthenticatedError()(request2Messages(request), request))
       case 403 =>
-        Forbidden(views.html.forbiddenError()(request2Messages(request)))
+        Forbidden(views.html.forbiddenError()(request2Messages(request), request))
       case 404 =>
-        NotFound(views.html.notFoundError()(request2Messages(request)))
+        NotFound(views.html.notFoundError()(request2Messages(request), request))
       case _ =>
-        Status(statusCode)(views.html.internalServerError()(request2Messages(request)))
+        Status(statusCode)(views.html.internalServerError()(request2Messages(request), request))
     }
 
     Future.successful(response)
@@ -33,9 +33,9 @@ class ErrorHandler @Inject() (val messagesApi: MessagesApi) extends HttpErrorHan
 
     val response = exception match {
       case authException: AuthorisationException =>
-        Forbidden(views.html.forbiddenError()(request2Messages(request)))
+        Forbidden(views.html.forbiddenError()(request2Messages(request), request))
       case e =>
-        InternalServerError(views.html.internalServerError()(request2Messages(request)))
+        InternalServerError(views.html.internalServerError()(request2Messages(request), request))
     }
 
     Future.successful(response)

--- a/app/views/contact.scala.html
+++ b/app/views/contact.scala.html
@@ -1,4 +1,4 @@
-@()(implicit messages: Messages)
+@()(implicit messages: Messages, request: RequestHeader)
 
 @main(Messages("contact.header")) {
     <div class="govuk-grid-row">

--- a/app/views/dashboard.scala.html
+++ b/app/views/dashboard.scala.html
@@ -1,4 +1,4 @@
-@()(implicit messages: Messages)
+@()(implicit messages: Messages, request: RequestHeader)
 
 @main(Messages("dashboard.header")) {
     <div class="govuk-grid-row">

--- a/app/views/error.scala.html
+++ b/app/views/error.scala.html
@@ -2,7 +2,7 @@
 * This is a placeholder to allow us to write unit tests which show the redirect to the error page.
 * It will be replaced once we have a properly designed error page
 *@
-@(errorMessage: String)(implicit messages: Messages)
+@(errorMessage: String)(implicit messages: Messages, request: RequestHeader)
 
 @main(Messages("error.header")) {
 @defining(play.core.PlayVersion.current) { version =>

--- a/app/views/fileChecksProgress.scala.html
+++ b/app/views/fileChecksProgress.scala.html
@@ -1,6 +1,6 @@
 @import java.util.UUID
 @import viewsapi.FrontEndInfo
-@(consignmentId: UUID, fileChecks: FileChecksProgress, frontEndInfo: FrontEndInfo)(implicit messages: Messages)
+@(consignmentId: UUID, fileChecks: FileChecksProgress, frontEndInfo: FrontEndInfo)(implicit messages: Messages, request: RequestHeader)
 
 @main(Messages("checkingRecords.header")) {
     @defining(play.core.PlayVersion.current) { version =>

--- a/app/views/fileChecksResults.scala.html
+++ b/app/views/fileChecksResults.scala.html
@@ -1,6 +1,6 @@
 @import java.util.UUID
 @import viewsapi.FrontEndInfo
-@(consignmentInfo: ConsignmentFolderInfo, consignmentId: java.util.UUID)(implicit messages: Messages)
+@(consignmentInfo: ConsignmentFolderInfo, consignmentId: java.util.UUID)(implicit messages: Messages, request: RequestHeader)
 
 @main(Messages("fileChecksResults.header")) {
 <div class="govuk-grid-row">

--- a/app/views/forbiddenError.scala.html
+++ b/app/views/forbiddenError.scala.html
@@ -1,4 +1,4 @@
-@()(implicit messages: Messages)
+@()(implicit messages: Messages, request: RequestHeader)
 
 @main(Messages("error.header")) {
 @defining(play.core.PlayVersion.current) { version =>

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -1,4 +1,4 @@
-@()(implicit messages: Messages)
+@()(implicit messages: Messages, request: RequestHeader)
 
 @main(Messages("home.header")) {
 @defining(play.core.PlayVersion.current) { version =>

--- a/app/views/internalServerError.scala.html
+++ b/app/views/internalServerError.scala.html
@@ -1,4 +1,4 @@
-@()(implicit messages: Messages)
+@()(implicit messages: Messages, request: RequestHeader)
 
 @main(Messages("error.header")) {
 @defining(play.core.PlayVersion.current) { version =>

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -5,7 +5,9 @@
 * object to insert into the body of the page.
 *@
 
-@(title: String, hasError: Boolean = false)(content: Html)(implicit messages: Messages)
+@import views.html.helper.CSPNonce
+
+@(title: String, hasError: Boolean = false)(content: Html)(implicit messages: Messages, request: RequestHeader)
 
 <!DOCTYPE html>
 <html lang="en">
@@ -19,8 +21,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" media="screen" href="@routes.Assets.versioned("stylesheets/main.css")">
     <link rel="shortcut icon" type="image/ico" href="@routes.Assets.versioned("images/favicon.ico")">
-    <script src="@routes.Assets.versioned("javascripts/all.js")" type="text/javascript"></script>
-    <script src="@routes.Assets.versioned("javascripts/main.js")" type="text/javascript"></script>
+    <script @{CSPNonce.attr} src="@routes.Assets.versioned("javascripts/all.js")" type="text/javascript"></script>
+    <script @{CSPNonce.attr} src="@routes.Assets.versioned("javascripts/main.js")" type="text/javascript"></script>
 
     </head>
     <body class="govuk-template__body">

--- a/app/views/notFoundError.scala.html
+++ b/app/views/notFoundError.scala.html
@@ -1,4 +1,4 @@
-@()(implicit messages: Messages)
+@()(implicit messages: Messages, request: RequestHeader)
 
 @main(Messages("error.header")) {
 @defining(play.core.PlayVersion.current) { version =>

--- a/app/views/silentSsoLogin.scala.html
+++ b/app/views/silentSsoLogin.scala.html
@@ -1,6 +1,9 @@
+@import views.html.helper.CSPNonce
+
+@()(implicit request: RequestHeader)
 <!DOCTYPE html>
 <html lang="en">
   <body>
-    <script src="@routes.Assets.versioned("javascripts/keycloak/silent-sso-login.js")" type="text/javascript"></script>
+    <script @{CSPNonce.attr} src="@routes.Assets.versioned("javascripts/keycloak/silent-sso-login.js")" type="text/javascript"></script>
   </body>
 </html>

--- a/app/views/transferComplete.scala.html
+++ b/app/views/transferComplete.scala.html
@@ -1,4 +1,4 @@
-@()(implicit messages: Messages)
+@()(implicit messages: Messages, request: RequestHeader)
 @main(Messages("transferComplete.title")) {
 @defining(play.core.PlayVersion.current) { version =>
 <div class="govuk-grid-row">

--- a/app/views/unauthenticatedError.scala.html
+++ b/app/views/unauthenticatedError.scala.html
@@ -1,4 +1,4 @@
-@()(implicit messages: Messages)
+@()(implicit messages: Messages, request: RequestHeader)
 
 @main(Messages("error.header")) {
 @defining(play.core.PlayVersion.current) { version =>

--- a/conf/application.base.conf
+++ b/conf/application.base.conf
@@ -41,7 +41,7 @@ play {
     default-src = 'self'
     # Override the default CSP script-src, which allows unsafe inline scripts. Allow 'eval' because keycloak-js has a
     # dependency which uses it. See TDR-1002.
-    script-src = 'self' 'unsafe-eval'
+    script-src = ${play.filters.csp.nonce.pattern} 'unsafe-eval'
     # Allow scripts to fetch data from TDR domains and AWS domains
     connect-src = 'self' ${auth.url} ${aws.cognito.url} ${aws.sts.url} ${consignmentapi.domain} ${aws.s3.us-bucket-url} ${aws.s3.uk-bucket-url}
     # Allow browser to load Keycloak iframe to support the OAuth2 silent authentication flow


### PR DESCRIPTION
keycloak-js depends on js-sha256, which currently imports two libraries using a call to eval

unsafe-eval should not be used because eval is a vector for attackers to run arbitrary code in a real user’s browser.

Using cryptographic nonce makes using unsafe-eval slightly less risky