### PR TITLE
Refactor customMetadata Tests to use new FormTestData

### DIFF
--- a/test/controllers/util/DynamicFormUtilsSpec.scala
+++ b/test/controllers/util/DynamicFormUtilsSpec.scala
@@ -8,6 +8,7 @@ import org.scalatestplus.mockito.MockitoSugar
 import play.api.mvc.AnyContentAsFormUrlEncoded
 import play.api.test.FakeRequest
 import play.api.test.Helpers.POST
+import testUtils.FormTestData
 
 import java.time.LocalDateTime
 import scala.collection.immutable.ListMap
@@ -79,7 +80,7 @@ class DynamicFormUtilsSpec extends AnyFlatSpec with MockitoSugar with BeforeAndA
     val thrownException: IllegalArgumentException =
       the[IllegalArgumentException] thrownBy dynamicFormUtils.validateAndConvertSubmittedValuesToFormFields(dynamicFormUtils.formAnswersWithValidInputNames)
 
-    thrownException.getMessage should equal(s"Metadata name TestProperty1 does not exist in submitted form values")
+    thrownException.getMessage should equal(s"Metadata name FoiExemptionAsserted does not exist in submitted form values")
   }
 
   "validateAndConvertSubmittedValuesToFormFields" should "not throw an exception if the metadata name (in the input name) " +
@@ -176,9 +177,9 @@ class DynamicFormUtilsSpec extends AnyFlatSpec with MockitoSugar with BeforeAndA
     val dateTime = LocalDateTime.now().plusDays(1)
     val rawFormToMakeRequestWith =
       ListMap(
-        "inputdate-TestProperty3-day" -> List(dateTime.getDayOfMonth.toString),
-        "inputdate-TestProperty3-month" -> List(dateTime.getMonthValue.toString),
-        "inputdate-TestProperty3-year" -> List(dateTime.getYear.toString)
+        "inputdate-FoiExemptionAsserted-day" -> List(dateTime.getDayOfMonth.toString),
+        "inputdate-FoiExemptionAsserted-month" -> List(dateTime.getMonthValue.toString),
+        "inputdate-FoiExemptionAsserted-year" -> List(dateTime.getYear.toString)
       )
 
     val mockRequest: FakeRequest[AnyContentAsFormUrlEncoded] =
@@ -186,7 +187,7 @@ class DynamicFormUtilsSpec extends AnyFlatSpec with MockitoSugar with BeforeAndA
         .apply(POST, s"/consignment/12345/add-closure-metadata")
         .withBody(AnyContentAsFormUrlEncoded(rawFormToMakeRequestWith))
 
