### PR TITLE
dependency updates

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0
 dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-databind" % "2.11.4" % Test
 
 val playPac4jVersion = "11.1.0-PLAY2.8"
-val pac4jVersion = "5.4.2"
+val pac4jVersion = "5.4.3"
 val akkaVersion = "2.6.3"
 val sttpVersion = "2.3.0"
 
@@ -32,7 +32,7 @@ libraryDependencies ++= Seq(
   "com.softwaremill.sttp.client" %% "core" % sttpVersion,
   "com.softwaremill.sttp.client" %% "circe" % sttpVersion,
   "com.softwaremill.sttp.client" %% "async-http-client-backend-future" % sttpVersion,
-  "uk.gov.nationalarchives" %% "tdr-graphql-client" % "0.0.24",
+  "uk.gov.nationalarchives" %% "tdr-graphql-client" % "0.0.25",
   "uk.gov.nationalarchives" %% "tdr-auth-utils" % "0.0.42",
   "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.234",
   ws,

--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ libraryDependencies ++= Seq(
   "com.softwaremill.sttp.client" %% "circe" % sttpVersion,
   "com.softwaremill.sttp.client" %% "async-http-client-backend-future" % sttpVersion,
   "uk.gov.nationalarchives" %% "tdr-graphql-client" % "0.0.25",
-  "uk.gov.nationalarchives" %% "tdr-auth-utils" % "0.0.42",
+  "uk.gov.nationalarchives" %% "tdr-auth-utils" % "0.0.45",
   "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.234",
   ws,
   "com.github.tomakehurst" % "wiremock-jre8" % "2.33.1" % Test,


### PR DESCRIPTION
- Update tdr-generated-graphql to 0.0.234
- Update wiremock-jre8 to 2.33.1
- Update pac4j-http, pac4j-oidc to 5.4.3
- Update tdr-graphql-client to 0.0.25
