### PR TITLE
Delete old comment about multiple bucket URLs

### DIFF
--- a/conf/application.base.conf
+++ b/conf/application.base.conf
@@ -14,8 +14,6 @@ aws {
   cognito.url = "https://cognito-identity.eu-west-2.amazonaws.com"
   sts.url = "https://sts.amazonaws.com"
   s3 {
-    # We need to specify both S3 URLs because the first upload request is always sent to the us-east-1 bucket URL, and
-    # then falls back to the eu-west-2 URL. See TDR-947.
     uk-bucket-url = "https://"${aws.s3.upload-bucket}".s3.eu-west-2.amazonaws.com"
   }
 }


### PR DESCRIPTION
TDR-947 has been done and the US bucket URL has been removed. So this comment is no longer needed.