### PR TITLE
Remove 'nhs design system' from pages

### DIFF
--- a/app/views/standard/additionalMetadataStart.scala.html
+++ b/app/views/standard/additionalMetadataStart.scala.html
@@ -10,24 +10,15 @@
         <h1 class="govuk-heading-l">Add, edit or delete metadata</h1>
         <h2 class="govuk-heading-s">Folder uploaded: @parentFolder</h2>
         <p class="govuk-body">You can now add or edit closure and descriptive metadata to your records. Or you can proceed without by clicking ‘Continue’ at the bottom of this page.</p>
+        <h2 class="govuk-heading-s">
+          <a class="govuk-link" href="#">Descriptive metadata</a>
+        </h2>
+        <p class="govuk-body">If you'd like to add or edit descriptive metadata to your records, you can do so here.</p>
+        <h2 class="govuk-heading-s">
+          <a class="govuk-link" href="#">Closure metadata</a>
+        </h2>
+        <p class="govuk-body">If you'd like to add or edit closure metadata to your records, you can do so here.</p>
 
-        <div class="nhsuk-card nhsuk-card--clickable">
-          <div class="nhsuk-card__content">
-            <h2 class="nhsuk-card__heading nhsuk-heading-m">
-              <a class="nhsuk-card__link" href="#">Descriptive metadata</a>
-            </h2>
-            <p class="nhsuk-card__description">If you'd like to add or edit descriptive metadata to your records, you can do so here.</p>
-          </div>
-        </div>
-        <p>
-        <div class="nhsuk-card nhsuk-card--clickable">
-          <div class="nhsuk-card__content">
-            <h2 class="nhsuk-card__heading nhsuk-heading-m">
-              <a class="nhsuk-card__link" href="#">Closure metadata</a>
-            </h2>
-            <p class="nhsuk-card__description">If you'd like to add or edit closure metadata to your records, you can do so here.</p>
-          </div>
-        </div>
         <a href="@routes.ConfirmTransferController.confirmTransfer(consignmentId)" role="button" draggable="false" class="govuk-button" data-module="govuk-button">
           Continue
         </a>

--- a/conf/application.base.conf
+++ b/conf/application.base.conf
@@ -41,8 +41,6 @@ play {
     connect-src = 'self' ${upload.url} ${auth.domain} ${consignmentapi.domain}
     # Allow browser to load Keycloak iframe to support the OAuth2 silent authentication flow
     child-src = 'self' ${auth.domain}
-    # Used for the card component on the additional metadata page.
-    font-src = "https://assets.nhs.uk"
   }
 }
 

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -19,7 +19,6 @@
         "graphql": "^16.5.0",
         "keycloak-js": "19.0.1",
         "minify": "^9.1.0",
-        "nhsuk-frontend": "^6.1.1",
         "npm-run-all": "^4.1.5",
         "sass": "^1.54.2",
         "ts-loader": "^9.3.1",
@@ -9047,11 +9046,6 @@
       "version": "2.6.2",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
-    },
-    "node_modules/nhsuk-frontend": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/nhsuk-frontend/-/nhsuk-frontend-6.1.1.tgz",
-      "integrity": "sha512-tDluQ3duklfB+LLgR2J0gBxJ6PVEUU9JQustW9LDw1u//gDXpeXE6+yMDk91ooaIEXGFQzXpln72N94r/Kr1AA=="
     },
     "node_modules/nice-try": {
       "version": "1.0.5",
@@ -19280,11 +19274,6 @@
       "version": "2.6.2",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
-    },
-    "nhsuk-frontend": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/nhsuk-frontend/-/nhsuk-frontend-6.1.1.tgz",
-      "integrity": "sha512-tDluQ3duklfB+LLgR2J0gBxJ6PVEUU9JQustW9LDw1u//gDXpeXE6+yMDk91ooaIEXGFQzXpln72N94r/Kr1AA=="
     },
     "nice-try": {
       "version": "1.0.5",

--- a/npm/package.json
+++ b/npm/package.json
@@ -51,7 +51,6 @@
     "graphql": "^16.5.0",
     "keycloak-js": "19.0.1",
     "minify": "^9.1.0",
-    "nhsuk-frontend": "^6.1.1",
     "npm-run-all": "^4.1.5",
     "sass": "^1.54.2",
     "ts-loader": "^9.3.1",

--- a/test/controllers/AdditionalMetadataControllerSpec.scala
+++ b/test/controllers/AdditionalMetadataControllerSpec.scala
@@ -60,10 +60,10 @@ class AdditionalMetadataControllerSpec extends FrontEndTestHelper {
         s"""        <p class="govuk-body">You can now add or edit closure and descriptive metadata to your records.""" +
            """ Or you can proceed without by clicking ‘Continue’ at the bottom of this page.</p>""".stripMargin) mustBe true
       startPageAsString.contains(
-        s"""            <p class="nhsuk-card__description">If you'd like to add or edit descriptive metadata""" +
+        s"""        <p class="govuk-body">If you'd like to add or edit descriptive metadata""" +
            """ to your records, you can do so here.</p>""") mustBe true
       startPageAsString.contains(
-        s"""            <p class="nhsuk-card__description">If you'd like to add or edit""" +
+        s"""        <p class="govuk-body">If you'd like to add or edit""" +
            """ closure metadata to your records, you can do so here.</p>""".stripMargin) mustBe true
       startPageAsString.contains(
         s"""        <a href="/consignment/$consignmentId/confirm-transfer" """ +
@@ -71,8 +71,8 @@ class AdditionalMetadataControllerSpec extends FrontEndTestHelper {
                                     |          Continue
                                     |        </a>""".stripMargin) mustBe true
       // Will change these links when we have the metadata pages to link them to.
-      startPageAsString.contains(s"""<a class="nhsuk-card__link" href="#">Descriptive metadata</a>""") mustBe true
-      startPageAsString.contains(s"""<a class="nhsuk-card__link" href="#">Closure metadata</a>""") mustBe true
+      startPageAsString.contains(s"""          <a class="govuk-link" href="#">Descriptive metadata</a>""") mustBe true
+      startPageAsString.contains(s"""          <a class="govuk-link" href="#">Closure metadata</a>""") mustBe true
     }
 
     "will return forbidden if the pages are accessed by a judgment user" in {

--- a/test/controllers/AdditionalMetadataControllerSpec.scala
+++ b/test/controllers/AdditionalMetadataControllerSpec.scala
@@ -58,7 +58,7 @@ class AdditionalMetadataControllerSpec extends FrontEndTestHelper {
       startPageAsString.contains(s"Closure metadata") mustBe true
       startPageAsString.contains(s"Continue") mustBe true
       // Will change these links when we have the metadata pages to link them to.
-      startPageAsString.contains(s"""<a class="nhsuk-card__link" href="#">""") mustBe true
+      startPageAsString.contains(s"""<a class="govuk-link" href="#">""") mustBe true
     }
 
     "will return forbidden if the pages are accessed by a judgment user" in {


### PR DESCRIPTION
The 'nhs design system' was causing override incompatabilties with the 'govuk design system' that was breaking the styling on other pages

Remove the 'nhs design system' and leave page with basic links for time being