### PR TITLE
Read auth url from environment variable.

### DIFF
--- a/app/configuration/KeycloakConfiguration.scala
+++ b/app/configuration/KeycloakConfiguration.scala
@@ -8,7 +8,7 @@ import scala.concurrent.ExecutionContext
 
 class KeycloakConfiguration @Inject ()(configuration: Configuration)(implicit val executionContext: ExecutionContext) {
   def token(value: String): Option[Token] = {
-    implicit val tdrKeycloakDeployment: TdrKeycloakDeployment = TdrKeycloakDeployment(s"${configuration.get[String]("auth.url")}/auth", "tdr", 3600)
+    implicit val tdrKeycloakDeployment: TdrKeycloakDeployment = TdrKeycloakDeployment(s"${configuration.get[String]("auth.url")}", "tdr", 3600)
     KeycloakUtils().token(value).toOption
   }
 }

--- a/app/controllers/KeycloakConfigurationController.scala
+++ b/app/controllers/KeycloakConfigurationController.scala
@@ -18,7 +18,7 @@ class KeycloakConfigurationController @Inject ()(val controllerComponents: Secur
   def keycloak: Action[AnyContent] = secureAction { implicit request: Request[AnyContent] =>
     val authUrl = configuration.get[String]("auth.url")
     Ok(Json.obj(
-      "auth-server-url" -> s"$authUrl/auth",
+      "auth-server-url" -> s"$authUrl",
       "resource" -> "tdr-fe",
       "realm" -> "tdr",
       "ssl-required" -> "external"))

--- a/app/modules/SecurityModule.scala
+++ b/app/modules/SecurityModule.scala
@@ -50,7 +50,7 @@ class SecurityModule extends AbstractModule {
     val callback = configuration.get[String]("auth.callback")
     val secret = configuration.get[String]("auth.secret")
     oidcConfiguration.setSecret(secret)
-    oidcConfiguration.setDiscoveryURI(s"$authUrl/auth/realms/tdr/.well-known/openid-configuration")
+    oidcConfiguration.setDiscoveryURI(s"$authUrl/realms/tdr/.well-known/openid-configuration")
     oidcConfiguration.setPreferredJwsAlgorithm(JWSAlgorithm.RS256)
     // Setting this causes pac4j to get a new access token using the refresh token when the original access token expires
     oidcConfiguration.setExpireSessionWithToken(true)

--- a/conf/application.base.conf
+++ b/conf/application.base.conf
@@ -5,6 +5,7 @@ akka.actor.allow-java-serialization = "on"
 akka.actor.warn-about-java-serializer-usage = "off"
 
 auth.secret = ${AUTH_SECRET}
+auth.url=${AUTH_URL}
 
 consignmentapi.url = ${consignmentapi.domain}"/graphql"
 
@@ -36,9 +37,9 @@ play {
     # dependency which uses it. See TDR-1002.
     script-src = ${play.filters.csp.nonce.pattern} 'unsafe-eval'
     # Allow scripts to fetch data from TDR domains and AWS domains
-    connect-src = 'self' ${upload.url} ${auth.url} ${consignmentapi.domain}
+    connect-src = 'self' ${upload.url} ${auth.domain} ${consignmentapi.domain}
     # Allow browser to load Keycloak iframe to support the OAuth2 silent authentication flow
-    child-src = 'self' ${auth.url}
+    child-src = 'self' ${auth.domain}
   }
 }
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -2,7 +2,7 @@
 
 include "application.local-base"
 
-auth.url="https://auth.tdr-integration.nationalarchives.gov.uk"
+auth.domain="auth.tdr-integration.nationalarchives.gov.uk"
 
 upload.url="https://upload.tdr-integration.nationalarchives.gov.uk"
 

--- a/conf/application.intg.conf
+++ b/conf/application.intg.conf
@@ -3,7 +3,7 @@ include "application.base"
 # https://www.playframework.com/documentation/latest/Configuration
 play.http.secret.key=${PLAY_SECRET_KEY}
 
-auth.url="https://auth.tdr-integration.nationalarchives.gov.uk"
+auth.domain="auth.tdr-integration.nationalarchives.gov.uk"
 auth.callback="https://tdr-integration.nationalarchives.gov.uk/callback"
 
 consignmentapi.domain="https://api.tdr-integration.nationalarchives.gov.uk"

--- a/conf/application.local-full-stack.conf
+++ b/conf/application.local-full-stack.conf
@@ -3,7 +3,7 @@
 
 include "application.local-base"
 
-auth.url="http://localhost:8081"
+auth.domain="localhost:8081"
 
 s3.endpointOverride="http://localhost:9444/s3"
 

--- a/conf/application.prod.conf
+++ b/conf/application.prod.conf
@@ -3,7 +3,7 @@ include "application.base"
 # https://www.playframework.com/documentation/latest/Configuration
 play.http.secret.key=${PLAY_SECRET_KEY}
 
-auth.url="https://auth.tdr.nationalarchives.gov.uk"
+auth.domain="auth.tdr.nationalarchives.gov.uk"
 auth.callback="https://tdr.nationalarchives.gov.uk/callback"
 
 consignmentapi.domain="https://api.tdr.nationalarchives.gov.uk"

--- a/conf/application.staging.conf
+++ b/conf/application.staging.conf
@@ -3,7 +3,7 @@ include "application.base"
 # https://www.playframework.com/documentation/latest/Configuration
 play.http.secret.key=${PLAY_SECRET_KEY}
 
-auth.url="https://auth.tdr-staging.nationalarchives.gov.uk"
+auth.domain="auth.tdr-staging.nationalarchives.gov.uk"
 auth.callback="https://tdr-staging.nationalarchives.gov.uk/callback"
 
 consignmentapi.domain="https://api.tdr-staging.nationalarchives.gov.uk"

--- a/test/controllers/KeycloakConfigurationControllerSpec.scala
+++ b/test/controllers/KeycloakConfigurationControllerSpec.scala
@@ -17,7 +17,7 @@ class KeycloakConfigurationControllerSpec extends FrontEndTestHelper {
       doAnswer(_ => authUrl).when(configuration).get[String]("auth.url")
       val controller = new KeycloakConfigurationController(getAuthorisedSecurityComponents, configuration)
       val expectedResult: JsValue = Json.obj(
-        "auth-server-url" -> s"$authUrl/auth",
+        "auth-server-url" -> s"$authUrl",
         "resource" -> "tdr-fe",
         "realm" -> "tdr",
         "ssl-required" -> "external")

--- a/test/resources/application.conf
+++ b/test/resources/application.conf
@@ -1,6 +1,7 @@
 # https://www.playframework.com/documentation/latest/Configuration
 play.http.port=9000
 
+auth.domain="localhost:9005"
 auth.url="http://localhost:9005"
 auth.callback="http://localhost:9000/callback"
 auth.secret="f5d12779-2927-4992-a7cf-77358cf42e20"


### PR DESCRIPTION
I've changed this so when Keycloak is upgraded I can change the auth url
just by running terraform.

I've tried this locally and it's ok.
https://github.com/nationalarchives/tdr-terraform-environments/pull/223
will need to be merged first.
