### PR TITLE
Stop using pull request target.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: TDR Run API tests
 on:
-  pull_request_target:
+  pull_request:
   push:
     branches-ignore:
       - master


### PR DESCRIPTION
This is useless as is because it runs the code from the master branch, not the
code from the fork which is causing us to merge all kinds of broken
things.

There are ways around this but I need to look into them more, for now,
this should stop bad updates breaking the front end.
