### PR TITLE
Remove 'a' from sentence

### DIFF
--- a/app/views/fileChecksProgress.scala.html
+++ b/app/views/fileChecksProgress.scala.html
@@ -19,7 +19,7 @@
                 <li>Validating data integrity</li>
             </ul>
             <p class="govuk-body govuk-!-margin-bottom-7">For more information on these checks, please see our
-                <a href="@routes.FaqController.faq()#progress-checks" target="_blank" rel="noopener noreferrer" class="govuk-link">FAQ (opens in a new tab)</a> for this service.
+                <a href="@routes.FaqController.faq()#progress-checks" target="_blank" rel="noopener noreferrer" class="govuk-link">FAQ (opens in new tab)</a> for this service.
             </p>
 
             <div class="govuk-notification-banner" id="file-checks-completed-banner" tabindex="-1" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner" @if(!fileChecks.isComplete) {hidden}>

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -18,7 +18,7 @@
     </a>
 
     <h2 class="govuk-heading-m">Before you start</h2>
-    <p class="govuk-body">This service is in private beta. Please see our <a href="@routes.FaqController.faq()#private-beta" target="_blank" rel="noopener noreferrer" class="govuk-link">FAQ (opens in a new tab)</a> for information about how this may impact how you use this service.</p>
+    <p class="govuk-body">This service is in private beta. Please see our <a href="@routes.FaqController.faq()#private-beta" target="_blank" rel="noopener noreferrer" class="govuk-link">FAQ (opens in new tab)</a> for information about how this may impact how you use this service.</p>
 
   </div>
 </div>

--- a/app/views/transferAgreement.scala.html
+++ b/app/views/transferAgreement.scala.html
@@ -16,7 +16,7 @@
             <span class="govuk-warning-text__icon" aria-hidden="true">!</span> <!-- "aria-hidden" was added by GDS to prevent screen reader from saying "exclamation mark"-->
             <strong class="govuk-warning-text__text">
               <span class="govuk-warning-text__assistive">Warning</span>
-                This service is in private beta. During this time, the Transfer Digital Records service can only accept records that are in English, are Public Records and are Crown Copyright. For more information, please see our <a href="@routes.FaqController.faq()#other-languages" target="_blank" rel="noopener noreferrer" class="govuk-link">FAQ (opens in a new tab)</a> if you need to transfer records that this service cannot currently handle.
+                This service is in private beta. During this time, the Transfer Digital Records service can only accept records that are in English, are Public Records and are Crown Copyright. For more information, please see our <a href="@routes.FaqController.faq()#other-languages" target="_blank" rel="noopener noreferrer" class="govuk-link">FAQ (opens in new tab)</a> if you need to transfer records that this service cannot currently handle.
             </strong>
           </div>
         @errorSummary(

--- a/app/views/upload.scala.html
+++ b/app/views/upload.scala.html
@@ -88,7 +88,7 @@
                                     Choose folder
                                 </label>
                             </div>
-                            <p class="govuk-body">For more information on what metadata will be captured during the upload please visit our <a href="@routes.FaqController.faq()#metadata-captured" target="_blank" rel="noopener noreferrer" class="govuk-link">FAQ (opens in a new tab)</a>.</p>
+                            <p class="govuk-body">For more information on what metadata will be captured during the upload please visit our <a href="@routes.FaqController.faq()#metadata-captured" target="_blank" rel="noopener noreferrer" class="govuk-link">FAQ (opens in new tab)</a>.</p>
 
                             <!-- Buttons -->
                             <div class="govuk-button-group">


### PR DESCRIPTION
small PR to remove 'a' from 'opens in a new tab' sentence.