### PR TITLE
Fix auth issue

### DIFF
--- a/app/modules/SecurityModule.scala
+++ b/app/modules/SecurityModule.scala
@@ -2,6 +2,7 @@ package modules
 
 import com.google.inject.{AbstractModule, Provides}
 import com.nimbusds.jose.JWSAlgorithm
+import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod
 import configuration.CustomSavedRequestHandler
 import org.pac4j.core.client.Clients
 import org.pac4j.core.config.Config
@@ -9,7 +10,7 @@ import org.pac4j.core.context.session.SessionStore
 import org.pac4j.core.engine.{DefaultCallbackLogic, DefaultSecurityLogic}
 import org.pac4j.core.profile.CommonProfile
 import org.pac4j.oidc.client.OidcClient
-import org.pac4j.oidc.config.OidcConfiguration
+import org.pac4j.oidc.config.{OidcConfiguration, PrivateKeyJWTClientAuthnMethodConfig}
 import org.pac4j.play.scala.{DefaultSecurityComponents, Pac4jScalaTemplateHelper, SecurityComponents}
 import org.pac4j.play.store.PlayCacheSessionStore
 import org.pac4j.play.{CallbackController, LogoutController}
@@ -51,6 +52,7 @@ class SecurityModule extends AbstractModule {
     val secret = configuration.get[String]("auth.secret")
     oidcConfiguration.setSecret(secret)
     oidcConfiguration.setDiscoveryURI(s"$authUrl/realms/tdr/.well-known/openid-configuration")
+    oidcConfiguration.setClientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
     oidcConfiguration.setPreferredJwsAlgorithm(JWSAlgorithm.RS256)
     // Setting this causes pac4j to get a new access token using the refresh token when the original access token expires
     oidcConfiguration.setExpireSessionWithToken(true)

--- a/app/modules/SecurityModule.scala
+++ b/app/modules/SecurityModule.scala
@@ -10,7 +10,7 @@ import org.pac4j.core.context.session.SessionStore
 import org.pac4j.core.engine.{DefaultCallbackLogic, DefaultSecurityLogic}
 import org.pac4j.core.profile.CommonProfile
 import org.pac4j.oidc.client.OidcClient
-import org.pac4j.oidc.config.{OidcConfiguration, PrivateKeyJWTClientAuthnMethodConfig}
+import org.pac4j.oidc.config.OidcConfiguration
 import org.pac4j.play.scala.{DefaultSecurityComponents, Pac4jScalaTemplateHelper, SecurityComponents}
 import org.pac4j.play.store.PlayCacheSessionStore
 import org.pac4j.play.{CallbackController, LogoutController}


### PR DESCRIPTION
Set CLIENT_SECRET_BASIC authentication method explicitly as it was failing with the latest version (5.7.0) of pac4j.
If we don't set then it uses PRIVATE_KEY_JWT by default.