### PR TITLE
TDR-2462 - Show an error message on the navigation page

### DIFF
--- a/app/controllers/AdditionalMetadataNavigationController.scala
+++ b/app/controllers/AdditionalMetadataNavigationController.scala
@@ -4,23 +4,25 @@ import auth.TokenSecurity
 import configuration.KeycloakConfiguration
 import graphql.codegen.types.FileFilters
 import org.pac4j.play.scala.SecurityComponents
+import play.api.cache.AsyncCacheApi
 import play.api.mvc.{Action, AnyContent, Request}
 import services.ConsignmentService
+import viewsapi.Caching.preventCaching
 
 import java.util.UUID
 import javax.inject.Inject
 import scala.concurrent.Future
+import scala.concurrent.duration.DurationInt
 
 class AdditionalMetadataNavigationController @Inject() (
     val consignmentService: ConsignmentService,
     val keycloakConfiguration: KeycloakConfiguration,
-    val controllerComponents: SecurityComponents
+    val controllerComponents: SecurityComponents,
+    val cache: AsyncCacheApi
 ) extends TokenSecurity {
 
   def getAllFiles(consignmentId: UUID, metadataType: String): Action[AnyContent] = standardTypeAction(consignmentId) { implicit request: Request[AnyContent] =>
-    consignmentService
-      .getAllConsignmentFiles(consignmentId, request.token.bearerAccessToken)
-      .map(allFiles => {
+    getCachedFiles(consignmentId, metadataType, request).map(allFiles => {
         Ok(views.html.standard.additionalMetadataNavigation(consignmentId, request.token.name, allFiles, metadataType))
       })
   }
@@ -32,20 +34,34 @@ class AdditionalMetadataNavigationController @Inject() (
       .toList
       .filter(_ != "csrfToken")
       .map(UUID.fromString)
-    if (metadataType == "closure") {
-      val fileFilters = FileFilters(None, Option(fileIds), None)
-      consignmentService
-        .getConsignmentFileMetadata(consignmentId, request.token.bearerAccessToken, Option(fileFilters))
-        .map(consignment => {
-          val areAllClosed = consignmentService.areAllFilesClosed(consignment)
-          if (areAllClosed) {
-            Redirect(routes.AddClosureMetadataController.addClosureMetadata(consignmentId, fileIds))
-          } else {
-            Redirect(routes.AdditionalMetadataClosureStatusController.getClosureStatusPage(consignmentId, fileIds))
-          }
-        })
+
+    if (fileIds.nonEmpty) {
+      if (metadataType == "closure") {
+        val fileFilters = FileFilters(None, Option(fileIds), None)
+        consignmentService
+          .getConsignmentFileMetadata(consignmentId, request.token.bearerAccessToken, Option(fileFilters))
+          .map(consignment => {
+            val areAllClosed = consignmentService.areAllFilesClosed(consignment)
+            if (areAllClosed) {
+              Redirect(routes.AddClosureMetadataController.addClosureMetadata(consignmentId, fileIds))
+            } else {
+              Redirect(routes.AdditionalMetadataClosureStatusController.getClosureStatusPage(consignmentId, fileIds))
+            }
+          })
+      } else {
+        Future(Redirect(routes.AdditionalMetadataSummaryController.getSelectedSummaryPage(consignmentId, fileIds)))
+      }
     } else {
-      Future(Redirect(routes.AdditionalMetadataSummaryController.getSelectedSummaryPage(consignmentId, fileIds)))
+      getCachedFiles(consignmentId, metadataType, request).map(allFiles => {
+          BadRequest(views.html.standard.additionalMetadataNavigation(consignmentId, request.token.name, allFiles, metadataType, displayError = true))
+        })
     }
   }
+
+  private def getCachedFiles(consignmentId: UUID, metadataType: String, request: Request[AnyContent]): Future[ConsignmentService.File] = {
+    cache.getOrElseUpdate(s"$consignmentId-$metadataType-allFiles", 1.hour)(
+      consignmentService.getAllConsignmentFiles(consignmentId, request.token.bearerAccessToken)
+    )
+  }
+
 }

--- a/app/controllers/AdditionalMetadataNavigationController.scala
+++ b/app/controllers/AdditionalMetadataNavigationController.scala
@@ -7,7 +7,6 @@ import org.pac4j.play.scala.SecurityComponents
 import play.api.cache.AsyncCacheApi
 import play.api.mvc.{Action, AnyContent, Request}
 import services.ConsignmentService
-import viewsapi.Caching.preventCaching
 
 import java.util.UUID
 import javax.inject.Inject
@@ -23,8 +22,8 @@ class AdditionalMetadataNavigationController @Inject() (
 
   def getAllFiles(consignmentId: UUID, metadataType: String): Action[AnyContent] = standardTypeAction(consignmentId) { implicit request: Request[AnyContent] =>
     getCachedFiles(consignmentId, metadataType, request).map(allFiles => {
-        Ok(views.html.standard.additionalMetadataNavigation(consignmentId, request.token.name, allFiles, metadataType))
-      })
+      Ok(views.html.standard.additionalMetadataNavigation(consignmentId, request.token.name, allFiles, metadataType))
+    })
   }
 
   def submitFiles(consignmentId: UUID, metadataType: String): Action[AnyContent] = standardTypeAction(consignmentId) { implicit request: Request[AnyContent] =>
@@ -53,8 +52,8 @@ class AdditionalMetadataNavigationController @Inject() (
       }
     } else {
       getCachedFiles(consignmentId, metadataType, request).map(allFiles => {
-          BadRequest(views.html.standard.additionalMetadataNavigation(consignmentId, request.token.name, allFiles, metadataType, displayError = true))
-        })
+        BadRequest(views.html.standard.additionalMetadataNavigation(consignmentId, request.token.name, allFiles, metadataType, displayError = true))
+      })
     }
   }
 

