### PR TITLE
Don't show leave page confirmation on upload error

### DIFF
--- a/npm/src/errorhandling/index.ts
+++ b/npm/src/errorhandling/index.ts
@@ -1,3 +1,5 @@
+import { pageUnloadAction } from "../upload"
+
 export class LoggedOutError extends Error {
   loginUrl: string
   constructor(loginUrl: string, message?: string) {
@@ -10,6 +12,7 @@ export function handleUploadError(
   error: Error,
   additionalLoggingInfo: string = "Upload failed"
 ) {
+  window.removeEventListener("beforeunload", pageUnloadAction)
   if (error instanceof LoggedOutError) {
     showLoggedOutError(error.loginUrl)
   } else {

--- a/npm/src/upload/index.ts
+++ b/npm/src/upload/index.ts
@@ -5,6 +5,11 @@ import { FileUploadInfo, UploadForm } from "./upload-form"
 import { IFileWithPath } from "@nationalarchives/file-information"
 import { IFrontEndInfo } from "../index"
 
+export const pageUnloadAction: (e: BeforeUnloadEvent) => void = (e) => {
+  e.preventDefault()
+  e.returnValue = ""
+}
+
 export class FileUploader {
   clientFileProcessing: ClientFileProcessing
   stage: string
@@ -31,10 +36,6 @@ export class FileUploader {
     files: IFileWithPath[],
     uploadFilesInfo: FileUploadInfo
   ) => {
-    const pageUnloadAction: (e: BeforeUnloadEvent) => void = (e) => {
-      e.preventDefault()
-      e.returnValue = ""
-    }
     window.addEventListener("beforeunload", pageUnloadAction)
 
     try {


### PR DESCRIPTION
I've moved the pageUnloadFunction out of the class and exported it so it can be used in the error handling file and then I remove the event listener when the handleUploadError function is called.
