### PR TITLE
Fix 400 error when s3 sdk tries to upload to us-east-1

### DIFF
--- a/conf/application.base.conf
+++ b/conf/application.base.conf
@@ -16,7 +16,6 @@ aws {
   s3 {
     # We need to specify both S3 URLs because the first upload request is always sent to the us-east-1 bucket URL, and
     # then falls back to the eu-west-2 URL. See TDR-947.
-    us-bucket-url = "https://"${aws.s3.upload-bucket}".s3.amazonaws.com"
     uk-bucket-url = "https://"${aws.s3.upload-bucket}".s3.eu-west-2.amazonaws.com"
   }
 }
@@ -45,7 +44,7 @@ play {
     # dependency which uses it. See TDR-1002.
     script-src = ${play.filters.csp.nonce.pattern} 'unsafe-eval'
     # Allow scripts to fetch data from TDR domains and AWS domains
-    connect-src = 'self' ${auth.url} ${aws.cognito.url} ${aws.sts.url} ${consignmentapi.domain} ${aws.s3.us-bucket-url} ${aws.s3.uk-bucket-url}
+    connect-src = 'self' ${auth.url} ${aws.cognito.url} ${aws.sts.url} ${consignmentapi.domain} ${aws.s3.uk-bucket-url}
     # Allow browser to load Keycloak iframe to support the OAuth2 silent authentication flow
     child-src = 'self' ${auth.url}
   }

--- a/npm/src/index.ts
+++ b/npm/src/index.ts
@@ -6,7 +6,7 @@ import { ClientFileMetadataUpload } from "./clientfilemetadataupload"
 import { goToNextPage } from "./upload/next-page-redirect"
 import { FileChecks } from "./filechecks"
 import { CognitoIdentity, STS } from "aws-sdk"
-import { initAll } from 'govuk-frontend'
+import { initAll } from "govuk-frontend"
 
 window.onload = function () {
   initAll()
@@ -99,7 +99,7 @@ export const renderModules = () => {
         new FileUploader(
           clientFileProcessing,
           identityId,
-          frontEndInfo.stage,
+          frontEndInfo,
           goToNextPage
         ).initialiseFormListeners()
       })

