### PR TITLE
Add generated email for error page link

### DIFF
--- a/app/views/partials/fileCheckGenericErrorMessage.scala.html
+++ b/app/views/partials/fileCheckGenericErrorMessage.scala.html
@@ -1,7 +1,7 @@
 <p class="govuk-body">
     One or more files you uploaded have failed our checks. Please
-    <a class="govuk-link" href="@routes.ContactController.contact()">contact</a>
-    us to resolve this issue.
+    <a class="govuk-link" href="mailto:tdr@@nationalachives.gov.uk?subject=Problem with Results of checks">Contact us</a>
+    to resolve this issue.
 </p>
 <p class="govuk-body">Possible failure causes:</p>
 <ul class="govuk-list govuk-list--bullet">


### PR DESCRIPTION
There is also an email Link on the error page for judgments but as the story only mentions the error page for standard user I have only included those changes.