### PR TITLE
Remove '/' from path if present

### DIFF
--- a/npm/src/clientfilemetadataupload/index.ts
+++ b/npm/src/clientfilemetadataupload/index.ts
@@ -54,8 +54,11 @@ export class ClientFileMetadataUpload {
   ): Promise<ITdrFile[]> {
     const clientFileData: IClientFileData[] = metadata.map((m, matchId) => {
       const { checksum, path, lastModified, file } = m
+      //Files uploaded with 'drag and files' have '/'  prepended, those uploaded with 'browse' don't
+      //Ensure file paths stored in database are consistent
+      const validatedPath = path.startsWith("/") ? path.substring(1) : path
       const metadataInput: ClientSideMetadataInput = {
-        originalPath: path,
+        originalPath: validatedPath,
         checksum,
         lastModified: lastModified.getTime(),
         fileSize: file.size,


### PR DESCRIPTION
Ensure file path entries in database are consistent

Files uploaded with 'drag and drop' have a '/' prepended to the file path, those uploaded with 'browse' don't

Make the change at the metadata upload point as this is just to ensure consistent entries in the database, and not for any other purpose