--- a/npm/src/s3upload/index.ts
+++ b/npm/src/s3upload/index.ts
@@ -16,10 +16,10 @@ type TdrS3 = Pick<S3, "upload">
 export class S3Upload {
   s3: TdrS3
   identityId: string
-  constructor(identityId: string) {
+  constructor(identityId: string, region: string) {
     const timeout = 20 * 60 * 1000
     const connectTimeout = 20 * 60 * 1000
-    this.s3 = new S3({ httpOptions: { timeout, connectTimeout } })
+    this.s3 = new S3({ region, httpOptions: { timeout, connectTimeout } })
     this.identityId = identityId
   }
   private uploadSingleFile: (

--- a/npm/src/upload/index.ts
+++ b/npm/src/upload/index.ts
@@ -3,6 +3,7 @@ import { ClientFileMetadataUpload } from "../clientfilemetadataupload"
 import { S3Upload } from "../s3upload"
 import { FileUploadInfo, UploadForm } from "./upload-form"
 import { IFileWithPath } from "@nationalarchives/file-information"
+import { IFrontEndInfo } from "../index"
 
 export class FileUploader {
   clientFileProcessing: ClientFileProcessing
@@ -12,14 +13,14 @@ export class FileUploader {
   constructor(
     clientFileProcessing: ClientFileMetadataUpload,
     identityId: string,
-    stage: string,
+    frontendInfo: IFrontEndInfo,
     goToNextPage: () => void
   ) {
     this.clientFileProcessing = new ClientFileProcessing(
       clientFileProcessing,
-      new S3Upload(identityId)
+      new S3Upload(identityId, frontendInfo.region)
     )
-    this.stage = stage
+    this.stage = frontendInfo.stage
     this.goToNextPage = goToNextPage
   }
 

--- a/npm/test/clientfileprocessing.test.ts
+++ b/npm/test/clientfileprocessing.test.ts
@@ -20,7 +20,7 @@ beforeEach(() => jest.resetModules())
 
 class S3UploadMock extends S3Upload {
   constructor() {
-    super("some Cognito user ID")
+    super("some Cognito user ID", "region")
   }
 
   uploadToS3: (
@@ -425,7 +425,7 @@ test("Error thrown if S3 upload fails", async () => {
   const metadataUpload: ClientFileMetadataUpload = new ClientFileMetadataUpload(
     client
   )
-  const s3Upload = new S3Upload("some Cognito user ID")
+  const s3Upload = new S3Upload("some Cognito user ID", "region")
   const fileProcessing = new ClientFileProcessing(metadataUpload, s3Upload)
 
   await expect(
@@ -476,13 +476,9 @@ function checkExpectedPageState(percentage: String) {
     "govuk-grid-row"
   )
 
-  expect(fileUpload && fileUpload.getAttribute("hidden")).toEqual(
-    "true"
-  )
+  expect(fileUpload && fileUpload.getAttribute("hidden")).toEqual("true")
 
-  expect(uploadError && uploadError.getAttribute("hidden")).toEqual(
-    ""
-  )
+  expect(uploadError && uploadError.getAttribute("hidden")).toEqual("")
 
   expect(
     progressBarElement && progressBarElement.getAttribute("value")

--- a/npm/test/s3upload.test.ts
+++ b/npm/test/s3upload.test.ts
@@ -60,7 +60,7 @@ const checkCallbackCalls: (
 
 test("a single file upload returns the correct key", async () => {
   const file = new File(["file1"], "file1")
-  const s3Upload = new S3Upload("identityId")
+  const s3Upload = new S3Upload("identityId", "region")
   s3Upload.s3 = new MockSuccessfulS3()
   const result = await s3Upload.uploadToS3(
     "16b73cc7-a81e-4317-a7a4-9bbb5fa1cc4e",
@@ -77,7 +77,7 @@ test("a single file upload returns the correct key", async () => {
 test("a single file upload calls the callback correctly", async () => {
   const file = new File(["file1"], "file1")
   const callback = jest.fn()
-  const s3Upload = new S3Upload("identityId")
+  const s3Upload = new S3Upload("identityId", "region")
   s3Upload.s3 = new MockSuccessfulS3()
   await s3Upload.uploadToS3(
     "16b73cc7-a81e-4317-a7a4-9bbb5fa1cc4e",
@@ -107,7 +107,7 @@ test("multiple file uploads return the correct keys", async () => {
     { fileId: fileIds[2], file: file3 },
     { fileId: fileIds[3], file: file4 }
   ]
-  const s3Upload = new S3Upload("identityId")
+  const s3Upload = new S3Upload("identityId", "region")
   s3Upload.s3 = new MockSuccessfulS3()
   const result = await s3Upload.uploadToS3(
     "16b73cc7-a81e-4317-a7a4-9bbb5fa1cc4e",
@@ -137,7 +137,7 @@ test("multiple file uploads call the callback correctly", async () => {
     { fileId: "", file: new File(["file4"], "file4") }
   ]
   const callback = jest.fn()
-  const s3Upload = new S3Upload("identityId")
+  const s3Upload = new S3Upload("identityId", "region")
   s3Upload.s3 = new MockSuccessfulS3()
   await s3Upload.uploadToS3(
     "16b73cc7-a81e-4317-a7a4-9bbb5fa1cc4e",
@@ -173,7 +173,7 @@ test("multiple file uploads call the callback correctly", async () => {
 test("when there is an error with the upload, an error is returned", async () => {
   const fileId = "1df92708-d66b-4b55-8c1e-bb945a5c4fb5"
   const file = new File(["file1"], "file1")
-  const s3Upload = new S3Upload("identityId")
+  const s3Upload = new S3Upload("identityId", "region")
   s3Upload.s3 = new MockFailedS3()
   const result = s3Upload.uploadToS3(
     "16b73cc7-a81e-4317-a7a4-9bbb5fa1cc4e",
@@ -187,7 +187,7 @@ test("when there is an error with the upload, an error is returned", async () =>
 test("a single file upload calls the callback correctly with a different chunk size", async () => {
   const file = new File(["file1"], "file1")
   const callback = jest.fn()
-  const s3Upload = new S3Upload("identityId")
+  const s3Upload = new S3Upload("identityId", "region")
   s3Upload.s3 = new MockSuccessfulS3(2)
   await s3Upload.uploadToS3(
     "16b73cc7-a81e-4317-a7a4-9bbb5fa1cc4e",

--- a/npm/test/upload-form.test.ts
+++ b/npm/test/upload-form.test.ts
@@ -1,10 +1,11 @@
 import "@testing-library/jest-dom"
-import {IFileWithPath} from "@nationalarchives/file-information"
-import {ClientFileMetadataUpload} from "../src/clientfilemetadataupload"
-import {GraphqlClient} from "../src/graphql"
-import {FileUploader} from "../src/upload"
-import {UploadForm, IReader, IWebkitEntry} from "../src/upload/upload-form"
-import {mockKeycloakInstance} from "./utils"
+import { IFileWithPath } from "@nationalarchives/file-information"
+import { ClientFileMetadataUpload } from "../src/clientfilemetadataupload"
+import { GraphqlClient } from "../src/graphql"
+import { FileUploader } from "../src/upload"
+import { UploadForm, IReader, IWebkitEntry } from "../src/upload/upload-form"
+import { mockKeycloakInstance } from "./utils"
+import { IFrontEndInfo } from "../src"
 
 const mockFileList: (file: File[]) => FileList = (file: File[]) => {
   return {
@@ -183,11 +184,19 @@ class MockDom {
       "https://example.com",
       mockKeycloakInstance
     )
+    const frontendInfo: IFrontEndInfo = {
+      apiUrl: "",
+      cognitoRoleArn: "",
+      identityPoolId: "",
+      identityProviderName: "",
+      region: "",
+      stage: "test"
+    }
     const uploadMetadata = new ClientFileMetadataUpload(client)
     return new FileUploader(
       uploadMetadata,
       "identityId",
-      "test",
+      frontendInfo,
       mockGoToNextPage
     )
   }
@@ -207,21 +216,21 @@ const triggerInputEvent: (element: HTMLElement, domEvent: string) => void = (
   element.dispatchEvent(event)
 }
 
-const dummyFolder = {
+const dummyFolder = ({
   lastModified: 2147483647,
   name: "Mock Folder",
   size: 0,
   type: "",
   webkitRelativePath: ""
-} as unknown as File
+} as unknown) as File
 
-const dummyFile = {
+const dummyFile = ({
   lastModified: 2147483647,
   name: "Mock File",
   size: 3008,
   type: "pdf",
   webkitRelativePath: "Parent_Folder"
-} as unknown as File
+} as unknown) as File
 
 const dummyIFileWithPath = {
   file: dummyFile,
@@ -232,7 +241,7 @@ const dummyIFileWithPath = {
 test("Input button updates the page with correct folder information if there are 1 or more files in folder", () => {
   const mockDom = new MockDom()
   mockDom.fileUploader.initialiseFormListeners()
-  mockDom.uploadForm!.files = {files: [dummyIFileWithPath]}
+  mockDom.uploadForm!.files = { files: [dummyIFileWithPath] }
   mockDom.selectFolderViaButton()
 
   expect(mockDom.folderRetrievalSuccessMessage!).not.toHaveAttribute(

--- a/npm/test/upload.test.ts
+++ b/npm/test/upload.test.ts
@@ -7,6 +7,7 @@ import { FileUploader } from "../src/upload"
 import { mockKeycloakInstance } from "./utils"
 import { GraphqlClient } from "../src/graphql"
 import { ClientFileMetadataUpload } from "../src/clientfilemetadataupload"
+import { IFrontEndInfo } from "../src"
 jest.mock("../src/clientfileprocessing")
 
 beforeEach(() => jest.resetModules())
@@ -105,10 +106,18 @@ test("upload function console logs error when upload fails", async () => {
 function setUpFileUploader(): FileUploader {
   const client = new GraphqlClient("https://test.im", mockKeycloakInstance)
   const uploadMetadata = new ClientFileMetadataUpload(client)
+  const frontendInfo: IFrontEndInfo = {
+    apiUrl: "",
+    cognitoRoleArn: "",
+    identityPoolId: "",
+    identityProviderName: "",
+    region: "",
+    stage: "test"
+  }
   return new FileUploader(
     uploadMetadata,
     "identityId",
-    "test",
+    frontendInfo,
     mockGoToNextPage
   )
 }


### PR DESCRIPTION
The region is inside the frontend info object so I've had to to a bit of refactoring to get it into the correct file, and then change the tests to use the new constructor.
There are other changes which are prettier changing the imports and other bits which I've left in the PR as it's good to keep things consistent.
