### PR TITLE
Fix parent folder name function.

### DIFF
--- a/npm/src/upload/form/upload-form.ts
+++ b/npm/src/upload/form/upload-form.ts
@@ -259,7 +259,7 @@ export class UploadForm {
     const relativePath: string = firstItem.path
     if (relativePath.includes("/")) {
       const splitPath: string[] = relativePath.split("/")
-      return splitPath[1]
+      return splitPath[0]
     } else {
       return relativePath
     }


### PR DESCRIPTION
Because it was taking the second item in the array, it was causing the
wrong parent folder name to be set.
