### PR TITLE
Make ESLint search within subfolders & fix ESLint errors

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -14,7 +14,7 @@
     "build-css": "npm-run-all add-stylesheet-dir sass-compile compress-css",
     "build:local": "npm-run-all copy-assets build-css build-ts:prod",
     "build": "npm-run-all copy-assets build-css build-ts:prod",
-    "lint": "eslint src/**/*.ts src/**/**/*.ts",
+    "lint": "eslint src --ext .ts",
     "stylelint": "npx stylelint **/*.scss",
     "test": "jest",
     "checks": "npm-run-all lint stylelint test",

--- a/npm/package.json
+++ b/npm/package.json
@@ -14,7 +14,7 @@
     "build-css": "npm-run-all add-stylesheet-dir sass-compile compress-css",
     "build:local": "npm-run-all copy-assets build-css build-ts:prod",
     "build": "npm-run-all copy-assets build-css build-ts:prod",
-    "lint": "eslint src/**/*.ts",
+    "lint": "eslint src/**/*.ts src/**/**/*.ts",
     "stylelint": "npx stylelint **/*.scss",
     "test": "jest",
     "checks": "npm-run-all lint stylelint test",

--- a/npm/src/upload/form/update-and-display-success-message.ts
+++ b/npm/src/upload/form/update-and-display-success-message.ts
@@ -1,8 +1,9 @@
 export const addFileSelectionSuccessMessage = (fileName: string) => {
+  // eslint-disable-next-line no-undef
   const fileNameElements: NodeListOf<Element> =
     document.querySelectorAll(".file-name")
   if (fileNameElements) {
-    fileNameElements.forEach(e => e.textContent = fileName)
+    fileNameElements.forEach((e) => (e.textContent = fileName))
   }
 }
 
@@ -10,14 +11,19 @@ export const addFolderSelectionSuccessMessage = (
   folderName: string,
   folderSize: number
 ) => {
+  // eslint-disable-next-line no-undef
   const folderNameElements: NodeListOf<Element> =
     document.querySelectorAll(".folder-name")
+  // eslint-disable-next-line no-undef
   const folderSizeElements: NodeListOf<Element> =
     document.querySelectorAll(".folder-size")
 
   if (folderNameElements && folderSizeElements) {
-    folderNameElements.forEach(e => e.textContent = folderName)
-    folderSizeElements.forEach(e => e.textContent = `${folderSize} ${folderSize === 1 ? "file" : "files"}`)
+    folderNameElements.forEach((e) => (e.textContent = folderName))
+    folderSizeElements.forEach(
+      (e) =>
+        (e.textContent = `${folderSize} ${folderSize === 1 ? "file" : "files"}`)
+    )
   }
 }
 
@@ -28,7 +34,9 @@ export const displaySelectionSuccessMessage = (
   }
 ) => {
   const selectionArea = document.querySelector("#selection-area")
-  const successMessageContainer: HTMLElement | null = document.querySelector("#item-selection-success-container")
+  const successMessageContainer: HTMLElement | null = document.querySelector(
+    "#item-selection-success-container"
+  )
 
   selectionArea?.classList.remove("govuk-form-group--error")
 

--- a/npm/src/upload/form/upload-form.ts
+++ b/npm/src/upload/form/upload-form.ts
@@ -146,7 +146,10 @@ export class UploadForm {
         return resultOrError
       }
     }
-    displaySelectionSuccessMessage(this.successAndRemovalMessageContainer, this.warningMessages)
+    displaySelectionSuccessMessage(
+      this.successAndRemovalMessageContainer,
+      this.warningMessages
+    )
     this.removeDragover()
   }
 
@@ -169,7 +172,10 @@ export class UploadForm {
       const parentFolder = this.getParentFolderName(this.selectedFiles)
       addFolderSelectionSuccessMessage(parentFolder, this.selectedFiles.length)
     }
-    displaySelectionSuccessMessage(this.successAndRemovalMessageContainer, this.warningMessages)
+    displaySelectionSuccessMessage(
+      this.successAndRemovalMessageContainer,
+      this.warningMessages
+    )
   }
 
   removeSelectedItem = (ev: Event): void => {
@@ -261,9 +267,8 @@ export class UploadForm {
     )
   }
 
-  readonly successAndRemovalMessageContainer: HTMLElement | null = document.querySelector(
-    "#success-and-removal-message-container"
-  )
+  readonly successAndRemovalMessageContainer: HTMLElement | null =
+    document.querySelector("#success-and-removal-message-container")
 
   private getParentFolderName(folder: IEntryWithPath[]) {
     const firstItem: IEntryWithPath = folder.filter((f) => isFile(f))[0]


### PR DESCRIPTION
When we were running 'npm run lint', it wasn't searching the subfolder of 'upload', so this should fix that