### PR TITLE
Make header content appear on multiple lines when page is zoomed in/v…

### DIFF
--- a/npm/css-src/sass/_header.scss
+++ b/npm/css-src/sass/_header.scss
@@ -5,12 +5,11 @@
 $govuk-header-link: govuk-colour('white');
 
 .govuk-header__tna-logo {
-  float: left;
   width: 220px;
 }
 
 .govuk-header__tna-logo-image {
-  width: 220px;
+  width: 90%;
 }
 
 .govuk-header__tna-content {
@@ -56,5 +55,21 @@ $govuk-header-link: govuk-colour('white');
   &:link,
   &:visited {
     text-decoration: none;
+  }
+}
+
+@media (max-width: 48.06249em) {
+  .tna-header {
+    display: block;
+  }
+
+  .tna-header ul {
+    list-style-type: none; // for some reason, the bullets appear when you zoom in; this line ensures that they don't.
+    margin-block-start: 0;
+    padding-inline-start: 0;
+  }
+
+  .govuk-header__link--service-name {
+    margin-bottom: 0;
   }
 }

--- a/npm/css-src/sass/_header.scss
+++ b/npm/css-src/sass/_header.scss
@@ -9,7 +9,7 @@ $govuk-header-link: govuk-colour('white');
 }
 
 .govuk-header__tna-logo-image {
-  width: 90%;
+  width: 220px;
 }
 
 .govuk-header__tna-content {


### PR DESCRIPTION
…iewed on a small screen

When this issue was first discovered, it was using an older Mac with a 1600 x 900 resolution;
it could be replicated by zooming the page in, to 500%.

Now, when the page is zoomed in at 175+%, it will move the title and 'Sign out' button
on a new line; GDS' page does the same thing at 175%.

This solution should solve the header issue for:

1. Screens zoomed in 175% and above
2. Screens with lower resolutions
3. Small screens like phones/tablets