### PR TITLE
Change aria role to alert

### DIFF
--- a/app/views/fileChecksProgress.scala.html
+++ b/app/views/fileChecksProgress.scala.html
@@ -22,7 +22,7 @@
                 <a href="@routes.FaqController.faq()" class="govuk-link">FAQ</a> for this service.
             </p>
 
-            <div class="govuk-notification-banner" id="file-checks-completed-banner" tabindex="-1" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner" @if(!fileChecks.isComplete) {hidden}>
+            <div class="govuk-notification-banner" id="file-checks-completed-banner" tabindex="-1" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner" @if(!fileChecks.isComplete) {hidden}>
                 <div class="govuk-notification-banner__header">
                     <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
                         Important


### PR DESCRIPTION
The gov uk design system says to use role alert for the notification
banner. I've changed it here so we can retest with Voiceover for Mac
