### PR TITLE
Update description for FOIExemptionCode

### DIFF
--- a/app/views/partials/inputDropdown.scala.html
+++ b/app/views/partials/inputDropdown.scala.html
@@ -25,7 +25,9 @@ fieldErrors: List[String] = Nil
             </label>
         </h2>
         <div id="@formFieldId-hint" class="govuk-hint">
-            @fieldDescription
+             @* hard coding the description as the database cannot contain html*@
+            Add one or more exemption code to this closure. Here is a
+            <a target="_blank" href="https://www.legislation.gov.uk/ukpga/2000/36/contents">full list of FOI codes and their designated exemptions</a>.
         </div>
     } else {
         <label class="govuk-label" for="@formFieldId">

--- a/app/views/partials/inputDropdown.scala.html
+++ b/app/views/partials/inputDropdown.scala.html
@@ -25,9 +25,13 @@ fieldErrors: List[String] = Nil
             </label>
         </h2>
         <div id="@formFieldId-hint" class="govuk-hint">
-             @* hard coding the description as the database cannot contain html*@
-            Add one or more exemption code to this closure. Here is a
-            <a target="_blank" href="https://www.legislation.gov.uk/ukpga/2000/36/contents">full list of FOI codes and their designated exemptions</a>.
+            @if(fieldId == "FoiExemptionCode") {
+                @* hard coding the description as the database cannot contain html*@
+                Add one or more exemption code to this closure. Here is a
+                <a target="_blank" href="https://www.legislation.gov.uk/ukpga/2000/36/contents">full list of FOI codes and their designated exemptions</a>.
+            } else {
+                @fieldDescription
+            }
         </div>
     } else {
         <label class="govuk-label" for="@formFieldId">

--- a/test/controllers/AddClosureMetadataControllerSpec.scala
+++ b/test/controllers/AddClosureMetadataControllerSpec.scala
@@ -720,7 +720,7 @@ class AddClosureMetadataControllerSpec extends FrontEndTestHelper {
         |                FOI exemption code
         |            </label>""".replace("................", "                "),
       """        <div id="inputdropdown-FoiExemptionCode-hint" class="govuk-hint">
-        |            Select the exemption code that applies
+        |            Add one or more exemption code to this closure. Here is a<a target="_blank" href="https://www.legislation.gov.uk/ukpga/2000/36/contents">full list of FOI codes and their designated exemptions</a>.
         |        </div>""",
       """<select class="govuk-select" id="inputdropdown-FoiExemptionCode" name="inputdropdown-FoiExemptionCode"  >""",
       """        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">


### PR DESCRIPTION
Updated the description for FOIExemptionCode for the form. I have hard coded the description because the properties of the form is driven from the database but we cannot have html in the database for the link.