### PR TITLE
Pin tdr-generated-graphql

### DIFF
--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -13,7 +13,7 @@
         "@aws-sdk/client-s3": "^3.58.0",
         "@aws-sdk/lib-storage": "^3.58.0",
         "@nationalarchives/file-information": "^1.0.293",
-        "@nationalarchives/tdr-generated-graphql": "^1.0.195",
+        "@nationalarchives/tdr-generated-graphql": "1.0.185",
         "copyfiles": "^2.4.1",
         "events": "^3.3.0",
         "govuk-frontend": "^4.0.0",
@@ -2759,12 +2759,13 @@
       }
     },
     "node_modules/@nationalarchives/tdr-generated-graphql": {
-      "version": "1.0.195",
-      "resolved": "https://registry.npmjs.org/@nationalarchives/tdr-generated-graphql/-/tdr-generated-graphql-1.0.195.tgz",
-      "integrity": "sha512-VoFiiR8df2AW/itv5ImXJa0Eybquqh7fUd8SbpUo4i7E2PKdrutl3feeOB4k/JaYDOFpW/VOKt09QnG8j9oiJg==",
+      "version": "1.0.185",
+      "resolved": "https://registry.npmjs.org/@nationalarchives/tdr-generated-graphql/-/tdr-generated-graphql-1.0.185.tgz",
+      "integrity": "sha512-E3uRcaT2ZjfxfhC4MitJcnsIO0z+RXw1O4e18D2txA0cFJAlqlc9mqx879y3CZ9GOFSu93Oou6RjfgNtxLpQQA==",
       "dependencies": {
         "@graphql-codegen/cli": "^2.6.2",
         "apollo-link-http": "^1.5.17",
+        "dts-bundle": "^0.7.3",
         "graphql": "^16.3.0",
         "y18n": "^5.0.8"
       }
@@ -2950,6 +2951,11 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "node_modules/@types/detect-indent": {
+      "version": "0.1.30",
+      "resolved": "https://registry.npmjs.org/@types/detect-indent/-/detect-indent-0.1.30.tgz",
+      "integrity": "sha1-3GgrtBK05lugmOcO2tc7SDP7kQ0="
+    },
     "node_modules/@types/eslint": {
       "version": "8.4.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.1.tgz",
@@ -2975,6 +2981,15 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
       "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
       "dev": true
+    },
+    "node_modules/@types/glob": {
+      "version": "5.0.30",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.30.tgz",
+      "integrity": "sha1-ECZAnFYlqGiQdGAoCNCCsoZ7ilE=",
+      "dependencies": {
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.5",
@@ -3045,10 +3060,20 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/minimatch": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
+      "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
+    },
     "node_modules/@types/minimist": {
       "version": "1.2.1",
       "integrity": "sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==",
       "dev": true
+    },
+    "node_modules/@types/mkdirp": {
+      "version": "0.3.29",
+      "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-0.3.29.tgz",
+      "integrity": "sha1-fyrX7FX5FEgvybHsS7GuYCjUYGY="
     },
     "node_modules/@types/node": {
       "version": "15.12.2",
@@ -4608,8 +4633,7 @@
     },
     "node_modules/commander": {
       "version": "2.20.3",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "node_modules/common-tags": {
       "version": "1.8.2",
@@ -5124,6 +5148,91 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/dts-bundle": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/dts-bundle/-/dts-bundle-0.7.3.tgz",
+      "integrity": "sha1-Nyt7tpyCB4LmOC9ABzmmnc7T1Zo=",
+      "dependencies": {
+        "@types/detect-indent": "0.1.30",
+        "@types/glob": "5.0.30",
+        "@types/mkdirp": "0.3.29",
+        "@types/node": "8.0.0",
+        "commander": "^2.9.0",
+        "detect-indent": "^0.2.0",
+        "glob": "^6.0.4",
+        "mkdirp": "^0.5.0"
+      },
+      "bin": {
+        "dts-bundle": "lib/dts-bundle.js"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/dts-bundle/node_modules/@types/node": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.0.tgz",
+      "integrity": "sha512-j2tekvJCO7j22cs+LO6i0kRPhmQ9MXaPZ55TzOc1lzkN5b6BWqq4AFjl04s1oRRQ1v5rSe+KEvnLUSTonuls/A=="
+    },
+    "node_modules/dts-bundle/node_modules/detect-indent": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-0.2.0.tgz",
+      "integrity": "sha1-BCkUSYl5rC2fPHPk/z5od9O8krY=",
+      "dependencies": {
+        "get-stdin": "^0.1.0",
+        "minimist": "^0.1.0"
+      },
+      "bin": {
+        "detect-indent": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dts-bundle/node_modules/get-stdin": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-0.1.0.tgz",
+      "integrity": "sha1-WZivJKr8gC0VyCxoVlfuuLENSpE=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dts-bundle/node_modules/glob": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+      "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+      "dependencies": {
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "2 || 3",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/dts-bundle/node_modules/minimist": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.1.0.tgz",
+      "integrity": "sha1-md9lelJXTCHJBXSX33QnkLK0wN4="
+    },
+    "node_modules/dts-bundle/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/dts-bundle/node_modules/mkdirp/node_modules/minimist": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "node_modules/duplexer3": {
       "version": "0.1.4",
@@ -15048,12 +15157,13 @@
       }
     },
     "@nationalarchives/tdr-generated-graphql": {
-      "version": "1.0.195",
-      "resolved": "https://registry.npmjs.org/@nationalarchives/tdr-generated-graphql/-/tdr-generated-graphql-1.0.195.tgz",
-      "integrity": "sha512-VoFiiR8df2AW/itv5ImXJa0Eybquqh7fUd8SbpUo4i7E2PKdrutl3feeOB4k/JaYDOFpW/VOKt09QnG8j9oiJg==",
+      "version": "1.0.185",
+      "resolved": "https://registry.npmjs.org/@nationalarchives/tdr-generated-graphql/-/tdr-generated-graphql-1.0.185.tgz",
+      "integrity": "sha512-E3uRcaT2ZjfxfhC4MitJcnsIO0z+RXw1O4e18D2txA0cFJAlqlc9mqx879y3CZ9GOFSu93Oou6RjfgNtxLpQQA==",
       "requires": {
         "@graphql-codegen/cli": "^2.6.2",
         "apollo-link-http": "^1.5.17",
+        "dts-bundle": "^0.7.3",
         "graphql": "^16.3.0",
         "y18n": "^5.0.8"
       }
@@ -15204,6 +15314,11 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/detect-indent": {
+      "version": "0.1.30",
+      "resolved": "https://registry.npmjs.org/@types/detect-indent/-/detect-indent-0.1.30.tgz",
+      "integrity": "sha1-3GgrtBK05lugmOcO2tc7SDP7kQ0="
+    },
     "@types/eslint": {
       "version": "8.4.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.1.tgz",
@@ -15229,6 +15344,15 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
       "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
       "dev": true
+    },
+    "@types/glob": {
+      "version": "5.0.30",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.30.tgz",
+      "integrity": "sha1-ECZAnFYlqGiQdGAoCNCCsoZ7ilE=",
+      "requires": {
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
     },
     "@types/graceful-fs": {
       "version": "4.1.5",
@@ -15299,10 +15423,20 @@
         "@types/node": "*"
       }
     },
+    "@types/minimatch": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
+      "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
+    },
     "@types/minimist": {
       "version": "1.2.1",
       "integrity": "sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==",
       "dev": true
+    },
+    "@types/mkdirp": {
+      "version": "0.3.29",
+      "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-0.3.29.tgz",
+      "integrity": "sha1-fyrX7FX5FEgvybHsS7GuYCjUYGY="
     },
     "@types/node": {
       "version": "15.12.2",
@@ -16467,8 +16601,7 @@
     },
     "commander": {
       "version": "2.20.3",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "common-tags": {
       "version": "1.8.2",
@@ -16876,6 +17009,74 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.1.tgz",
       "integrity": "sha512-hYf+jZNNqJBD2GiMYb+5mqOIX4R4RRHXU3qWMWYN+rqcR2/YpRL2bUHr8C8fU+5DNvqYjJ8YvMGSLuVPWU1cNg=="
+    },
+    "dts-bundle": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/dts-bundle/-/dts-bundle-0.7.3.tgz",
+      "integrity": "sha1-Nyt7tpyCB4LmOC9ABzmmnc7T1Zo=",
+      "requires": {
+        "@types/detect-indent": "0.1.30",
+        "@types/glob": "5.0.30",
+        "@types/mkdirp": "0.3.29",
+        "@types/node": "8.0.0",
+        "commander": "^2.9.0",
+        "detect-indent": "^0.2.0",
+        "glob": "^6.0.4",
+        "mkdirp": "^0.5.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.0.tgz",
+          "integrity": "sha512-j2tekvJCO7j22cs+LO6i0kRPhmQ9MXaPZ55TzOc1lzkN5b6BWqq4AFjl04s1oRRQ1v5rSe+KEvnLUSTonuls/A=="
+        },
+        "detect-indent": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-0.2.0.tgz",
+          "integrity": "sha1-BCkUSYl5rC2fPHPk/z5od9O8krY=",
+          "requires": {
+            "get-stdin": "^0.1.0",
+            "minimist": "^0.1.0"
+          }
+        },
+        "get-stdin": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-0.1.0.tgz",
+          "integrity": "sha1-WZivJKr8gC0VyCxoVlfuuLENSpE="
+        },
+        "glob": {
+          "version": "6.0.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "minimist": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.1.0.tgz",
+          "integrity": "sha1-md9lelJXTCHJBXSX33QnkLK0wN4="
+        },
+        "mkdirp": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+          "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+          "requires": {
+            "minimist": "^1.2.6"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.6",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+              "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+            }
+          }
+        }
+      }
     },
     "duplexer3": {
       "version": "0.1.4",

--- a/npm/package.json
+++ b/npm/package.json
@@ -45,7 +45,7 @@
     "@aws-sdk/client-s3": "^3.58.0",
     "@aws-sdk/lib-storage": "^3.58.0",
     "@nationalarchives/file-information": "^1.0.293",
-    "@nationalarchives/tdr-generated-graphql": "^1.0.195",
+    "@nationalarchives/tdr-generated-graphql": "1.0.185",
     "copyfiles": "^2.4.1",
     "events": "^3.3.0",
     "govuk-frontend": "^4.0.0",


### PR DESCRIPTION
The dependabot updates this morning put a new version of
tdr-generated-graphql which has broken the upload.

I'll fix whatever is wrong with that at some point but for now, I'll pin
it to the last known working version.
