### PR TITLE
Remove MANAGEMENT_ACCOUNT

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,5 +19,4 @@ jobs:
         npm --prefix npm run checks
         sbt test
     secrets:
-      MANAGEMENT_ACCOUNT: ${{ secrets.MANAGEMENT_ACCOUNT }}
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
This is now optional in tdr-github-actions. Once all the repos have removed it, we can take it out of that repo.