### PR TITLE
Show 500 page if the parent folder is missing.

### DIFF
--- a/app/controllers/FileChecksResultsController.scala
+++ b/app/controllers/FileChecksResultsController.scala
@@ -22,10 +22,11 @@ class FileChecksResultsController @Inject()(val controllerComponents: SecurityCo
 
   def fileCheckResultsPage(consignmentId: UUID): Action[AnyContent] = secureAction.async { implicit request: Request[AnyContent] =>
     consignmentService.getConsignmentFileChecks(consignmentId, request.token.bearerAccessToken).map(fileCheck => {
+      val parentFolder = fileCheck.parentFolder.getOrElse(throw new IllegalStateException(s"No parent folder found for consignment: '$consignmentId'"))
       if(fileCheck.allChecksSucceeded) {
         val consignmentInfo = ConsignmentFolderInfo(
           fileCheck.totalFiles,
-          fileCheck.parentFolder.getOrElse(throw new IllegalStateException(s"No parent folder found for consignment: '$consignmentId'"))
+          parentFolder
         )
         Ok(views.html.fileChecksResults(consignmentInfo, consignmentId))
       } else {


### PR DESCRIPTION
The check for the parent folder is a check to make sure that the upload
has been completed before trying to access the records results. The
problem is this isn't being checked if allChecksSucceeded returns false.
This returns false if the file checks haven't happened yet so what you
end up with is a page saying your file checks have failed even before
you've uploaded any files.
I've moved the get or throw line up a bit so we get the 500 page now as
we used to.
