### PR TITLE
Give 0-byte files a size of 1 at the point of totalChunks calculation

### DIFF
--- a/npm/src/s3upload/index.ts
+++ b/npm/src/s3upload/index.ts
@@ -36,11 +36,11 @@ export class S3Upload {
     totalChunks: number
   }> = async (consignmentId, files, callback, stage) => {
     const totalFiles = files.length
-    const totalChunks: number =
-      files.reduce(
-        (fileSizeTotal, file) => fileSizeTotal + file.file.size,
-        0
-      ) || totalFiles
+    const totalChunks: number = files.reduce(
+      (fileSizeTotal, file) =>
+        fileSizeTotal + (file.file.size ? file.file.size : 1),
+      0
+    )
     let processedChunks = 0
     const sendData: S3.ManagedUpload.SendData[] = []
     for (const file of files) {
@@ -93,7 +93,7 @@ export class S3Upload {
         )
       })
     } else {
-      const chunks = file.size + processedChunks
+      const chunks = 1 + processedChunks
       this.updateUploadProgress(
         chunks,
         totalChunks,

--- a/npm/test/s3upload.test.ts
+++ b/npm/test/s3upload.test.ts
@@ -288,5 +288,7 @@ test(`multiple file uploads (some with 0 bytes, some not) returns processedChunk
   expect(result.processedChunks).toEqual(
     byteSizeofAllFiles + numberOfFilesWithZeroBytes
   )
-  expect(result.totalChunks).toEqual(byteSizeofAllFiles)
+  expect(result.totalChunks).toEqual(
+    byteSizeofAllFiles + numberOfFilesWithZeroBytes
+  )
 })


### PR DESCRIPTION
The reason for this is in the case of a folder that has a file with bytes and the rest are 0-byte files.
Once the file with bytes (e.g 100 bytes) has completed uploading, the percentage would be at 100%
(since the totalChunks would have been 100, then when it processes the 0-byte files, since we are giving
them a value of 1, the progress will go past 100%.

Also, file.size + processedChunks was changed to 1 + processedChunks because file.size for 0-byte files would be 0
and therefore, the progress bar would be slightly behind when it comes to updating