### PR TITLE
Set placeholder credentials after cookie request.

### DIFF
--- a/npm/src/index.ts
+++ b/npm/src/index.ts
@@ -51,13 +51,12 @@ export const renderModules = () => {
     uploadContainer.removeAttribute("hidden")
     const frontEndInfo = getFrontEndInfo()
 
-    configureAws(frontEndInfo)
-
     getKeycloakInstance().then((keycloak) => {
       fetch(`${frontEndInfo.uploadUrl}/cookies`, {
         credentials: "include",
         headers: { Authorization: `Bearer ${keycloak.token}` }
       }).then(() => {
+        configureAws(frontEndInfo)
         const graphqlClient = new GraphqlClient(frontEndInfo.apiUrl, keycloak)
         const clientFileProcessing = new ClientFileMetadataUpload(graphqlClient)
         const updateConsignmentStatus = new UpdateConsignmentStatus(


### PR DESCRIPTION
The end to end tests are checking to see if the credentials for upload
are set correctly by looking at `AWS.config.credentials` in the
javascript.

We now using signed cookies instead of using AWS config but the SDK
still makes us set a value so they're set to `placeholder-id` at the
moment.

These were being set before the cookies request returned. This means
that the e2e tests were finding the credentials, assuming the page was
ready for upload and trying to send the upload too early, before the
cookie request is complete.

By setting the placeholder credentials after the call the cookies
endpoint, the e2e tests should pass and it won't make any difference to
the behaviour of the front end itself.
