### PR TITLE
Remove unused div with duplicate id from file check failure page

### DIFF
--- a/app/views/fileChecksFailed.scala.html
+++ b/app/views/fileChecksFailed.scala.html
@@ -8,7 +8,6 @@
 
       <div id="upload-progress-error" class="govuk-error-summary upload-error" aria-labelledby="error-summary-title"
       role="alert" data-module="govuk-error-summary" tabindex="-1">
-        <div id="upload-progress-error">
           <h2 class="govuk-error-summary__title" id="error-summary-title">
           @Messages("fileChecksFailure.error.title")
           </h2>
@@ -21,7 +20,6 @@
               <li>@Messages("fileChecksFailure.error.list.corrupted")</li>
             </ul>
           </div>
-        </div>
       </div>
       <button class="govuk-button govuk-button--primary" data-module="govuk-button">
       @Messages("fileChecksFailure.return")


### PR DESCRIPTION
Lighthouse in Chrome reported that there were two divs with identical ids which there were. But the div isn't needed, I've removed it and the behaviour doesn't change and the lighthouse report now shows 100% for
accessibility.
