### PR TITLE
TDR-2287 Make filename not show glove icon on hover

### DIFF
--- a/npm/css-src/sass/main.scss
+++ b/npm/css-src/sass/main.scss
@@ -47,6 +47,10 @@ a {
   margin-bottom: 10px;
 }
 
+.govuk-checkboxes__label {
+  cursor: default;
+}
+
 .transfer-complete p {
   margin: 0;
 }


### PR DESCRIPTION
This makes it so that when you hover over the filenames you will no longer see a glove icon. Folders will still display glove icon.