### PR TITLE
Add link to service unavailable sass file.

### DIFF
--- a/npm/css-src/sass/_header.scss
+++ b/npm/css-src/sass/_header.scss
@@ -1,6 +1,6 @@
 // Stylesheet also used in tdr-auth-server repo: https://github.com/nationalarchives/tdr-auth-server
 // Stylesheet also used in tdr-service-unavailable repo: https://github.com/nationalarchives/tdr-service-unavailable/blob/master/css-src/sass/_header.scss
-// Any changes should also be added to tdr-auth-server repo version
+// Any changes should also be added to the tdr-auth-server and tdr-service-unavailable repo versions.
 
 $govuk-header-link: govuk-colour('white');
 

--- a/npm/css-src/sass/_header.scss
+++ b/npm/css-src/sass/_header.scss
@@ -1,4 +1,5 @@
 // Stylesheet also used in tdr-auth-server repo: https://github.com/nationalarchives/tdr-auth-server
+// Stylesheet also used in tdr-service-unavailable repo: https://github.com/nationalarchives/tdr-service-unavailable/blob/master/css-src/sass/_header.scss
 // Any changes should also be added to tdr-auth-server repo version
 
 $govuk-header-link: govuk-colour('white');


### PR DESCRIPTION
We're now using the same custom css in the tdr-service-unavailable repo.
I've added a link here so we replicate any changes in that repo.
