### PR TITLE
Check file check status less frequently

### DIFF
--- a/npm/src/filechecks/index.ts
+++ b/npm/src/filechecks/index.ts
@@ -23,6 +23,6 @@ export class FileChecks {
         clearInterval(intervalId)
         displayChecksCompletedBanner()
       }
-    }, 2000)
+    }, 20000)
   }
 }


### PR DESCRIPTION
Check whether the file checks have finished every 20 seconds rather than every 2 seconds.

Checking every 2 seconds looks like it was contributing to performance issues where several people were making large transfers in parallel, and they all had the file checks page open.

This isn't a real fix for the performance issues - we'll need to work out which DB queries are being slow - but it's a quick fix to make and it might ease up some of the load on the DB.

It's currently less important to get frequent updates because we are showing the static "file checks in progress" page rather than the progress bars. If we reinstate the progress bars, we'll have to address the performance issues properly if we haven't already done that.