### PR TITLE
Remove DTS bundle plugin.

### DIFF
--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -35,7 +35,6 @@
         "@typescript-eslint/parser": "^5.16.0",
         "aws-sdk-client-mock": "^0.6.2",
         "copyfiles": "^2.4.1",
-        "dts-bundle": "^0.7.3",
         "eslint": "^8.11.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-import": "^2.25.4",

--- a/npm/package.json
+++ b/npm/package.json
@@ -67,7 +67,6 @@
     "@typescript-eslint/parser": "^5.16.0",
     "aws-sdk-client-mock": "^0.6.2",
     "copyfiles": "^2.4.1",
-    "dts-bundle": "^0.7.3",
     "eslint": "^8.11.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-import": "^2.25.4",

--- a/npm/webpack.config.js
+++ b/npm/webpack.config.js
@@ -35,18 +35,3 @@ module.exports = {
     path: path.resolve(__dirname, "../public/javascripts")
   }
 }
-
-function DtsBundlePlugin() {}
-DtsBundlePlugin.prototype.apply = function (compiler) {
-  compiler.plugin("done", function () {
-    var dts = require("dts-bundle")
-
-    dts.bundle({
-      name: "tdr",
-      main: "src/index.d.ts",
-      out: "../dist/index.d.ts",
-      removeSource: true,
-      outputAsModuleFolder: true // to use npm in-package typings
-    })
-  })
-}


### PR DESCRIPTION
Dependabot is trying to upgrade minimist to the latest stable version as
there's an alert on it but it can't because dts-bundle is using an old
version.

The project itself seems dead. It hasn't had a commit since 2017. I'm
not sure why we added it but we don't seem to need it. We still get the
typescript mapping files in the browser which is all we need.
We aren't publishing this anywhere so we don't need d.ts files creating.
