### PR TITLE
Add logback dependencies.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,7 @@ libraryDependencies ++= Seq(
   "com.softwaremill.sttp.client" %% "async-http-client-backend-future" % sttpVersion,
   "uk.gov.nationalarchives" %% "tdr-graphql-client" % "0.0.48",
   "uk.gov.nationalarchives" %% "tdr-auth-utils" % "0.0.73",
-  "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.257",
+  "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.256",
   "ch.qos.logback" % "logback-classic" % "1.2.11",
   ws,
   "com.github.tomakehurst" % "wiremock-jre8" % "2.33.2" % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -34,12 +34,15 @@ libraryDependencies ++= Seq(
   "com.softwaremill.sttp.client" %% "async-http-client-backend-future" % sttpVersion,
   "uk.gov.nationalarchives" %% "tdr-graphql-client" % "0.0.48",
   "uk.gov.nationalarchives" %% "tdr-auth-utils" % "0.0.73",
-  "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.256",
+  "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.257",
+  "ch.qos.logback" % "logback-classic" % "1.2.11",
   ws,
   "com.github.tomakehurst" % "wiremock-jre8" % "2.33.2" % Test,
   "org.mockito" % "mockito-core" % "4.7.0" % Test,
   "org.scalatestplus" %% "mockito-3-4" % "3.2.10.0" % Test
 )
+
+disablePlugins(PlayLogback)
 scalacOptions ++= Seq("-language:implicitConversions")
 
 libraryDependencies += play.sbt.PlayImport.cacheApi


### PR DESCRIPTION
Something has happened with the logging in the front end. I don't know
what but it isn't outputting anything and slf4j is complaining so I've
disabled the built in logging and added an explicit dependency on
logback and it seems happy now.
