### PR TITLE
TDR-2609 Retain selection for TitleClosed & DescriptionClosed when submitting partial form

### DIFF
--- a/app/controllers/AddAdditionalMetadataController.scala
+++ b/app/controllers/AddAdditionalMetadataController.scala
@@ -302,7 +302,7 @@ class AddAdditionalMetadataController @Inject() (
         case radioButtonGroupField: RadioButtonGroupField =>
           metadataMap
             .get(radioButtonGroupField.fieldId)
-            .map(metadata => RadioButtonGroupField.update(radioButtonGroupField, stringToBoolean(metadata.value)))
+            .map(_ => RadioButtonGroupField.update(radioButtonGroupField, stringToBoolean(radioButtonGroupField.selectedOption)))
             .getOrElse(radioButtonGroupField)
         case textField: TextField =>
           metadataMap


### PR DESCRIPTION
This change makes it so that when submitting a partial form, the users selection for TitleClosed & Description Closed is retained.