### PR TITLE
Add validation to Radio buttons for completeness

### DIFF
--- a/app/controllers/util/DynamicFormUtils.scala
+++ b/app/controllers/util/DynamicFormUtils.scala
@@ -31,6 +31,7 @@ class DynamicFormUtils(request: Request[AnyContent], defaultFieldValues: List[Fo
           case radioButtonGroupField: RadioButtonGroupField =>
             val selectedOption = fieldValue.head._2.headOption.getOrElse("")
             radioButtonGroupField.copy(selectedOption = selectedOption)
+              .copy(fieldErrors = RadioButtonGroupField.validate(selectedOption, radioButtonGroupField).map(List(_)).getOrElse(Nil))
 
           case textField: TextField =>
             val text = fieldValue.head._2.head

--- a/app/controllers/util/FormField.scala
+++ b/app/controllers/util/FormField.scala
@@ -40,9 +40,18 @@ object FormField {
   val invalidDayError = "%s does not have %d days."
   val invalidDayForLeapYearError = "%s %d does not have %d days in it."
   val futureDateError = "%s date cannot be a future date."
+  val radioOptionNotSelectedError = "There was no value selected for %s."
+  val invalidRadioOptionSelectedError = "Option '%s' was not an option provided to the user."
 }
 
 object RadioButtonGroupField {
+
+  def validate(option: String, radioButtonGroupField: RadioButtonGroupField): Option[String] =
+    option match {
+      case "" => Some(radioOptionNotSelectedError.format(radioButtonGroupField.fieldName))
+      case value if !radioButtonGroupField.options.exists(_.value == value) => Some(invalidRadioOptionSelectedError.format(value))
+      case _ => None
+    }
 
   def update(radioButtonGroupField: RadioButtonGroupField, value: Boolean): RadioButtonGroupField =
     radioButtonGroupField.copy(selectedOption = if (value) "yes" else "no")

--- a/test/controllers/AddClosureMetadataControllerSpec.scala
+++ b/test/controllers/AddClosureMetadataControllerSpec.scala
@@ -24,7 +24,6 @@ import services.{ConsignmentService, CustomMetadataService}
 import testUtils.{CheckPageForStaticElements, FormTester, FrontEndTestHelper, MockInputOption}
 import uk.gov.nationalarchives.tdr.GraphQLClient
 
-import java.time.LocalDateTime
 import java.util.UUID
 import scala.concurrent.duration.Duration
 import scala.concurrent.{ExecutionContext, Future}
@@ -117,14 +116,14 @@ class AddClosureMetadataControllerSpec extends FrontEndTestHelper {
       id="inputradio-TitlePublic-Yes",
       value="yes",
       fieldType="inputRadio",
-      errorMessage=s"There was no value selected for Is Title Closed."
+      errorMessage=s"There was no value selected for Is the title closed?."
     ),
     MockInputOption(
       name="inputradio-TitlePublic",
       label="No",
       id="inputradio-TitlePublic-No",
       value="no",
-      errorMessage=s"There was no value selected for Is Title Closed.",
+      errorMessage=s"There was no value selected for Is the title closed?.",
       fieldType="inputRadio"
     )
   )
@@ -264,7 +263,7 @@ class AddClosureMetadataControllerSpec extends FrontEndTestHelper {
         ("inputdate-ClosureStartDate-year", ""),
         ("inputnumeric-ClosurePeriod-years", ""),
         ("inputdropdown-FoiExemptionCode", ""),
-        ("inputradio-TitlePublic", "yes")
+        ("inputradio-TitlePublic", "")
       )
 
       val addClosureMetadataPage = addClosureMetadataController.addClosureMetadataSubmit(consignmentId)

--- a/test/controllers/util/DynamicFormUtilsSpec.scala
+++ b/test/controllers/util/DynamicFormUtilsSpec.scala
@@ -93,7 +93,7 @@ class DynamicFormUtilsSpec extends AnyFlatSpec with MockitoSugar with BeforeAndA
       "inputdate-fieldidcontainsdaymonthyearoryears-year" -> List("2020"),
       "inputnumeric-fieldidcontainsdaymonthoryear-years" -> List("4"),
       "inputdropdown-fieldidendswithday" -> List("TestValue 3"),
-      "inputradio-fieldidendswithmonth" -> List("Yes"),
+      "inputradio-fieldidendswithmonth" -> List("yes"),
       "inputtext-fieldidendswithyear" -> List("Some Text"),
       "csrfToken" -> List("12345")
     )
@@ -309,7 +309,7 @@ case class MockFormValues(day: List[String] = List("3"),
                           year: List[String] = List("2021"),
                           numericTextBoxValue: List[String] = List("5"),
                           dropdownValue: List[String] = List("TestValue 3"),
-                          radioValue: List[String] = List("Yes"),
+                          radioValue: List[String] = List("yes"),
                           day2: List[String] = List("7"),
                           month2: List[String] = List("9"),
                           year2: List[String] = List("2022"),

--- a/test/testUtils/FormTester.scala
+++ b/test/testUtils/FormTester.scala
@@ -18,6 +18,7 @@ class FormTester(defaultOptions: List[MockInputOption], smallCheckbox: String=" 
 
     assert(checkIfCorrectOptionsWerePassedIntoForm(optionsSelected),
       s"\nThe option(s) selected ${optionsSelected.keys.mkString(", ")}, do not match the options passed into this class")
+    val optionNames: Seq[String] = defaultOptions.map(_.name)
     defaultOptions.foreach {
       defaultOption =>
         val (htmlErrorSummary, htmlErrorMessage) = generateErrorMessages(defaultOption)
@@ -40,8 +41,8 @@ class FormTester(defaultOptions: List[MockInputOption], smallCheckbox: String=" 
               val expectedHtmlForOption = addValuesToAttributes(defaultOption, defaultOption.value, hasDependency=hasErrorDependency)
               val elementSelectedWasNotPlaceholder: Boolean = optionsSelected(defaultOption.name) != ""
               checkPageForElements(htmlAsString, expectedHtmlForOption, htmlErrorSummary, htmlErrorMessage, elementSelected = elementSelectedWasNotPlaceholder)
-            } else {// either no option was submitted or no value entered (is an empty string)
-              val optionDoesNotBelongToAGroup = defaultOption.name != defaultOption.id
+            } else { // either no option was submitted or no value entered (is an empty string)
+              val optionDoesNotBelongToAGroup = optionNames.count(name => name == defaultOption.name) == 1
               val userHasRemovedDefaultValue = selectedValue == "" && defaultOption.value != selectedValue && optionDoesNotBelongToAGroup
               val value = if(userHasRemovedDefaultValue) selectedValue else defaultOption.value
               val expectedHtmlForOption = addValuesToAttributes(


### PR DESCRIPTION
Previously, radio buttons didn't have validation because on the closure metadata form, an option is always selected by default, but it just makes sense to have it for the future and also to check what would happen if a user sent us something unexpected via the form.