### PR TITLE
Add a check to each 'input' view for whether it's on a dynamic form

### DIFF
--- a/app/views/partials/inputDate.scala.html
+++ b/app/views/partials/inputDate.scala.html
@@ -3,7 +3,8 @@ dateInputHeading: String,
 dateInputHint: String,
 dateOptions: Seq[(String, String)],
 enteredDateOptions: Option[Seq[(String, String)]],
-fieldError: List[String])(implicit messages: Messages)
+fieldError: List[String],
+attributes: Map[Symbol, Any]=Map())(implicit messages: Messages)
 
 @import views.html.partials.errorMessage
 
@@ -17,6 +18,7 @@ fieldError: List[String])(implicit messages: Messages)
         )
     }
 }
+@isDynamicForm = @{attributes.getOrElse(Symbol("_dynamicForm"), false).asInstanceOf[Boolean]}
 
 <div class="govuk-form-group @{if(fieldError.nonEmpty) "govuk-form-group--error" else ""}">
     <fieldset class="govuk-fieldset" role="group" aria-describedby="date-input-hint">
@@ -46,7 +48,7 @@ fieldError: List[String])(implicit messages: Messages)
                                       ) "govuk-input--error" else ""
                                       }"
                                id="date-input-@{dateOption.toLowerCase()}"
-                               name="inputdate-@fieldId-@dateOption.toLowerCase()"
+                               name="@{if(isDynamicForm) s"inputdate-$fieldId-${dateOption.toLowerCase()}" else fieldId}"
                                value="@value"
                                type="number"
                                inputmode="numeric"

--- a/app/views/partials/inputRadioGroup.scala.html
+++ b/app/views/partials/inputRadioGroup.scala.html
@@ -1,4 +1,4 @@
-@(fieldId: String,
+@(fieldName: String,
 radioOptions: Seq[(String, String)],
 selectedRadioOption: Seq[(String, String)],
 attributes: Map[Symbol, Any],
@@ -11,6 +11,8 @@ fieldError: List[String]
 @isDisabled = {@attributes.get(Symbol("_disabledOption"))}
 @radioOptionsSize = @{if(attributes.get(Symbol("_largeOption")).contains(true)) "" else "govuk-radios--small"}
 @optionSize = @{if(attributes.get(Symbol("_newlineOption")).contains(true)) "" else "govuk-radios--inline"}
+@isDynamicForm = @{attributes.getOrElse(Symbol("_dynamicForm"), false).asInstanceOf[Boolean]}
+@fieldId = @{if(isDynamicForm) s"inputradio-$fieldName" else fieldName}
 
 <div class="govuk-form-group @{if(fieldError.nonEmpty) "govuk-form-group--error" else ""}">
     <fieldset class="govuk-fieldset">
@@ -24,7 +26,7 @@ fieldError: List[String]
                 <input
                         class="govuk-radios__input"
                         id="@fieldId-@value"
-                        name="inputradio-@fieldId"
+                        name="@fieldId"
                         type="radio"
                         value="@value"
                         @isDisabled

--- a/app/views/partials/inputSingleCheckbox.scala.html
+++ b/app/views/partials/inputSingleCheckbox.scala.html
@@ -1,4 +1,4 @@
-@(fieldId: String,
+@(fieldName: String,
 attributes: Map[Symbol, Any],
 fieldError: Seq[String]
 )(implicit messages: Messages)
@@ -11,7 +11,8 @@ fieldError: Seq[String]
 @disabledStatus = {@attributes.get(Symbol("_disabledOption"))}
 @checkedStatus = {@attributes.get(Symbol("_checkedOption"))}
 @isSmallCheckbox = {@attributes.get(Symbol("_smallCheckbox"))}
-
+@isDynamicForm = @{attributes.getOrElse(Symbol("_dynamicForm"), false).asInstanceOf[Boolean]}
+@fieldId = @{if(isDynamicForm) s"inputcheckbox-$fieldName" else fieldName}
     <div class="govuk-checkboxes @{if(fieldError.nonEmpty) "govuk-form-group--error" else ""}">
         @errorMessage(fieldId, fieldError)
         <div class='govuk-checkboxes__item@if(isSmallCheckbox.toString() == "true"){ govuk-checkboxes--small}'>
@@ -19,7 +20,7 @@ fieldError: Seq[String]
                 @checkedStatus
                 class="govuk-checkboxes__input"
                 id="@fieldId"
-                name="inputcheckbox-@fieldId"
+                name="@fieldId"
                 type="checkbox"
                 value="@value"
                 @disabledStatus />

--- a/app/views/partials/inputText.scala.html
+++ b/app/views/partials/inputText.scala.html
@@ -4,9 +4,11 @@ inputTextHint: String,
 fieldOptions: Seq[(String, String)],
 inputType: String,
 fieldError: Seq[String],
+attributes: Map[Symbol, Any]=Map(),
 inputTextDataType: String="text")(implicit messages: Messages)
 @suffixText = @{fieldOptions.head._1}
 @defaultText = @{fieldOptions.head._2}
+@isDynamicForm = @{attributes.getOrElse(Symbol("_dynamicForm"), false).asInstanceOf[Boolean]}
 
 @import views.html.partials.errorMessage
 
@@ -24,11 +26,11 @@ inputTextDataType: String="text")(implicit messages: Messages)
         <div class="govuk-input__wrapper">
             <input
                 class="govuk-input govuk-input--width-5 @{if(fieldError.nonEmpty)"govuk-input--error" else ""}"
-                id=@suffixText
-                name=input@inputTextDataType-@fieldId-@suffixText.toLowerCase()
-                type=@inputType
-                placeholder=@defaultText
-                inputmode=@inputTextDataType
+                id="@suffixText"
+                name="@{if(isDynamicForm) s"input$inputTextDataType-$fieldId-${suffixText.toLowerCase()}" else fieldId}"
+                type="@inputType"
+                placeholder="@defaultText"
+                inputmode="@inputTextDataType"
             >
             <div class="govuk-input__suffix" aria-hidden="true">@suffixText</div>
         </div>

--- a/app/views/standard/addClosureMetadata.scala.html
+++ b/app/views/standard/addClosureMetadata.scala.html
@@ -39,7 +39,8 @@
                                     Symbol("_requiredOption") -> fieldToApplyToFile.fieldRequired,
                                     Symbol("_largeOption") -> true,
                                     Symbol("_newlineOption") -> true,
-                                    Symbol("_disabledOption") -> ""
+                                    Symbol("_disabledOption") -> "",
+                                    Symbol("_dynamicForm") -> true
                                 ),
                                 fieldToApplyToFile.fieldError
                             )
