### PR TITLE
TDR-2682 Add multi value properties to metadata csv

### DIFF
--- a/app/controllers/DownloadMetadataController.scala
+++ b/app/controllers/DownloadMetadataController.scala
@@ -42,8 +42,8 @@ class DownloadMetadataController @Inject() (
       val filteredMetadata = customMetadata.filter(_.allowExport).sortBy(_.exportOrdinal.getOrElse(Int.MaxValue))
       val header: List[String] = filteredMetadata.map(f => f.fullName.getOrElse(f.name))
       val rows: List[List[String]] = metadata.files.map(file => {
-        val groupedMetadata = file.fileMetadata.groupBy(_.name).view.mapValues(_.head).toMap
-        filteredMetadata.map(fm => groupedMetadata.value(fm.name))
+        val groupedMetadata = file.fileMetadata.groupBy(_.name).view.mapValues(_.map(_.value).mkString("|")).toMap
+        filteredMetadata.map(fm => groupedMetadata.getOrElse(fm.name, ""))
       })
       val csvString = CsvUtils.writeCsv(header :: rows)
       Ok(csvString)

--- a/test/controllers/DownloadMetadataControllerSpec.scala
+++ b/test/controllers/DownloadMetadataControllerSpec.scala
@@ -106,6 +106,30 @@ class DownloadMetadataControllerSpec extends FrontEndTestHelper {
       csvList.last("File Name") must equal("FileName2")
     }
 
+    "download the csv for rows with multiple values" in {
+      val customProperties = List(
+        customMetadata("TestProperty1", "Test Property 1"),
+        customMetadata("TestProperty2", "Test Property 2"),
+        customMetadata("FileName", "File Name")
+      )
+      val metadataFileOne = List(
+        FileMetadata("TestProperty1", "TestValue1File1"),
+        FileMetadata("TestProperty2", "TestValue2File1"),
+        FileMetadata("TestProperty2", "TestValue2File2"),
+        FileMetadata("FileName", "FileName1")
+      )
+      val files = List(
+        gcfm.GetConsignment.Files(UUID.randomUUID(), Some("FileName"), metadataFileOne),
+      )
+
+      val csvList: List[Map[String, String]] = getCsvFromController(customProperties, files).toLazyListWithHeaders().toList
+
+      csvList.size must equal(1)
+      csvList.head("Test Property 1") must equal("TestValue1File1")
+      csvList.head("Test Property 2") must equal("TestValue2File1|TestValue2File2")
+      csvList.head("File Name") must equal("FileName1")
+    }
+
     "ignore fields set with allowExport set to false" in {
       val customProperties = List(
         customMetadata("TestProperty1", "Test Property 1", allowExport = false),

--- a/test/controllers/DownloadMetadataControllerSpec.scala
+++ b/test/controllers/DownloadMetadataControllerSpec.scala
@@ -119,7 +119,7 @@ class DownloadMetadataControllerSpec extends FrontEndTestHelper {
         FileMetadata("FileName", "FileName1")
       )
       val files = List(
-        gcfm.GetConsignment.Files(UUID.randomUUID(), Some("FileName"), metadataFileOne),
+        gcfm.GetConsignment.Files(UUID.randomUUID(), Some("FileName"), metadataFileOne)
       )
 
       val csvList: List[Map[String, String]] = getCsvFromController(customProperties, files).toLazyListWithHeaders().toList

--- a/test/controllers/DownloadMetadataControllerSpec.scala
+++ b/test/controllers/DownloadMetadataControllerSpec.scala
@@ -115,7 +115,7 @@ class DownloadMetadataControllerSpec extends FrontEndTestHelper {
       val metadataFileOne = List(
         FileMetadata("TestProperty1", "TestValue1File1"),
         FileMetadata("TestProperty2", "TestValue2File1"),
-        FileMetadata("TestProperty2", "TestValue2File2"),
+        FileMetadata("TestProperty2", "TestValue3File1"),
         FileMetadata("FileName", "FileName1")
       )
       val files = List(
@@ -126,7 +126,7 @@ class DownloadMetadataControllerSpec extends FrontEndTestHelper {
 
       csvList.size must equal(1)
       csvList.head("Test Property 1") must equal("TestValue1File1")
-      csvList.head("Test Property 2") must equal("TestValue2File1|TestValue2File2")
+      csvList.head("Test Property 2") must equal("TestValue2File1|TestValue3File1")
       csvList.head("File Name") must equal("FileName1")
     }
 


### PR DESCRIPTION
Multi-properties are added to a single column using a '|' delimiter