--- a/app/views/standard/additionalMetadataNavigation.scala.html
+++ b/app/views/standard/additionalMetadataNavigation.scala.html
@@ -2,7 +2,8 @@
 @import services.ConsignmentService.File
 @import views.html.helper.CSRF
 @import views.html.partials.fileNavigationContent
-@(consignmentId: UUID, name: String, files: File, metadataType: String)(implicit messages: Messages, request: RequestHeader)
+
+@(consignmentId: UUID, name: String, files: File, metadataType: String, displayError: Boolean = false)(implicit messages: Messages, request: RequestHeader)
 
 @display(file: File, level: Int, size: Int, pos: Int) = {
   @if(file.fileType.contains("File") || file.children.isEmpty) {
@@ -56,18 +57,35 @@
   </li>
   }
 }
+@error = {
+  @if(displayError) {
+    <div class="govuk-error-summary govuk-!-margin-bottom-4" data-module="govuk-error-summary">
+      <div role="alert">
+        <h2 class="govuk-error-summary__title">There is a problem</h2>
+        <div class="govuk-error-summary__body">
+          <ul class="govuk-list govuk-error-summary__list">
+            <li>
+              <a href="#file-selection">Select at least one file or folder</a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  }
+}
 
 @main("Additional Metadata", name = name) {
   @defining(play.core.PlayVersion.current) { version =>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         @fileNavigationContent(metadataType, files.name)
+        @error
         <form method="post" action="@routes.AdditionalMetadataNavigationController.submitFiles(consignmentId, metadataType)">
           @CSRF.formField
           <button class="govuk-button" type="submit" role="button" draggable="false">
             Add or Edit Metadata
           </button>
-          <div class="govuk-tna-tree">
+          <div class="govuk-tna-tree" id="file-selection">
             <ul tabindex="0" class="govuk-tna-tree__nested-item-list" role="tree" aria-multiselectable="true">
             @display(files, 1, files.children.length, 0)
             </ul>
@@ -76,7 +94,6 @@
             Add or Edit Metadata
           </button>
         </form>
-
       </div>
     </div>
   }

--- a/test/controllers/AdditionalMetadataNavigationControllerSpec.scala
+++ b/test/controllers/AdditionalMetadataNavigationControllerSpec.scala
@@ -108,9 +108,11 @@ class AdditionalMetadataNavigationControllerSpec extends FrontEndTestHelper {
           new AdditionalMetadataNavigationController(consignmentService, getValidStandardUserKeycloakConfiguration, getAuthorisedSecurityComponents, MockAsyncCacheApi())
         val result = additionalMetadataController
           .submitFiles(consignmentId, "closure")
-          .apply(FakeRequest(POST, s"/consignment/$consignmentId/additional-metadata/files/closure/")
-            .withFormUrlEncodedBody(Seq((fileId, "checked")): _*)
-            .withCSRFToken)
+          .apply(
+            FakeRequest(POST, s"/consignment/$consignmentId/additional-metadata/files/closure/")
+              .withFormUrlEncodedBody(Seq((fileId, "checked")): _*)
+              .withCSRFToken
+          )
         playStatus(result) must equal(SEE_OTHER)
         redirectLocation(result).get must equal(s"/consignment/$consignmentId/additional-metadata/closure-status?fileIds=$fileId")
       }
@@ -123,9 +125,11 @@ class AdditionalMetadataNavigationControllerSpec extends FrontEndTestHelper {
           new AdditionalMetadataNavigationController(consignmentService, getValidStandardUserKeycloakConfiguration, getAuthorisedSecurityComponents, MockAsyncCacheApi())
         val result = additionalMetadataController
           .submitFiles(consignmentId, "closure")
-          .apply(FakeRequest(POST, s"/consignment/$consignmentId/additional-metadata/files/closure/")
-            .withFormUrlEncodedBody(Seq((fileId, "checked")): _*)
-            .withCSRFToken)
+          .apply(
+            FakeRequest(POST, s"/consignment/$consignmentId/additional-metadata/files/closure/")
+              .withFormUrlEncodedBody(Seq((fileId, "checked")): _*)
+              .withCSRFToken
+          )
         playStatus(result) must equal(SEE_OTHER)
         redirectLocation(result).get must equal(s"/consignment/$consignmentId/add-closure-metadata?fileIds=$fileId")
       }
@@ -137,9 +141,11 @@ class AdditionalMetadataNavigationControllerSpec extends FrontEndTestHelper {
         val fileId = UUID.randomUUID().toString
         val result = additionalMetadataController
           .submitFiles(consignmentId, "descriptive")
-          .apply(FakeRequest(POST, s"/consignment/$consignmentId/additional-metadata/files/descriptive/")
-            .withFormUrlEncodedBody(Seq((fileId, "checked")): _*)
-            .withCSRFToken)
+          .apply(
+            FakeRequest(POST, s"/consignment/$consignmentId/additional-metadata/files/descriptive/")
+              .withFormUrlEncodedBody(Seq((fileId, "checked")): _*)
+              .withCSRFToken
+          )
         playStatus(result) must equal(SEE_OTHER)
         redirectLocation(result).get must equal(s"/consignment/$consignmentId/additional-metadata/closure/selected-summary?fileIds=$fileId")
       }
@@ -151,8 +157,7 @@ class AdditionalMetadataNavigationControllerSpec extends FrontEndTestHelper {
           new AdditionalMetadataNavigationController(consignmentService, getValidStandardUserKeycloakConfiguration, getAuthorisedSecurityComponents, MockAsyncCacheApi())
         val result = additionalMetadataController
           .submitFiles(consignmentId, "closure")
-          .apply(FakeRequest(POST, s"/consignment/$consignmentId/additional-metadata/files/closure/")
-            .withCSRFToken)
+          .apply(FakeRequest(POST, s"/consignment/$consignmentId/additional-metadata/files/closure/").withCSRFToken)
 
         playStatus(result) must equal(BAD_REQUEST)
         val content = contentAsString(result)

--- a/test/controllers/AdditionalMetadataNavigationControllerSpec.scala
+++ b/test/controllers/AdditionalMetadataNavigationControllerSpec.scala
@@ -150,7 +150,7 @@ class AdditionalMetadataNavigationControllerSpec extends FrontEndTestHelper {
         redirectLocation(result).get must equal(s"/consignment/$consignmentId/additional-metadata/closure/selected-summary?fileIds=$fileId")
       }
 
-      "redirect to the file navigation page with an error message if a user submits the page without selecting any files" in {
+      "redirect to the file navigation page with an error message if a user submits the page without selecting any files and folders" in {
         val files = gcf.GetConsignment.Files(UUID.randomUUID(), None, None, None, gcf.GetConsignment.Files.Metadata(Option(""))) :: Nil
         val consignmentService = mockConsignmentService(files, "standard")
         val additionalMetadataController =

--- a/test/controllers/AdditionalMetadataNavigationControllerSpec.scala
+++ b/test/controllers/AdditionalMetadataNavigationControllerSpec.scala
@@ -10,7 +10,7 @@ import io.circe.Printer
 import io.circe.generic.auto._
 import io.circe.syntax._
 import play.api.Play.materializer
-import play.api.http.Status.{FORBIDDEN, FOUND, SEE_OTHER}
+import play.api.http.Status.{BAD_REQUEST, FORBIDDEN, FOUND, SEE_OTHER}
 import play.api.test.CSRFTokenHelper.CSRFRequest
 import play.api.test.FakeRequest
 import play.api.test.Helpers.{GET, POST, contentAsString, defaultAwaitTimeout, redirectLocation, status => playStatus}
@@ -44,14 +44,15 @@ class AdditionalMetadataNavigationControllerSpec extends FrontEndTestHelper {
           val consignmentService: ConsignmentService = mockConsignmentService(List(parentFile), "standard")
 
           val additionalMetadataController =
-            new AdditionalMetadataNavigationController(consignmentService, getValidStandardUserKeycloakConfiguration, getAuthorisedSecurityComponents)
+            new AdditionalMetadataNavigationController(consignmentService, getValidStandardUserKeycloakConfiguration, getAuthorisedSecurityComponents, MockAsyncCacheApi())
           val result = additionalMetadataController
             .getAllFiles(consignmentId, metadataType)
             .apply(FakeRequest(GET, s"/consignment/$consignmentId/additional-metadata/files/$metadataType/").withCSRFToken)
           val content = contentAsString(result)
 
           content.contains(s"Add or edit $metadataType metadata on file basis") must be(true)
-          content.contains(s"Folder uploaded: ${parentFile.fileName.get}")
+          content.contains(s"Folder uploaded: ${parentFile.fileName.get}") must be(true)
+          content.contains("Select at least one file or folder") must be(false)
         }
 
         s"render the file navigation page with nested directories for metadata type $metadataType" in {
@@ -64,7 +65,7 @@ class AdditionalMetadataNavigationControllerSpec extends FrontEndTestHelper {
           val consignmentService: ConsignmentService = mockConsignmentService(List(parentFile, descendantOneFile, descendantTwoFile), "standard")
 
           val additionalMetadataController =
-            new AdditionalMetadataNavigationController(consignmentService, getValidStandardUserKeycloakConfiguration, getAuthorisedSecurityComponents)
+            new AdditionalMetadataNavigationController(consignmentService, getValidStandardUserKeycloakConfiguration, getAuthorisedSecurityComponents, MockAsyncCacheApi())
           val result = additionalMetadataController
             .getAllFiles(consignmentId, metadataType)
             .apply(FakeRequest(GET, s"/consignment/$consignmentId/additional-metadata/files/$metadataType/").withCSRFToken)
@@ -80,7 +81,7 @@ class AdditionalMetadataNavigationControllerSpec extends FrontEndTestHelper {
       "return forbidden for a judgment user" in {
         val consignmentService = mockConsignmentService(Nil, "judgment")
         val additionalMetadataController =
-          new AdditionalMetadataNavigationController(consignmentService, getValidJudgmentUserKeycloakConfiguration, getAuthorisedSecurityComponents)
+          new AdditionalMetadataNavigationController(consignmentService, getValidJudgmentUserKeycloakConfiguration, getAuthorisedSecurityComponents, MockAsyncCacheApi())
         val result = additionalMetadataController
           .getAllFiles(consignmentId, "closure")
           .apply(FakeRequest(GET, s"/consignment/$consignmentId/additional-metadata/files/closure/").withCSRFToken)
@@ -90,7 +91,7 @@ class AdditionalMetadataNavigationControllerSpec extends FrontEndTestHelper {
       "return a redirect the login page for a logged out user" in {
         val consignmentService = mockConsignmentService(Nil, "standard")
         val additionalMetadataController =
-          new AdditionalMetadataNavigationController(consignmentService, getValidStandardUserKeycloakConfiguration, getUnauthorisedSecurityComponents)
+          new AdditionalMetadataNavigationController(consignmentService, getValidStandardUserKeycloakConfiguration, getUnauthorisedSecurityComponents, MockAsyncCacheApi())
         val result = additionalMetadataController
           .getAllFiles(consignmentId, "closure")
           .apply(FakeRequest(GET, s"/consignment/$consignmentId/additional-metadata/files/closure/").withCSRFToken)
@@ -102,42 +103,79 @@ class AdditionalMetadataNavigationControllerSpec extends FrontEndTestHelper {
       "redirect to the closure status page with the correct file ids and closure metadata type if the files are not already closed" in {
         val files = gcf.GetConsignment.Files(UUID.randomUUID(), None, None, None, gcf.GetConsignment.Files.Metadata(Option(""))) :: Nil
         val consignmentService = mockConsignmentService(files, "standard")
+        val fileId = UUID.randomUUID().toString
         val additionalMetadataController =
-          new AdditionalMetadataNavigationController(consignmentService, getValidStandardUserKeycloakConfiguration, getAuthorisedSecurityComponents)
+          new AdditionalMetadataNavigationController(consignmentService, getValidStandardUserKeycloakConfiguration, getAuthorisedSecurityComponents, MockAsyncCacheApi())
         val result = additionalMetadataController
           .submitFiles(consignmentId, "closure")
-          .apply(FakeRequest(POST, s"/consignment/$consignmentId/additional-metadata/files/closure/").withCSRFToken)
+          .apply(FakeRequest(POST, s"/consignment/$consignmentId/additional-metadata/files/closure/")
+            .withFormUrlEncodedBody(Seq((fileId, "checked")): _*)
+            .withCSRFToken)
         playStatus(result) must equal(SEE_OTHER)
-        redirectLocation(result).get must equal(s"/consignment/$consignmentId/additional-metadata/closure-status")
+        redirectLocation(result).get must equal(s"/consignment/$consignmentId/additional-metadata/closure-status?fileIds=$fileId")
       }
 
       "redirect to the closure metadata page with the correct file ids and closure metadata type if the files are already closed" in {
         val files = gcf.GetConsignment.Files(UUID.randomUUID(), None, None, None, gcf.GetConsignment.Files.Metadata(Option(""))) :: Nil
         val consignmentService = mockConsignmentService(files, "standard", allClosed = true)
+        val fileId = UUID.randomUUID().toString
         val additionalMetadataController =
-          new AdditionalMetadataNavigationController(consignmentService, getValidStandardUserKeycloakConfiguration, getAuthorisedSecurityComponents)
+          new AdditionalMetadataNavigationController(consignmentService, getValidStandardUserKeycloakConfiguration, getAuthorisedSecurityComponents, MockAsyncCacheApi())
         val result = additionalMetadataController
           .submitFiles(consignmentId, "closure")
-          .apply(FakeRequest(POST, s"/consignment/$consignmentId/additional-metadata/files/closure/").withCSRFToken)
+          .apply(FakeRequest(POST, s"/consignment/$consignmentId/additional-metadata/files/closure/")
+            .withFormUrlEncodedBody(Seq((fileId, "checked")): _*)
+            .withCSRFToken)
         playStatus(result) must equal(SEE_OTHER)
-        redirectLocation(result).get must equal(s"/consignment/$consignmentId/add-closure-metadata")
+        redirectLocation(result).get must equal(s"/consignment/$consignmentId/add-closure-metadata?fileIds=$fileId")
       }
 
       "redirect to the metadata summary page if the metadata type is descriptive" in {
         val consignmentService = mockConsignmentService(Nil, "standard")
         val additionalMetadataController =
-          new AdditionalMetadataNavigationController(consignmentService, getValidStandardUserKeycloakConfiguration, getAuthorisedSecurityComponents)
+          new AdditionalMetadataNavigationController(consignmentService, getValidStandardUserKeycloakConfiguration, getAuthorisedSecurityComponents, MockAsyncCacheApi())
+        val fileId = UUID.randomUUID().toString
         val result = additionalMetadataController
           .submitFiles(consignmentId, "descriptive")
-          .apply(FakeRequest(POST, s"/consignment/$consignmentId/additional-metadata/files/descriptive/").withCSRFToken)
+          .apply(FakeRequest(POST, s"/consignment/$consignmentId/additional-metadata/files/descriptive/")
+            .withFormUrlEncodedBody(Seq((fileId, "checked")): _*)
+            .withCSRFToken)
         playStatus(result) must equal(SEE_OTHER)
-        redirectLocation(result).get must equal(s"/consignment/$consignmentId/additional-metadata/closure/selected-summary")
+        redirectLocation(result).get must equal(s"/consignment/$consignmentId/additional-metadata/closure/selected-summary?fileIds=$fileId")
+      }
+
+      "redirect to the file navigation page with an error message if a user submits the page without selecting any files" in {
+        val files = gcf.GetConsignment.Files(UUID.randomUUID(), None, None, None, gcf.GetConsignment.Files.Metadata(Option(""))) :: Nil
+        val consignmentService = mockConsignmentService(files, "standard")
+        val additionalMetadataController =
+          new AdditionalMetadataNavigationController(consignmentService, getValidStandardUserKeycloakConfiguration, getAuthorisedSecurityComponents, MockAsyncCacheApi())
+        val result = additionalMetadataController
+          .submitFiles(consignmentId, "closure")
+          .apply(FakeRequest(POST, s"/consignment/$consignmentId/additional-metadata/files/closure/")
+            .withCSRFToken)
+
+        playStatus(result) must equal(BAD_REQUEST)
+        val content = contentAsString(result)
+        content.contains(
+          """    <div class="govuk-error-summary govuk-!-margin-bottom-4" data-module="govuk-error-summary">
+            |      <div role="alert">
+            |        <h2 class="govuk-error-summary__title">There is a problem</h2>
+            |        <div class="govuk-error-summary__body">
+            |          <ul class="govuk-list govuk-error-summary__list">
+            |            <li>
+            |              <a href="#file-selection">Select at least one file or folder</a>
+            |            </li>
+            |          </ul>
+            |        </div>
+            |      </div>
+            |    </div>""".stripMargin
+        ) must be(true)
       }
 
       "return forbidden for a judgment user" in {
         val consignmentService = mockConsignmentService(Nil, "judgment")
         val additionalMetadataController =
-          new AdditionalMetadataNavigationController(consignmentService, getValidJudgmentUserKeycloakConfiguration, getAuthorisedSecurityComponents)
+          new AdditionalMetadataNavigationController(consignmentService, getValidJudgmentUserKeycloakConfiguration, getAuthorisedSecurityComponents, MockAsyncCacheApi())
         val result = additionalMetadataController
           .submitFiles(consignmentId, "closure")
           .apply(FakeRequest(POST, s"/consignment/$consignmentId/additional-metadata/files/closure/").withCSRFToken)
@@ -147,7 +185,7 @@ class AdditionalMetadataNavigationControllerSpec extends FrontEndTestHelper {
       "return a redirect the login page for a logged out user" in {
         val consignmentService = mockConsignmentService(Nil, "standard")
         val additionalMetadataController =
-          new AdditionalMetadataNavigationController(consignmentService, getValidStandardUserKeycloakConfiguration, getAuthorisedSecurityComponents)
+          new AdditionalMetadataNavigationController(consignmentService, getValidStandardUserKeycloakConfiguration, getUnauthorisedSecurityComponents, MockAsyncCacheApi())
         val result = additionalMetadataController
           .submitFiles(consignmentId, "descriptive")
           .apply(FakeRequest(POST, s"/consignment/$consignmentId/additional-metadata/files/descriptive/").withCSRFToken)


### PR DESCRIPTION
Show an error message if a user clicks on the 'Add or edit metadata' button without selecting any files