@@ -49,7 +50,8 @@
                                 fieldToApplyToFile.fieldHint,
                                 fieldToApplyToFile.fieldOptions,
                                 fieldToApplyToFile.selectedFieldOption,
-                                fieldToApplyToFile.fieldError
+                                fieldToApplyToFile.fieldError,
+                                Map(Symbol("_dynamicForm") -> true)
                             )
                             case "Decimal" | "Integer" => inputText(
                                 fieldToApplyToFile.fieldId,
@@ -58,6 +60,7 @@
                                 fieldToApplyToFile.fieldOptions,
                                 "number",
                                 fieldToApplyToFile.fieldError,
+                                Map(Symbol("_dynamicForm") -> true),
                                 "numeric"
                             )
                             case "Text" =>
@@ -82,7 +85,8 @@
                                         fieldToApplyToFile.fieldHint,
                                         fieldToApplyToFile.fieldOptions,
                                         "text",
-                                        fieldToApplyToFile.fieldError
+                                        fieldToApplyToFile.fieldError,
+                                        Map(Symbol("_dynamicForm") -> true)
                                     )
                                 }
                         }

--- a/test/testUtils/FormTester.scala
+++ b/test/testUtils/FormTester.scala
@@ -69,7 +69,7 @@ class FormTester(options: Map[String, (String, String)], smallCheckbox: String="
        |                $checkedStatus
        |                class="govuk-checkboxes__input"
        |                id="$name"
-       |                name="inputcheckbox-$name"
+       |                name="$name"
        |                type="checkbox"
        |                value="true"
        |                $disabledStatus />


### PR DESCRIPTION
A check has been added to each of the 'input' views; if it's a part of an dynamic page, then the
'name' attributes value will have the prefix 'input{inputtype}' else, it will just be the fieldId/fieldName
value that was passed in