### PR TITLE
Ignore dependabot branches on push.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches-ignore:
       - master
       - release-*
+      - dependabot*
 permissions:
   id-token: write
   contents: read


### PR DESCRIPTION
Dependabot update PRs are treated like PRs from forks which means that
they don't have access to secrets on the push event.

But they aren't actually forks so GitHub still tries to run the job on
push and it fails because it has no access to secrets.

We only want the pull_request_target trigger to run for dependabot.
Helpfully, dependabot prefixes all its branches with dependabot/ so
adding this to the ignore list for the push trigger should stop it
running.
