### PR TITLE
Add GET route for judgment homepage

### DIFF
--- a/app/controllers/HomepageController.scala
+++ b/app/controllers/HomepageController.scala
@@ -8,7 +8,7 @@ import play.api.mvc.{Action, AnyContent, Request}
 import services.ConsignmentService
 
 import javax.inject.{Inject, Singleton}
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class HomepageController @Inject()(val controllerComponents: SecurityComponents,
@@ -32,12 +32,18 @@ class HomepageController @Inject()(val controllerComponents: SecurityComponents,
 
   def homepage(): Action[AnyContent] = secureAction { implicit request: Request[AnyContent] => {
       if (request.token.isJudgmentUser) {
-        Ok(views.html.judgment.judgmentHomepage(request.token.name))
+        Redirect(routes.HomepageController.judgmentHomepage())
       } else if(request.token.isStandardUser){
         Ok(views.html.standard.homepage(request.token.name))
       } else {
         Ok(views.html.registrationComplete(request.token.name))
       }
+    }
+  }
+
+  def judgmentHomepage(): Action[AnyContent] = judgmentUserAction {
+    implicit request: Request[AnyContent] => {
+      Future(Ok(views.html.judgment.judgmentHomepage(request.token.name)))
     }
   }
 }

--- a/conf/routes
+++ b/conf/routes
@@ -39,6 +39,7 @@ GET         /sign-out                                                      @org.
 
 # Routes for judgment
 GET         /judgment/faq                                                  controllers.FaqController.judgmentFaq()
+GET         /judgment/homepage                                             controllers.HomepageController.judgmentHomepage()
 POST        /judgment/homepage                                             controllers.HomepageController.judgmentHomepageSubmit()
 GET         /judgment/help                                                 controllers.HelpController.judgmentHelp()
 GET         /judgment/:consignmentId/before-uploading                      controllers.BeforeUploadingController.beforeUploading(consignmentId: java.util.UUID)

--- a/test/controllers/HomepageControllerSpec.scala
+++ b/test/controllers/HomepageControllerSpec.scala
@@ -84,6 +84,16 @@ class HomepageControllerSpec extends FrontEndTestHelper {
       contentAsString(homepagePage) must include (s"""" href="/judgment/help">""")
     }
 
+    "return a redirect to the judgment homepage page with an authenticated judgment" in {
+      val controller = new HomepageController(
+        getAuthorisedSecurityComponents,
+        getValidJudgmentUserKeycloakConfiguration,
+        consignmentService)
+      val homepagePage = controller.homepage().apply(FakeRequest(GET, "/homepage").withCSRFToken)
+      status(homepagePage) mustBe SEE_OTHER
+      redirectLocation(homepagePage) must be(Some(s"/judgment/homepage"))
+    }
+
     "return a redirect to the auth server with an unauthenticated user" in {
       val controller = new HomepageController(
         getUnauthorisedSecurityComponents,

--- a/test/controllers/HomepageControllerSpec.scala
+++ b/test/controllers/HomepageControllerSpec.scala
@@ -71,7 +71,7 @@ class HomepageControllerSpec extends FrontEndTestHelper {
         getAuthorisedSecurityComponents,
         getValidJudgmentUserKeycloakConfiguration,
         consignmentService)
-      val homepagePage = controller.homepage().apply(FakeRequest(GET, "/homepage").withCSRFToken)
+      val homepagePage = controller.judgmentHomepage().apply(FakeRequest(GET, "/judgment/homepage").withCSRFToken)
       status(homepagePage) mustBe OK
       contentType(homepagePage) mustBe Some("text/html")
 


### PR DESCRIPTION
When the users session expires and they try to click the start transfer button they are directed to /judgment/homepage as a GET request but this route does not exist as a GET request but rather a POST request. This PR adds this route and makes sure the url is displayed correctly for judgment homepage.