### PR TITLE
Skip closure type confirmation if already confirmed.

### DIFF
--- a/app/controllers/AdditionalMetadataClosureStatusController.scala
+++ b/app/controllers/AdditionalMetadataClosureStatusController.scala
@@ -43,7 +43,7 @@ class AdditionalMetadataClosureStatusController @Inject() (
       response <-
         if (consignment.files.nonEmpty) {
           val filePaths = consignment.files.flatMap(_.fileMetadata).filter(_.name == clientSideOriginalFilepath).map(_.value)
-          val closureStatus = consignment.files.flatMap(_.fileMetadata).find(_.name == closureType.name).exists(_.value == closureType.value)
+          val areAllFilesClosed = consignmentService.areAllFilesClosed(consignment)
           cache.set(s"$consignmentId-data", (consignment.consignmentReference, filePaths, details.parentFolderId.get), 1.hour)
           Future(
             Ok(
@@ -53,7 +53,7 @@ class AdditionalMetadataClosureStatusController @Inject() (
                 fileIds,
                 closureStatusForm,
                 closureStatusField,
-                closureStatus,
+                areAllFilesClosed,
                 consignment.consignmentReference,
                 details.parentFolderId.get,
                 request.token.name
@@ -84,7 +84,7 @@ class AdditionalMetadataClosureStatusController @Inject() (
             fileIds,
             formWithErrors,
             closureStatusField,
-            closureStatus = false,
+            areAllFilesClosed = false,
             consignmentRef,
             parentFolderId,
             request.token.name

--- a/app/services/ConsignmentService.scala
+++ b/app/services/ConsignmentService.scala
@@ -3,11 +3,13 @@ package services
 import com.google.common.collect.Ordering.natural
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken
 import configuration.GraphQLConfiguration
+import controllers.util.MetadataProperty.closureType
 import graphql.codegen.AddConsignment.addConsignment
 import graphql.codegen.GetConsignment.getConsignment
 import graphql.codegen.GetConsignmentExport.getConsignmentForExport
 import graphql.codegen.GetConsignmentFiles.getConsignmentFiles
 import graphql.codegen.GetConsignmentFiles.getConsignmentFiles.GetConsignment.Files
+import graphql.codegen.GetConsignmentFilesMetadata.getConsignmentFilesMetadata.GetConsignment
 import graphql.codegen.GetConsignmentFilesMetadata.{getConsignmentFilesMetadata => gcfm}
 import graphql.codegen.GetConsignmentFolderDetails.getConsignmentFolderDetails
 import graphql.codegen.GetConsignmentReference.getConsignmentReference
@@ -64,6 +66,14 @@ class ConsignmentService @Inject() (val graphqlConfiguration: GraphQLConfigurati
           case None              => throw new IllegalStateException(s"No consignment found for consignment $consignmentId")
         }
       )
+  }
+
+  def areAllFilesClosed(consignment: GetConsignment): Boolean = {
+    consignment.files
+      .filter(file => file.fileMetadata.exists(metadata => metadata.name == "FileType" && metadata.value == "File"))
+      .filter(file => file.fileMetadata.exists(metadata => metadata.name == closureType.name && metadata.value != closureType.value))
+      .map(_.fileId)
+      .isEmpty
   }
 
   def getConsignmentFileMetadata(consignmentId: UUID, token: BearerAccessToken, fileFilters: Option[FileFilters] = None): Future[gcfm.GetConsignment] = {

--- a/app/services/ConsignmentService.scala
+++ b/app/services/ConsignmentService.scala
@@ -69,11 +69,9 @@ class ConsignmentService @Inject() (val graphqlConfiguration: GraphQLConfigurati
   }
 
   def areAllFilesClosed(consignment: GetConsignment): Boolean = {
-    consignment.files
+    !consignment.files
       .filter(file => file.fileMetadata.exists(metadata => metadata.name == "FileType" && metadata.value == "File"))
-      .filter(file => file.fileMetadata.exists(metadata => metadata.name == closureType.name && metadata.value != closureType.value))
-      .map(_.fileId)
-      .isEmpty
+      .exists(file => file.fileMetadata.exists(metadata => metadata.name == closureType.name && metadata.value != closureType.value))
   }
 
   def getConsignmentFileMetadata(consignmentId: UUID, token: BearerAccessToken, fileFilters: Option[FileFilters] = None): Future[gcfm.GetConsignment] = {

--- a/app/views/standard/additionalMetadataClosureStatus.scala.html
+++ b/app/views/standard/additionalMetadataClosureStatus.scala.html
@@ -8,7 +8,7 @@
 @import controllers.util.InputNameAndValue
 
 @(consignmentId: UUID, fileNames: List[String], fileIds: List[UUID], formData: Form[ClosureStatusFormData], inputNameAndValue: InputNameAndValue,
-        closureStatus: Boolean, consignmentRef: String, parentFolderId: UUID, name: String)(implicit messages: Messages, request: RequestHeader)
+        areAllFilesClosed: Boolean, consignmentRef: String, parentFolderId: UUID, name: String)(implicit messages: Messages, request: RequestHeader)
 @fieldErrors = @{formData("closureStatus").errors.headOption match {
     case Some(formError) => formError.messages
     case None => Nil
@@ -44,9 +44,9 @@
                                     Symbol("_label") -> inputNameAndValue.value,
                                     Symbol("_value") -> "true",
                                     Symbol("_smallCheckbox") -> false,
-                                    Symbol("_checkedOption") -> (if(closureStatus) "checked" else ""),
+                                    Symbol("_checkedOption") -> (if(areAllFilesClosed) "checked" else ""),
                                     Symbol("_requiredOption") -> true,
-                                    Symbol("_disabledOption") -> ""
+                                    Symbol("_disabledOption") -> (if(areAllFilesClosed) "disabled" else "")
                                 ),
                                 Nil
                             )
@@ -80,9 +80,15 @@
                     </details>
 
                     <div class="govuk-button-group">
-                        <button type= "submit" role="button" draggable="false" class="govuk-button" data-module="govuk-button">
-                            Continue
-                        </button>
+                        @if(areAllFilesClosed) {
+                            <a class="govuk-button" href="@routes.AddClosureMetadataController.addClosureMetadata(consignmentId, fileIds)" role="button" draggable="false" data-module="govuk-button">
+                                Continue
+                            </a>
+                        } else {
+                            <button type= "submit" role="button" draggable="false" class="govuk-button" data-module="govuk-button">
+                                Continue
+                            </button>
+                        }
                         <a class="govuk-link" href="@routes.AdditionalMetadataNavigationController.getAllFiles(consignmentId, "closure")">Cancel</a>
                     </div>
                 }

--- a/test/controllers/AddClosureMetadataControllerSpec.scala
+++ b/test/controllers/AddClosureMetadataControllerSpec.scala
@@ -28,7 +28,7 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers.{GET, contentAsString, contentType, status => playStatus, _}
 import services.{ConsignmentService, CustomMetadataService}
 import testUtils.{CheckPageForStaticElements, FormTester, FrontEndTestHelper}
-import testUtils.DefaultMockFormOptions.{expectedClosureDefaultOptions, expectedClosureDependencyDefaultOptions, MockInputOption}
+import testUtils.DefaultMockFormOptions.{expectedClosureDefaultOptions, expectedClosureDependencyDefaultOptions}
 import uk.gov.nationalarchives.tdr.GraphQLClient
 
 import java.util.UUID

--- a/test/services/ConsignmentServiceSpec.scala
+++ b/test/services/ConsignmentServiceSpec.scala
@@ -70,6 +70,16 @@ class ConsignmentServiceSpec extends AnyWordSpec with MockitoSugar with BeforeAn
   private val consignmentId = UUID.fromString("180f9166-fe3c-486e-b9ab-6dfa5f3058dc")
   private val seriesId = Some(UUID.fromString("d54a5118-33a0-4ba2-8030-d16efcf1d1f4"))
 
+  def generateMetadata(numberOfFiles: Int, fileType: String, closureType: String): List[gcfm.GetConsignment.Files] = {
+    val oldMetadata = gcfm.GetConsignment.Files.Metadata(None, None, None, None, None, None)
+    List
+      .fill(numberOfFiles)(UUID.randomUUID())
+      .map(fileId => {
+        val fileMetadata = List(gcfm.GetConsignment.Files.FileMetadata("FileType", fileType), gcfm.GetConsignment.Files.FileMetadata("ClosureType", closureType))
+        gcfm.GetConsignment.Files(fileId, fileMetadata, oldMetadata)
+      })
+  }
+
   override def afterEach(): Unit = {
     Mockito.reset(getConsignmentClient)
     Mockito.reset(addConsignmentClient)
@@ -491,6 +501,36 @@ class ConsignmentServiceSpec extends AnyWordSpec with MockitoSugar with BeforeAn
 
       val results = consignmentService.getConsignments(consignmentFilter, bearerAccessToken)
       results.failed.futureValue shouldBe a[HttpError]
+    }
+  }
+
+  "areAllFilesClosed" should {
+    "return true if all file files have a closure type of Closed" in {
+      val files = generateMetadata(2, "File", "Closed")
+      consignmentService.areAllFilesClosed(gcfm.GetConsignment(files, "")) should equal(true)
+    }
+
+    "return true if all files are closed but folders are open" in {
+      val files = generateMetadata(2, "File", "Closed")
+      val folders = generateMetadata(2, "Folder", "Open")
+      val consignment = gcfm.GetConsignment(files ++ folders, "")
+      consignmentService.areAllFilesClosed(consignment) should equal(true)
+    }
+
+    "return true if no files are provided" in {
+      consignmentService.areAllFilesClosed(gcfm.GetConsignment(Nil, "")) should equal(true)
+    }
+
+    "return false if one file is open and the others closed" in {
+      val closedFile = generateMetadata(1, "File", "Open")
+      val openFiles = generateMetadata(3, "File", "Closed")
+      val consignment = gcfm.GetConsignment(closedFile ++ openFiles, "")
+      consignmentService.areAllFilesClosed(consignment) should equal(false)
+    }
+
+    "return false if all files are open" in {
+      val files = generateMetadata(3, "File", "Open")
+      consignmentService.areAllFilesClosed(gcfm.GetConsignment(files, "")) should equal(false)
     }
   }
 }

--- a/test/services/ConsignmentServiceSpec.scala
+++ b/test/services/ConsignmentServiceSpec.scala
@@ -505,7 +505,7 @@ class ConsignmentServiceSpec extends AnyWordSpec with MockitoSugar with BeforeAn
   }
 
   "areAllFilesClosed" should {
-    "return true if all file files have a closure type of Closed" in {
+    "return true if all files have a closure type of Closed" in {
       val files = generateMetadata(2, "File", "Closed")
       consignmentService.areAllFilesClosed(gcfm.GetConsignment(files, "")) should equal(true)
     }

--- a/test/testUtils/FrontEndTestHelper.scala
+++ b/test/testUtils/FrontEndTestHelper.scala
@@ -116,6 +116,7 @@ trait FrontEndTestHelper extends PlaySpec with MockitoSugar with Injecting with 
       val foiExampleAsserted = LocalDateTime.of(1995, 1, 12, 10, 0)
       (
         List(
+          gcfm.GetConsignment.Files.FileMetadata("FileType", "File"),
           gcfm.GetConsignment.Files.FileMetadata("ClosureType", closureType),
           gcfm.GetConsignment.Files.FileMetadata("FoiExemptionCode", "mock code1"),
           gcfm.GetConsignment.Files.FileMetadata("ClosurePeriod", "4"),


### PR DESCRIPTION
This does a few things.

If all files are already confirmed as closed, the closure status page is
skipped.

If you go to the closure status page anyway, the checkbox is checked and
disabled and the submit button is changed to a link which takes you to
the custom metadata page.

I've put the logic for whether all files are closed or not in a separate
method so we can change the logic easily.
