### PR TITLE
Manually bump minify to version 8.0.2

### DIFF
--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -35,7 +35,7 @@
         "jest": "^27.2.4",
         "jest-fetch-mock": "^3.0.3",
         "lint-staged": "^11.1.2",
-        "minify": "^7.2.2",
+        "minify": "^8.0.2",
         "npm-run-all": "^4.1.5",
         "postcss-cli": "^9.0.1",
         "prettier": "2.4.1",
@@ -7005,9 +7005,9 @@
       }
     },
     "node_modules/minify": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/minify/-/minify-7.2.2.tgz",
-      "integrity": "sha512-AcgoqXRQX0o/PRrydK8klB5OD09lFjJ/OYVHGxmWmbg/DQP/ETmmPM4aA10NZBiGdlLeUnC9sCgrgJAt0P14mA==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/minify/-/minify-8.0.2.tgz",
+      "integrity": "sha512-RNH20TKixZOmEYEs2yxBPRqsUVOJ2XGU8AWqmezBSN/nuSki87gnAssq5jWIf2l0QZ124lMuSq1/YuxibxSeKQ==",
       "dev": true,
       "dependencies": {
         "clean-css": "^5.0.1",
@@ -7016,6 +7016,7 @@
         "find-up": "^6.1.0",
         "html-minifier-terser": "^6.0.2",
         "readjson": "^2.2.2",
+        "simport": "^1.2.0",
         "terser": "^5.3.2",
         "try-catch": "^3.0.0",
         "try-to-catch": "^3.0.0"
@@ -8841,6 +8842,19 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
+    },
+    "node_modules/simport": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/simport/-/simport-1.2.0.tgz",
+      "integrity": "sha512-85Bm7pKsqiiQ8rmYCaPDdlXZjJvuW6/k/FY8MTtLFMgU7f8S00CgTHfRtWB6KwSb6ek4p9YyG2enG1+yJbl+CA==",
+      "dev": true,
+      "dependencies": {
+        "readjson": "^2.2.0",
+        "try-to-catch": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=12.2"
+      }
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -16215,9 +16229,9 @@
       "dev": true
     },
     "minify": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/minify/-/minify-7.2.2.tgz",
-      "integrity": "sha512-AcgoqXRQX0o/PRrydK8klB5OD09lFjJ/OYVHGxmWmbg/DQP/ETmmPM4aA10NZBiGdlLeUnC9sCgrgJAt0P14mA==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/minify/-/minify-8.0.2.tgz",
+      "integrity": "sha512-RNH20TKixZOmEYEs2yxBPRqsUVOJ2XGU8AWqmezBSN/nuSki87gnAssq5jWIf2l0QZ124lMuSq1/YuxibxSeKQ==",
       "dev": true,
       "requires": {
         "clean-css": "^5.0.1",
@@ -16226,6 +16240,7 @@
         "find-up": "^6.1.0",
         "html-minifier-terser": "^6.0.2",
         "readjson": "^2.2.2",
+        "simport": "^1.2.0",
         "terser": "^5.3.2",
         "try-catch": "^3.0.0",
         "try-to-catch": "^3.0.0"
@@ -17577,6 +17592,16 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
+    },
+    "simport": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/simport/-/simport-1.2.0.tgz",
+      "integrity": "sha512-85Bm7pKsqiiQ8rmYCaPDdlXZjJvuW6/k/FY8MTtLFMgU7f8S00CgTHfRtWB6KwSb6ek4p9YyG2enG1+yJbl+CA==",
+      "dev": true,
+      "requires": {
+        "readjson": "^2.2.0",
+        "try-to-catch": "^3.0.0"
+      }
     },
     "sisteransi": {
       "version": "1.0.5",

--- a/npm/package.json
+++ b/npm/package.json
@@ -64,7 +64,7 @@
     "jest": "^27.2.4",
     "jest-fetch-mock": "^3.0.3",
     "lint-staged": "^11.1.2",
-    "minify": "^7.2.2",
+    "minify": "^8.0.2",
     "npm-run-all": "^4.1.5",
     "postcss-cli": "^9.0.1",
     "prettier": "2.4.1",


### PR DESCRIPTION
Dependabot alert for minify version 8 was ignored due to issue with an earlier minor version