### PR TITLE
Enabled redirect filter

### DIFF
--- a/conf/application.base.conf
+++ b/conf/application.base.conf
@@ -10,6 +10,8 @@ consignmentapi.url = ${consignmentapi.domain}"/graphql"
 
 logout.url="http://localhost:9000/signed-out"
 
+play.filters.enabled += play.filters.https.RedirectHttpsFilter
+
 aws {
   cognito.url = "https://cognito-identity.eu-west-2.amazonaws.com"
   sts.url = "https://sts.amazonaws.com"


### PR DESCRIPTION
Enabling this enables strict transport security.
https://www.playframework.com/documentation/2.8.x/RedirectHttpsFilter

This only runs in production mode so won't affect local development and so can go into the base config file.

This means that all http requests get a 308 response. This includes the load balancer health checks so we need to change the expected response code for the health check to 308 but this will be done in the terraform repo.