-    val mockProperties: List[GetCustomMetadata.customMetadata.CustomMetadata] = new CustomMetadataUtilsSpec().allProperties.find(_.name == "TestProperty3").toList
+    val mockProperties: List[GetCustomMetadata.customMetadata.CustomMetadata] = new FormTestData().setupCustomMetadatas().find(_.name == "FoiExemptionAsserted").toList
     val allMetadataAsFields: List[FormField] = new CustomMetadataUtils(mockProperties).convertPropertiesToFormFields(mockProperties.toSet)
     val metaDataField = allMetadataAsFields.head match {
       case e: DateField => e.copy(isFutureDateAllowed = false)
@@ -196,7 +197,7 @@ class DynamicFormUtilsSpec extends AnyFlatSpec with MockitoSugar with BeforeAndA
 
     val validatedForm = dynamicFormUtils.validateAndConvertSubmittedValuesToFormFields(dynamicFormUtils.formAnswersWithValidInputNames)
     val dateField = validatedForm.find(_.isInstanceOf[DateField]).get
-    dateField.fieldErrors should equal(List(s"Test Property 3 date cannot be a future date."))
+    dateField.fieldErrors should equal(List(s"FOI decision asserted date cannot be a future date."))
   }
 
   "validateAndConvertSubmittedValuesToFormFields" should "return a 'whole number'-related error for the numeric fields that are missing values" in {
@@ -235,38 +236,38 @@ class DynamicFormUtilsSpec extends AnyFlatSpec with MockitoSugar with BeforeAndA
 
   private def verifyUpdatedFormFields(mockFormValues: MockFormValues, validatedForm: List[FormField]): Unit = {
 
-    val date = validatedForm.find(_.fieldId == "TestProperty3").map(_.asInstanceOf[DateField]).get
+    val date = validatedForm.find(_.fieldId == "FoiExemptionAsserted").map(_.asInstanceOf[DateField]).get
     date.day.value should equal(mockFormValues.day.head.trim)
     date.month.value should equal(mockFormValues.month.head.trim)
     date.year.value should equal(mockFormValues.year.head.trim)
 
-    val date2 = validatedForm.find(_.fieldId == "TestProperty5").map(_.asInstanceOf[DateField]).get
+    val date2 = validatedForm.find(_.fieldId == "ClosureStartDate").map(_.asInstanceOf[DateField]).get
     date2.day.value should equal(mockFormValues.day2.head.trim)
     date2.month.value should equal(mockFormValues.month2.head.trim)
     date2.year.value should equal(mockFormValues.year2.head.trim)
 
-    val text = validatedForm.find(_.fieldId == "TestProperty1").map(_.asInstanceOf[TextField]).get
+    val text = validatedForm.find(_.fieldId == "ClosurePeriod").map(_.asInstanceOf[TextField]).get
     text.nameAndValue.value should equal(mockFormValues.numericTextBoxValue.head.trim)
 
-    val dropdownField = validatedForm.find(_.fieldId == "TestProperty4").map(_.asInstanceOf[DropdownField]).get
+    val dropdownField = validatedForm.find(_.fieldId == "Dropdown").map(_.asInstanceOf[DropdownField]).get
     dropdownField.selectedOption.map(_.value).get should equal(mockFormValues.dropdownValue.head)
 
-    val radioButtonGroupField = validatedForm.find(_.fieldId == "TestProperty2").map(_.asInstanceOf[RadioButtonGroupField]).get
+    val radioButtonGroupField = validatedForm.find(_.fieldId == "Radio").map(_.asInstanceOf[RadioButtonGroupField]).get
     radioButtonGroupField.selectedOption should equal(mockFormValues.radioValue.head)
   }
 
   private def generateFormAndSendRequest(mockFormValues: MockFormValues): (ListMap[String, List[String]], DynamicFormUtils) = {
     val rawFormToMakeRequestWith =
       ListMap(
-        "inputdate-TestProperty3-day" -> mockFormValues.day,
-        "inputdate-TestProperty3-month" -> mockFormValues.month,
-        "inputdate-TestProperty3-year" -> mockFormValues.year,
-        "inputdate-TestProperty5-day" -> mockFormValues.day2,
-        "inputdate-TestProperty5-month" -> mockFormValues.month2,
-        "inputdate-TestProperty5-year" -> mockFormValues.year2,
-        "inputnumeric-TestProperty1-years" -> mockFormValues.numericTextBoxValue,
-        "inputdropdown-TestProperty4" -> mockFormValues.dropdownValue,
-        "inputradio-TestProperty2" -> mockFormValues.radioValue,
+        "inputdate-FoiExemptionAsserted-day" -> mockFormValues.day,
+        "inputdate-FoiExemptionAsserted-month" -> mockFormValues.month,
+        "inputdate-FoiExemptionAsserted-year" -> mockFormValues.year,
+        "inputdate-ClosureStartDate-day" -> mockFormValues.day2,
+        "inputdate-ClosureStartDate-month" -> mockFormValues.month2,
+        "inputdate-ClosureStartDate-year" -> mockFormValues.year2,
+        "inputnumeric-ClosurePeriod" -> mockFormValues.numericTextBoxValue,
+        "inputdropdown-Dropdown" -> mockFormValues.dropdownValue,
+        "inputradio-Radio" -> mockFormValues.radioValue,
         "csrfToken" -> mockFormValues.csrfToken
       )
 
@@ -281,7 +282,7 @@ class DynamicFormUtilsSpec extends AnyFlatSpec with MockitoSugar with BeforeAndA
         .apply(POST, s"/consignment/12345/add-closure-metadata")
         .withBody(AnyContentAsFormUrlEncoded(rawFormToMakeRequestWith))
 
-    val mockProperties: List[GetCustomMetadata.customMetadata.CustomMetadata] = new CustomMetadataUtilsSpec().allProperties.take(5)
+    val mockProperties: List[GetCustomMetadata.customMetadata.CustomMetadata] = new FormTestData().setupCustomMetadatas()
     val customMetadataUtils: CustomMetadataUtils = new CustomMetadataUtils(mockProperties)
 
     val allMetadataAsFields: List[FormField] = customMetadataUtils.convertPropertiesToFormFields(mockProperties.toSet)
@@ -303,12 +304,12 @@ case class MockFormValues(
     day: List[String] = List("3"),
     month: List[String] = List("4"),
     year: List[String] = List("2021"),
-    numericTextBoxValue: List[String] = List("5"),
-    dropdownValue: List[String] = List("TestValue 3"),
-    radioValue: List[String] = List("yes"),
     day2: List[String] = List("7"),
     month2: List[String] = List("9"),
     year2: List[String] = List("2022"),
+    numericTextBoxValue: List[String] = List("5"),
+    dropdownValue: List[String] = List("dropdownValue"),
+    radioValue: List[String] = List("yes"),
     textValue: List[String] = List("Some Text"),
     csrfToken: List[String] = List("12345")
 )

--- a/test/testUtils/FormTestData.scala
+++ b/test/testUtils/FormTestData.scala
@@ -1,0 +1,97 @@
+package testUtils
+
+import graphql.codegen.GetCustomMetadata.customMetadata.CustomMetadata
+import graphql.codegen.GetCustomMetadata.customMetadata.CustomMetadata.Values
+import graphql.codegen.GetCustomMetadata.customMetadata.CustomMetadata.Values.Dependencies
+import graphql.codegen.types.DataType.{Boolean, DateTime, Integer, Text}
+import graphql.codegen.types.PropertyType.{Defined, Supplied}
+
+class FormTestData() {
+
+  // scalastyle:off method.length
+  def setupCustomMetadatas(): List[CustomMetadata] = {
+    val foiExemptionAsserted = CustomMetadata(
+      "FoiExemptionAsserted",
+      Some("Date of the Advisory Council approval (or SIRO approval if appropriate)"),
+      Some("FOI decision asserted"),
+      Supplied,
+      Some("MandatoryMetadata"),
+      DateTime,
+      editable = true,
+      multiValue = false,
+      defaultValue = None,
+      1,
+      values = Nil,
+      None,
+      allowExport = false
+    )
+    val closureStartDate = CustomMetadata(
+      "ClosureStartDate",
+      Some("This has been defaulted to the last date modified. If this is not correct, amend the field below."),
+      Some("Closure start date"),
+      Supplied,
+      Some("OptionalClosure"),
+      DateTime,
+      editable = true,
+      multiValue = false,
+      defaultValue = None,
+      2,
+      Nil,
+      None,
+      allowExport = false
+    )
+    val closurePeriod = CustomMetadata(
+      "ClosurePeriod",
+      Some("Number of years the record is closed from the closure start date"),
+      Some("Closure period"),
+      Supplied,
+      Some("MandatoryMetadata"),
+      Integer,
+      editable = true,
+      multiValue = false,
+      defaultValue = None,
+      3,
+      values = Nil,
+      None,
+      allowExport = false
+    )
+    val dropdown = CustomMetadata(
+      "Dropdown",
+      Some("A dropdown property"),
+      Some("Dropdown"),
+      Defined,
+      Some("Dropdown property group"),
+      Text,
+      editable = true,
+      multiValue = false,
+      defaultValue = None,
+      4,
+      List(
+        Values("dropdownValue", List(Dependencies("TestDropdownProperty")), 3)
+      ),
+      None,
+      allowExport = false
+    )
+    val radio = CustomMetadata(
+      "Radio",
+      Some("A radio "),
+      Some("Radio property"),
+      Supplied,
+      Some("MandatoryMetadata"),
+      Boolean,
+      editable = true,
+      multiValue = false,
+      defaultValue = None,
+      5,
+      List(
+        Values("yes", List(Dependencies("TestProperty2")), 1),
+        Values("no", Nil, 2)
+      ),
+      None,
+      allowExport = false
+    )
+
+    List(foiExemptionAsserted, closureStartDate, closurePeriod, dropdown, radio)
+  }
+  // scalastyle:on method.length
+}


### PR DESCRIPTION
I have replaced the `allProperties` declaration with a new `FormTestData` class. This should hopefully make it a bit easier to test the custom metadata form because it is easier to tell which property you are testing i.e. 'Dropdown' instead of 'TestProperty4'.