### PR TITLE
Version bump components

### DIFF
--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -12,7 +12,7 @@
         "@aws-sdk/client-s3": "^3.204.0",
         "@aws-sdk/lib-storage": "^3.85.0",
         "@nationalarchives/file-information": "^1.0.394",
-        "@nationalarchives/tdr-components": "1.0.0",
+        "@nationalarchives/tdr-components": "1.0.12",
         "@nationalarchives/tdr-generated-graphql": "1.0.299",
         "copyfiles": "^2.4.1",
         "events": "^3.3.0",
@@ -2948,9 +2948,9 @@
       }
     },
     "node_modules/@nationalarchives/tdr-components": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@nationalarchives/tdr-components/-/tdr-components-1.0.0.tgz",
-      "integrity": "sha512-U5BMhJPvQgqRo7mY6qeRltpUWP7GWEA4QaHFBYg2N6qXq2rr3RMZDAtxNxnHhCY+ixttMolG/I4gXp5LMijrVg==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@nationalarchives/tdr-components/-/tdr-components-1.0.12.tgz",
+      "integrity": "sha512-unTULGtZ8xo8Hwr9WiudyrNKuJIvZPEjYeniWa2t0MTxDdiQSEOibDtQONfo+2bO4ClnoQXfydfLRBv6mnQmvg==",
       "engines": {
         "node": ">= 4.2.0"
       },
@@ -15491,9 +15491,9 @@
       }
     },
     "@nationalarchives/tdr-components": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@nationalarchives/tdr-components/-/tdr-components-1.0.0.tgz",
-      "integrity": "sha512-U5BMhJPvQgqRo7mY6qeRltpUWP7GWEA4QaHFBYg2N6qXq2rr3RMZDAtxNxnHhCY+ixttMolG/I4gXp5LMijrVg==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@nationalarchives/tdr-components/-/tdr-components-1.0.12.tgz",
+      "integrity": "sha512-unTULGtZ8xo8Hwr9WiudyrNKuJIvZPEjYeniWa2t0MTxDdiQSEOibDtQONfo+2bO4ClnoQXfydfLRBv6mnQmvg==",
       "requires": {}
     },
     "@nationalarchives/tdr-generated-graphql": {

--- a/npm/package.json
+++ b/npm/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/client-s3": "^3.204.0",
     "@aws-sdk/lib-storage": "^3.85.0",
     "@nationalarchives/file-information": "^1.0.394",
-    "@nationalarchives/tdr-components": "1.0.0",
+    "@nationalarchives/tdr-components": "1.0.12",
     "@nationalarchives/tdr-generated-graphql": "1.0.299",
     "copyfiles": "^2.4.1",
     "events": "^3.3.0",


### PR DESCRIPTION
It turns out that you can't delete a package and republish over the same
version after a certain amount of time. I was trying to clear out the
older versions of the tdr-components library and got rid of everything.
Long story short, this is the next available version which I've
published manually to get the build working.
