### PR TITLE
Show the error message instead of hiding it

### DIFF
--- a/npm/src/errorhandling/index.ts
+++ b/npm/src/errorhandling/index.ts
@@ -91,7 +91,7 @@ function showLoggedOutError(login: string) {
   }
 
   if (loggedOutError && loginLink) {
-    loggedOutError.setAttribute("hidden", "true")
+    loggedOutError.removeAttribute("hidden")
     loginLink.href = login
   }
 }


### PR DESCRIPTION
This is for bug https://national-archives.atlassian.net/browse/TDR-957
The loggedOutError element is the error we're supposed to be showing to the user but it's being hidden instead of shown. I've changed this.
