### PR TITLE
Tdr-1838 Add transfer reference to judgment workflow

### DIFF
--- a/app/controllers/FileChecksController.scala
+++ b/app/controllers/FileChecksController.scala
@@ -48,13 +48,16 @@ class FileChecksController @Inject()(val controllerComponents: SecurityComponent
 
   def judgmentFileChecksPage(consignmentId: UUID): Action[AnyContent] = judgmentTypeAction(consignmentId) { implicit request: Request[AnyContent] =>
     getFileChecksProgress(request, consignmentId)
-      .map {
+      .flatMap {
         fileChecks => if(fileChecks.isComplete) {
-          Ok(views.html.fileChecksProgressAlreadyConfirmed(
+          Future(Ok(views.html.fileChecksProgressAlreadyConfirmed(
             consignmentId, frontEndInfoConfiguration.frontEndInfo, request.token.name, isJudgmentUser = true
-          )).uncache()
+          )).uncache())
         } else {
-          Ok(views.html.judgment.judgmentFileChecksProgress(consignmentId, frontEndInfoConfiguration.frontEndInfo, request.token.name)).uncache()
+          consignmentService.getConsignmentRef(consignmentId, request.token.bearerAccessToken).map(r =>
+            Ok(views.html.judgment.judgmentFileChecksProgress(consignmentId, r.consignmentReference, frontEndInfoConfiguration.frontEndInfo, request.token.name
+            )).uncache()
+          )
         }
       }
   }

--- a/app/controllers/FileChecksResultsController.scala
+++ b/app/controllers/FileChecksResultsController.scala
@@ -39,11 +39,14 @@ class FileChecksResultsController @Inject()(val controllerComponents: SecurityCo
   def judgmentFileCheckResultsPage(consignmentId: UUID): Action[AnyContent] = judgmentTypeAction(consignmentId) { implicit request: Request[AnyContent] =>
     consignmentService.getConsignmentFileChecks(consignmentId, request.token.bearerAccessToken).flatMap(fileCheck => {
       if (fileCheck.allChecksSucceeded) {
-        consignmentService.getConsignmentFilePath(consignmentId, request.token.bearerAccessToken).map(files => {
-          val filename = files.files.head.metadata.clientSideOriginalFilePath
+        for {
+          filepath <- consignmentService.getConsignmentFilePath(consignmentId, request.token.bearerAccessToken)
+          ref <- consignmentService.getConsignmentRef(consignmentId, request.token.bearerAccessToken)
+        } yield {
+          val filename = filepath.files.head.metadata.clientSideOriginalFilePath
             .getOrElse(throw new IllegalStateException(s"Filename cannot be found for judgment upload: '$consignmentId'"))
-          Ok(views.html.judgment.judgmentFileChecksResults(filename, consignmentId, request.token.name))
-        })
+          Ok(views.html.judgment.judgmentFileChecksResults(filename, consignmentId, ref.consignmentReference, request.token.name))
+        }
       } else {
         Future(Ok(views.html.fileChecksFailed(request.token.name, isJudgmentUser = true)))
       }

--- a/app/views/judgment/judgmentBeforeUploading.scala.html
+++ b/app/views/judgment/judgmentBeforeUploading.scala.html
@@ -1,5 +1,6 @@
+@import views.html.partials.{progressIndicator, transferReference}
+
 @import java.util.UUID
-@import views.html.partials.progressIndicator
 
 @(consignmentId: UUID, consignmentRef: String, name: String)(implicit request: RequestHeader, messages: Messages)
 @main("Check your file before uploading", name = name, isJudgmentUser = true) {
@@ -27,6 +28,7 @@
         <a class="govuk-link" href="@routes.HomepageController.homepage()">Cancel</a>
       </div>
     </div>
+    @transferReference(consignmentRef)
 </div>
 }
 }

--- a/app/views/judgment/judgmentFileChecksProgress.scala.html
+++ b/app/views/judgment/judgmentFileChecksProgress.scala.html
@@ -1,9 +1,8 @@
 @import java.util.UUID
 @import viewsapi.FrontEndInfo
-@import views.html.partials.{frontEndInputs, progressIndicator}
+@import views.html.partials.{frontEndInputs, progressIndicator, transferReference}
 @import views.html.helper.form
-@import views.html.helper.form
-@(consignmentId: UUID, frontEndInfo: FrontEndInfo, name: String)(implicit messages: Messages, request: RequestHeader)
+@(consignmentId: UUID, consignmentRef: String, frontEndInfo: FrontEndInfo, name: String)(implicit messages: Messages, request: RequestHeader)
 
 @main("Checking your upload", name = name, isJudgmentUser = true) {
     @defining(play.core.PlayVersion.current) { version =>
@@ -20,6 +19,7 @@
             <!--        Form to redirect user once file checks have completed. It sends consignmentId to record results' placeholder page -->
             @form(routes.FileChecksResultsController.judgmentFileCheckResultsPage(consignmentId), Symbol("id") -> "file-checks-form") { }
         </div>
+        @transferReference(consignmentRef)
     </div>
     }
 }

--- a/app/views/judgment/judgmentFileChecksResults.scala.html
+++ b/app/views/judgment/judgmentFileChecksResults.scala.html
@@ -1,8 +1,8 @@
 @import views.html.helper.CSRF
+@import views.html.partials.{progressIndicator, transferReference}
+
 @import java.util.UUID
-@import viewsapi.FrontEndInfo
-@import views.html.partials.progressIndicator
-@(filename: String, consignmentId: java.util.UUID, name: String)(implicit messages: Messages, request: RequestHeader)
+@(filename: String, consignmentId: UUID, consignmentRef: String, name: String)(implicit messages: Messages, request: RequestHeader)
 
 @main("Results of checks", name = name, isJudgmentUser = true) {
     <div class="govuk-grid-row">
@@ -28,5 +28,6 @@
                 </form>
             </div>
         </div>
+        @transferReference(consignmentRef)
     </div>
 }

--- a/app/views/judgment/judgmentUpload.scala.html
+++ b/app/views/judgment/judgmentUpload.scala.html
@@ -3,7 +3,7 @@
 @import viewsapi.FrontEndInfo
 @import java.util.UUID
 
-@(consignmentId: UUID, pageHeading1stHalf: String, pageHeading2ndHalf: String, frontEndInfo: FrontEndInfo, name: String)(implicit request: RequestHeader, messages: Messages)
+@(consignmentId: UUID, consignmentRef: String, pageHeading1stHalf: String, pageHeading2ndHalf: String, frontEndInfo: FrontEndInfo, name: String)(implicit request: RequestHeader, messages: Messages)
 
 @main("Upload your judgment", name = name, isJudgmentUser = true) {
 <noscript>
@@ -88,6 +88,7 @@
         <!--        Form to redirect user once upload has completed. It sends consignmentId to file checks placeholder page -->
         @form(routes.FileChecksController.judgmentFileChecksPage(consignmentId), Symbol("id") -> "upload-data-form") { }
     </div>
+    @transferReference(consignmentRef)
 </div>
 <div id="upload-progress" class="govuk-grid-row" hidden>
     <div class="govuk-grid-column-two-thirds" role="status" aria-live="assertive">
@@ -125,5 +126,6 @@
             </div>
         </div>
     </div>
+    @transferReference(consignmentRef)
 </div>
 }

--- a/app/views/partials/transferReference.scala.html
+++ b/app/views/partials/transferReference.scala.html
@@ -1,0 +1,13 @@
+@(consignmentRef: String)
+<div class="govuk-grid-column-one-third">
+    <details open class="govuk-details" data-module="govuk-details">
+        <summary class="govuk-details__summary">
+            <span class="govuk-details__summary-text">
+                Transfer reference
+            </span>
+        </summary>
+        <div class="govuk-details__text">
+            @consignmentRef
+        </div>
+    </details>
+</div>

--- a/test/controllers/FileChecksControllerSpec.scala
+++ b/test/controllers/FileChecksControllerSpec.scala
@@ -4,7 +4,6 @@ import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock.{containing, okJson, post, urlEqualTo}
 import configuration.GraphQLConfiguration
 import graphql.codegen.GetFileCheckProgress.{getFileCheckProgress => fileCheck}
-import graphql.codegen.GetConsignmentReference.{getConsignmentReference => gcr}
 import io.circe.Printer
 import io.circe.generic.auto._
 import io.circe.syntax._
@@ -67,7 +66,7 @@ class FileChecksControllerSpec extends FrontEndTestHelper with TableDrivenProper
         val dataString: String = progressData(filesProcessedWithAntivirus, filesProcessedWithChecksum, filesProcessedWithFFID, allChecksSucceeded = false)
 
         mockGraphqlResponse(dataString, userType)
-        setConsignmentReferenceResponse()
+        setConsignmentReferenceResponse(wiremockServer)
 
         val recordsController = new FileChecksController(
           getAuthorisedSecurityComponents,
@@ -224,16 +223,5 @@ class FileChecksControllerSpec extends FrontEndTestHelper with TableDrivenProper
     )
     val dataString: String = data.asJson.printWith(Printer(dropNullValues = false, ""))
     dataString
-  }
-
-  private def setConsignmentReferenceResponse() = {
-    val client = new GraphQLConfiguration(app.configuration).getClient[gcr.Data, gcr.Variables]()
-    val consignmentReferenceResponse: gcr.GetConsignment = new gcr.GetConsignment("TEST-TDR-2021-GB")
-    val data: client.GraphqlData = client.GraphqlData(Some(gcr.Data(Some(consignmentReferenceResponse))), List())
-    val dataString: String = data.asJson.printWith(Printer(dropNullValues = false, ""))
-
-    wiremockServer.stubFor(post(urlEqualTo("/graphql"))
-      .withRequestBody(containing("getConsignmentReference"))
-      .willReturn(okJson(dataString)))
   }
 }

--- a/test/controllers/TransferCompleteControllerSpec.scala
+++ b/test/controllers/TransferCompleteControllerSpec.scala
@@ -1,23 +1,17 @@
 package controllers
 
-import java.util.UUID
 import com.github.tomakehurst.wiremock.WireMockServer
-import com.github.tomakehurst.wiremock.client.WireMock.{containing, okJson, post, urlEqualTo}
-import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import configuration.GraphQLConfiguration
-import io.circe.Printer
 import org.pac4j.play.scala.SecurityComponents
+import play.api.http.Status.FORBIDDEN
+import play.api.mvc.Result
 import play.api.test.CSRFTokenHelper.CSRFRequest
 import play.api.test.FakeRequest
 import play.api.test.Helpers.{GET, contentAsString, defaultAwaitTimeout, status}
 import services.ConsignmentService
 import util.FrontEndTestHelper
-import graphql.codegen.GetConsignmentReference.{getConsignmentReference => gcr}
-import io.circe.syntax.EncoderOps
-import io.circe.generic.auto._
-import play.api.http.Status.FORBIDDEN
-import play.api.mvc.Result
 
+import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
 
 class TransferCompleteControllerSpec extends FrontEndTestHelper {
@@ -40,7 +34,7 @@ class TransferCompleteControllerSpec extends FrontEndTestHelper {
 
   "TransferCompleteController GET" should {
     "render the success page if the export was triggered successfully" in {
-      setConsignmentReferenceResponse()
+      setConsignmentReferenceResponse(wiremockServer)
       val transferCompleteSubmit = callTransferComplete("consignment")
       contentAsString(transferCompleteSubmit) must include("Transfer complete")
       contentAsString(transferCompleteSubmit) must include("TEST-TDR-2021-GB")
@@ -52,7 +46,7 @@ class TransferCompleteControllerSpec extends FrontEndTestHelper {
     }
 
     "render the success page if the export was triggered successfully for a judgment user" in {
-      setConsignmentReferenceResponse()
+      setConsignmentReferenceResponse(wiremockServer)
       val transferCompleteSubmit = callTransferComplete("judgment")
       contentAsString(transferCompleteSubmit) must include("Transfer complete")
       contentAsString(transferCompleteSubmit) must include("TEST-TDR-2021-GB")
@@ -68,7 +62,7 @@ class TransferCompleteControllerSpec extends FrontEndTestHelper {
   forAll(userChecks) { (_, url) =>
     s"The $url upload page" should {
       s"return 403 if the url doesn't match the consignment type" in {
-        setConsignmentReferenceResponse()
+        setConsignmentReferenceResponse(wiremockServer)
         val controller = instantiateTransferCompleteController(getAuthorisedSecurityComponents, url)
         val consignmentId = UUID.randomUUID()
         setConsignmentTypeResponse(wiremockServer, url)
@@ -85,17 +79,6 @@ class TransferCompleteControllerSpec extends FrontEndTestHelper {
         status(transferCompleteSubmit) mustBe FORBIDDEN
       }
     }
-  }
-
-  private def setConsignmentReferenceResponse(): StubMapping = {
-    val client = new GraphQLConfiguration(app.configuration).getClient[gcr.Data, gcr.Variables]()
-    val consignmentReferenceResponse: gcr.GetConsignment = new gcr.GetConsignment("TEST-TDR-2021-GB")
-    val data: client.GraphqlData = client.GraphqlData(Some(gcr.Data(Some(consignmentReferenceResponse))), List())
-    val dataString: String = data.asJson.printWith(Printer(dropNullValues = false, ""))
-
-    wiremockServer.stubFor(post(urlEqualTo("/graphql"))
-      .withRequestBody(containing("getConsignmentReference"))
-      .willReturn(okJson(dataString)))
   }
 
   private def instantiateTransferCompleteController(securityComponents: SecurityComponents, path: String) = {

--- a/test/controllers/UploadControllerSpec.scala
+++ b/test/controllers/UploadControllerSpec.scala
@@ -5,6 +5,7 @@ import com.github.tomakehurst.wiremock.client.WireMock.{containing, okJson, post
 import configuration.GraphQLConfiguration
 import graphql.codegen.GetConsignmentStatus.getConsignmentStatus.GetConsignment.CurrentStatus
 import graphql.codegen.GetConsignmentStatus.{getConsignmentStatus => gcs}
+import graphql.codegen.GetConsignmentReference.{getConsignmentReference => gcr}
 import io.circe.Printer
 import io.circe.generic.auto._
 import io.circe.syntax._
@@ -153,6 +154,7 @@ class UploadControllerSpec extends FrontEndTestHelper {
       val controller = new UploadController(getAuthorisedSecurityComponents,
         graphQLConfiguration, getValidJudgmentUserKeycloakConfiguration, frontEndInfoConfiguration, consignmentService)
 
+      setConsignmentReferenceResponse()
       stubGetConsignmentStatusResponse()
       setConsignmentTypeResponse(wiremockServer, "judgment")
 
@@ -165,6 +167,7 @@ class UploadControllerSpec extends FrontEndTestHelper {
       uploadPageAsString must include("Upload judgment")
       uploadPageAsString must include("You may now upload the judgment you wish to transfer. You can only upload one file.")
       uploadPageAsString must include (s"""" href="/judgment/faq">""")
+      uploadPageAsString must include ("TEST-TDR-2021-GB")
     }
 
     "render the judgment upload in progress page if the upload is in progress" in {
@@ -176,6 +179,7 @@ class UploadControllerSpec extends FrontEndTestHelper {
 
       stubGetConsignmentStatusResponse(transferAgreementStatus = Some("Completed"), uploadStatus = Some("InProgress"))
       setConsignmentTypeResponse(wiremockServer, "judgment")
+      setConsignmentReferenceResponse()
 
       val uploadPage = controller.judgmentUploadPage(consignmentId)
         .apply(FakeRequest(GET, s"/judgment/$consignmentId/upload").withCSRFToken)
@@ -185,6 +189,7 @@ class UploadControllerSpec extends FrontEndTestHelper {
       uploadPageAsString must include("Uploading judgment")
       uploadPageAsString must include("Your upload was interrupted and could not be completed.")
       uploadPageAsString must include (s"""" href="/judgment/faq">""")
+//      uploadPageAsString must include ("TEST-TDR-2021-GB")
     }
 
     "render the judgment upload is complete page if the upload has completed" in {
@@ -196,6 +201,7 @@ class UploadControllerSpec extends FrontEndTestHelper {
 
       stubGetConsignmentStatusResponse(transferAgreementStatus = Some("Completed"), uploadStatus = Some("Completed"))
       setConsignmentTypeResponse(wiremockServer, "judgment")
+      setConsignmentReferenceResponse()
 
       val uploadPage = controller.judgmentUploadPage(consignmentId)
         .apply(FakeRequest(GET, s"/judgment/$consignmentId/upload").withCSRFToken)
@@ -209,6 +215,7 @@ class UploadControllerSpec extends FrontEndTestHelper {
            |        Continue
            |      </a>""".stripMargin)
       uploadPageAsString must include (s"""" href="/judgment/faq">""")
+//      uploadPageAsString must include (consignmentRef)
     }
   }
 
@@ -315,5 +322,16 @@ class UploadControllerSpec extends FrontEndTestHelper {
 
   private def removeNewLinesAndIndentation(formattedJsonBody: String) = {
     formattedJsonBody.replaceAll("\n\\s*", "")
+  }
+
+  private def setConsignmentReferenceResponse() = {
+    val client = new GraphQLConfiguration(app.configuration).getClient[gcr.Data, gcr.Variables]()
+    val consignmentReferenceResponse: gcr.GetConsignment = new gcr.GetConsignment("TEST-TDR-2021-GB")
+    val data: client.GraphqlData = client.GraphqlData(Some(gcr.Data(Some(consignmentReferenceResponse))), List())
+    val dataString: String = data.asJson.printWith(Printer(dropNullValues = false, ""))
+
+    wiremockServer.stubFor(post(urlEqualTo("/graphql"))
+      .withRequestBody(containing("getConsignmentReference"))
+      .willReturn(okJson(dataString)))
   }
 }

--- a/test/util/FrontEndTestHelper.scala
+++ b/test/util/FrontEndTestHelper.scala
@@ -65,6 +65,13 @@ trait FrontEndTestHelper extends PlaySpec with MockitoSugar with Injecting with 
       .willReturn(okJson(dataString)))
   }
 
+  def setConsignmentReferenceResponse(wiremockServer: WireMockServer, consignmentRef: String = "TEST-TDR-2021-GB"): StubMapping = {
+    val dataString = s"""{"data": {"getConsignment": {"consignmentReference": "$consignmentRef"}}}"""
+    wiremockServer.stubFor(post(urlEqualTo("/graphql"))
+      .withRequestBody(containing("getConsignmentReference"))
+      .willReturn(okJson(dataString)))
+  }
+
   val userChecks: TableFor2[KeycloakConfiguration, String] = Table(
     ("user", "url"),
     (getValidJudgmentUserKeycloakConfiguration, "consignment"),


### PR DESCRIPTION
I have added the consignment reference to all the pages attached in this [story](https://national-archives.atlassian.net/browse/TDR-1838).
There are some other pages I am not sure whether it should have the consignment reference or not such as:

- UploadInProgress (Your upload was interrupted and could not be completed)
- Upload Completed page (When you go back after already finishing an upload)
- FileCheckProgressAlreadyConfirmed
- File-Checks completed page