### PR TITLE
Use base alpine image with jdk 15 installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,15 @@
-FROM openjdk:15-alpine
+FROM alpine
 #For alpine versions need to create a group before adding a user to the image
 RUN addgroup --system frontendgroup && adduser --system frontenduser -G frontendgroup
 WORKDIR play
 COPY target/universal/tdr-transfer-frontend*.zip .
-RUN apk update && apk upgrade p11-kit && apk add bash unzip && unzip -qq tdr-transfer-frontend-*.zip
+RUN apk update && apk upgrade p11-kit busybox && apk add bash unzip && \
+    apk add openjdk15 --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community && \
+    unzip -qq tdr-transfer-frontend-*.zip
 RUN chown -R frontenduser /play
 
 USER frontenduser
+
 CMD  tdr-transfer-frontend-*/bin/tdr-transfer-frontend \
                         -Dplay.http.secret.key=$PLAY_SECRET_KEY \
                         -Dconfig.resource=application.$ENVIRONMENT.conf \


### PR DESCRIPTION
Tried upgrading busybox on the openjdk image but it seems to be
on an older version of alpine and there are still vulnerabilities in the
latest version of busybox for that version.

Instead of using the openjdk image, use the
standard alpine image and installed openjdk 15 from the alpine edge
repository.