### PR TITLE
Set the max length of a post body

### DIFF
--- a/conf/application.base.conf
+++ b/conf/application.base.conf
@@ -47,3 +47,5 @@ play {
 }
 
 region = "eu-west-2"
+
+parsers.text.maxLength=1M


### PR DESCRIPTION
We're getting a 413 error for some consignments with large files. The
default max size for a POST request is 100Kb, this makes it 1M. We can
tweak it if it causes problems.
