### PR TITLE
Add preferred algorithm.

### DIFF
--- a/app/modules/SecurityModule.scala
+++ b/app/modules/SecurityModule.scala
@@ -1,6 +1,7 @@
 package modules
 
 import com.google.inject.{AbstractModule, Provides}
+import com.nimbusds.jose.JWSAlgorithm
 import configuration.CustomSavedRequestHandler
 import org.pac4j.core.client.Clients
 import org.pac4j.core.config.Config
@@ -50,6 +51,7 @@ class SecurityModule extends AbstractModule {
     val secret = configuration.get[String]("auth.secret")
     oidcConfiguration.setSecret(secret)
     oidcConfiguration.setDiscoveryURI(s"$authUrl/auth/realms/tdr/.well-known/openid-configuration")
+    oidcConfiguration.setPreferredJwsAlgorithm(JWSAlgorithm.RS256)
     // Setting this causes pac4j to get a new access token using the refresh token when the original access token expires
     oidcConfiguration.setExpireSessionWithToken(true)
     val oidcClient = new OidcClient[OidcConfiguration](oidcConfiguration)


### PR DESCRIPTION
This is to prevent the error `Preferred JWS algorithm: null not available` which we're getting from the frontend. From debugging the pac4j code and looking at the keycloak documentation, the algorithm Keycloak is using is RS256. I've tested this locally and all of the auth is still working as expected.
