### PR TITLE
dependency updates

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,7 @@ libraryDependencies ++= Seq(
   "com.softwaremill.sttp.client" %% "async-http-client-backend-future" % sttpVersion,
   "uk.gov.nationalarchives" %% "tdr-graphql-client" % "0.0.21",
   "uk.gov.nationalarchives" %% "tdr-auth-utils" % "0.0.38",
-  "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.223",
+  "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.226",
   ws,
   "com.github.tomakehurst" % "wiremock-jre8" % "2.26.3" % Test,
   "org.mockito" % "mockito-core" % "3.3.3" % Test

--- a/build.sbt
+++ b/build.sbt
@@ -42,6 +42,6 @@ libraryDependencies ++= Seq(
 scalacOptions ++= Seq("-language:implicitConversions")
 
 libraryDependencies += play.sbt.PlayImport.cacheApi
-libraryDependencies += "com.github.karelcemus" %% "play-redis" % "2.6.1"
+libraryDependencies += "com.github.karelcemus" %% "play-redis" % "2.7.0"
 
 pipelineStages := Seq(digest)

--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ libraryDependencies ++= Seq(
   "uk.gov.nationalarchives" %% "tdr-auth-utils" % "0.0.40",
   "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.226",
   ws,
-  "com.github.tomakehurst" % "wiremock-jre8" % "2.26.3" % Test,
+  "com.github.tomakehurst" % "wiremock-jre8" % "2.32.0" % Test,
   "org.mockito" % "mockito-core" % "3.12.4" % Test
 )
 scalacOptions ++= Seq("-language:implicitConversions")

--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ libraryDependencies ++= Seq(
   "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.226",
   ws,
   "com.github.tomakehurst" % "wiremock-jre8" % "2.26.3" % Test,
-  "org.mockito" % "mockito-core" % "3.3.3" % Test
+  "org.mockito" % "mockito-core" % "3.12.4" % Test
 )
 scalacOptions ++= Seq("-language:implicitConversions")
 

--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ libraryDependencies ++= Seq(
   "com.softwaremill.sttp.client" %% "circe" % sttpVersion,
   "com.softwaremill.sttp.client" %% "async-http-client-backend-future" % sttpVersion,
   "uk.gov.nationalarchives" %% "tdr-graphql-client" % "0.0.21",
-  "uk.gov.nationalarchives" %% "tdr-auth-utils" % "0.0.38",
+  "uk.gov.nationalarchives" %% "tdr-auth-utils" % "0.0.40",
   "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.226",
   ws,
   "com.github.tomakehurst" % "wiremock-jre8" % "2.26.3" % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ watchSources ++= (baseDirectory.value / "npm/src" ** "*").get
 scalaVersion := "2.13.8"
 
 libraryDependencies += guice
-libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "4.0.3" % Test
+libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0" % Test
 
 //Needed to run the tests. Prevents incompatible databind version errors.
 //More details on a similar error here: https://stackoverflow.com/questions/43841091/spark2-1-0-incompatible-jackson-versions-2-7-6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.13")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.14")
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 resolvers += Resolver.jcenterRepo
 addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.4")


### PR DESCRIPTION
- Update play-redis to 2.7.0
- Update filters-helpers, play-ahc-ws, ... to 2.8.14
- Update mockito-core to 3.12.4
- Update scalatestplus-play to 5.1.0
- Update tdr-generated-graphql to 0.0.226
