### PR TITLE
Reduced spacing between checkboxes

### DIFF
--- a/app/views/inputSingleCheckbox.scala.html
+++ b/app/views/inputSingleCheckbox.scala.html
@@ -10,9 +10,8 @@ args: (Symbol, Any)*
 @label = {@elements.args.get(Symbol("_label"))}
 @isSelected = {@elements.args.selectedInput(value.toString)}
 
-<div class="govuk-form-group @elements.setErrorClass()">
-    @errorMessage(elements)
-    <div class="govuk-checkboxes">
+    <div class="govuk-checkboxes @elements.setErrorClass()">
+        @errorMessage(elements)
         <div class='govuk-checkboxes__item @if(elements.args.contains(Symbol("_smallCheckbox"))){govuk-checkboxes--small}'>
             <input
                     @isSelected
@@ -27,4 +26,4 @@ args: (Symbol, Any)*
             </label>
         </div>
     </div>
-</div>
+

--- a/app/views/transferAgreement.scala.html
+++ b/app/views/transferAgreement.scala.html
@@ -31,6 +31,7 @@
             routes.TransferAgreementController.transferAgreementSubmit(consignmentId),
             (Symbol("novalidate"), "")
         ) {
+        <div class="govuk-form-group">
         @CSRF.formField
             @inputSingleCheckbox(
                 transferAgreementForm("publicRecord"),
@@ -81,6 +82,7 @@
                 Symbol("_checkedOption") -> transferAgreementForm.data.getOrElse("openRecords", ""),
                 Symbol("_requiredOption") -> true
             )
+        </div>
         <!-- Buttons -->
         <div class="govuk-button-group">
             <!-- Continue -->

--- a/app/views/transferSummary.scala.html
+++ b/app/views/transferSummary.scala.html
@@ -50,6 +50,7 @@
                 </div>
             </dl>
         <p class="govuk-body">@Messages("transferSummary.bodyBelow")</p>
+        <div class="govuk-form-group ">
             @form(
             routes.TransferSummaryController.finalTransferConfirmationSubmit(consignmentId),
             (Symbol("novalidate"), "")
@@ -74,6 +75,7 @@
                     Symbol("_requiredOption") -> true
                     )
                 </fieldset>
+            </div>
                 <div>
                     <!-- Transfer -->
                     <button data-prevent-double-click="true" class="govuk-button" type="submit" data-module="govuk-button" role="button">


### PR DESCRIPTION
There was too much spacing between checkboxes because for each checkbox we used a div with class 'govuk-form-group' which should be around all checkboxes only once.