### PR TITLE
TDR-2767 Correctly format datetime datatypes for download csv

### DIFF
--- a/app/controllers/DownloadMetadataController.scala
+++ b/app/controllers/DownloadMetadataController.scala
@@ -47,13 +47,18 @@ class DownloadMetadataController @Inject() (
       val header: List[String] = filteredMetadata.map(f => f.fullName.getOrElse(f.name))
       val fileMetadataRows: List[List[String]] = metadata.files.map(file => {
         val groupedMetadata = file.fileMetadata.groupBy(_.name).view.mapValues(_.map(_.value).mkString("|")).toMap
-        filteredMetadata.map(customMetadata => groupedMetadata.get(customMetadata.name).map(fileMetadataValue => {
-          if (filteredMetadata.find(_.name == customMetadata.name).exists(_.dataType == DataType.DateTime)) {
-            LocalDateTime.parse(fileMetadataValue, parseFormatter).format(formatter)
-          } else {
-            fileMetadataValue
-          }
-        }).getOrElse(""))
+        filteredMetadata.map(customMetadata =>
+          groupedMetadata
+            .get(customMetadata.name)
+            .map(fileMetadataValue => {
+              if (filteredMetadata.find(_.name == customMetadata.name).exists(_.dataType == DataType.DateTime)) {
+                LocalDateTime.parse(fileMetadataValue, parseFormatter).format(formatter)
+              } else {
+                fileMetadataValue
+              }
+            })
+            .getOrElse("")
+        )
       })
       val csvString = CsvUtils.writeCsv(header :: fileMetadataRows)
       Ok(csvString)

--- a/app/controllers/DownloadMetadataController.scala
+++ b/app/controllers/DownloadMetadataController.scala
@@ -4,11 +4,14 @@ import auth.TokenSecurity
 import configuration.KeycloakConfiguration
 import controllers.util.CsvUtils
 import graphql.codegen.GetConsignmentFilesMetadata.getConsignmentFilesMetadata.GetConsignment.Files.FileMetadata
-import graphql.codegen.types.FileFilters
+import graphql.codegen.GetCustomMetadata.customMetadata.CustomMetadata
+import graphql.codegen.types.DataType
 import org.pac4j.play.scala.SecurityComponents
 import play.api.mvc.{Action, AnyContent, Request}
 import services.{ConsignmentService, CustomMetadataService}
 
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 import java.util.UUID
 import javax.inject.Inject
 
@@ -35,16 +38,24 @@ class DownloadMetadataController @Inject() (
 
   def downloadMetadataCsv(consignmentId: UUID): Action[AnyContent] = standardTypeAction(consignmentId) { implicit request: Request[AnyContent] =>
     for {
-      metadata <- consignmentService.getConsignmentFileMetadata(consignmentId, request.token.bearerAccessToken, None, None, None)
+      metadata <- consignmentService.getConsignmentFileMetadata(consignmentId, request.token.bearerAccessToken, None, None)
       customMetadata <- customMetadataService.getCustomMetadata(consignmentId, request.token.bearerAccessToken)
     } yield {
-      val filteredMetadata = customMetadata.filter(_.allowExport).sortBy(_.exportOrdinal.getOrElse(Int.MaxValue))
+      val parseFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd[ ]['T']HH:mm:ss[.SSS][.SS][.S]")
+      val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")
+      val filteredMetadata: List[CustomMetadata] = customMetadata.filter(_.allowExport).sortBy(_.exportOrdinal.getOrElse(Int.MaxValue))
       val header: List[String] = filteredMetadata.map(f => f.fullName.getOrElse(f.name))
-      val rows: List[List[String]] = metadata.files.map(file => {
+      val fileMetadataRows: List[List[String]] = metadata.files.map(file => {
         val groupedMetadata = file.fileMetadata.groupBy(_.name).view.mapValues(_.map(_.value).mkString("|")).toMap
-        filteredMetadata.map(fm => groupedMetadata.getOrElse(fm.name, ""))
+        filteredMetadata.map(customMetadata => groupedMetadata.get(customMetadata.name).map(fileMetadataValue => {
+          if (filteredMetadata.find(_.name == customMetadata.name).exists(_.dataType == DataType.DateTime)) {
+            LocalDateTime.parse(fileMetadataValue, parseFormatter).format(formatter)
+          } else {
+            fileMetadataValue
+          }
+        }).getOrElse(""))
       })
-      val csvString = CsvUtils.writeCsv(header :: rows)
+      val csvString = CsvUtils.writeCsv(header :: fileMetadataRows)
       Ok(csvString)
         .as("text/csv")
         .withHeaders("Content-Disposition" -> s"attachment; filename=${metadata.consignmentReference}-metadata.csv")

--- a/test/controllers/DownloadMetadataControllerSpec.scala
+++ b/test/controllers/DownloadMetadataControllerSpec.scala
@@ -8,7 +8,7 @@ import graphql.codegen.GetConsignmentFilesMetadata.getConsignmentFilesMetadata.G
 import graphql.codegen.GetConsignmentFilesMetadata.getConsignmentFilesMetadata.GetConsignment.Files.FileMetadata
 import graphql.codegen.GetCustomMetadata.{customMetadata => cm}
 import graphql.codegen.GetConsignmentFilesMetadata.{getConsignmentFilesMetadata => gcfm}
-import graphql.codegen.types.DataType.Text
+import graphql.codegen.types.DataType.{DateTime, Text}
 import graphql.codegen.types.PropertyType.Supplied
 import io.circe.Printer
 import io.circe.generic.auto._
@@ -22,6 +22,8 @@ import testUtils.{CheckPageForStaticElements, FrontEndTestHelper}
 import uk.gov.nationalarchives.tdr.GraphQLClient
 
 import java.io.StringReader
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 import java.util.UUID
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -30,8 +32,13 @@ class DownloadMetadataControllerSpec extends FrontEndTestHelper {
   val wiremockServer = new WireMockServer(9006)
   val checkPageForStaticElements = new CheckPageForStaticElements()
 
-  def customMetadata(name: String, fullName: String, exportOrdinal: Int = Int.MaxValue, allowExport: Boolean = true): cm.CustomMetadata =
-    cm.CustomMetadata(name, None, Option(fullName), Supplied, None, Text, editable = false, multiValue = false, None, 1, Nil, Option(exportOrdinal), allowExport)
+  def customMetadata(name: String, fullName: String, exportOrdinal: Int = Int.MaxValue, allowExport: Boolean = true): cm.CustomMetadata = {
+    if(name == "DateTimeProperty"){
+      cm.CustomMetadata(name, None, Option(fullName), Supplied, None, DateTime, editable = false, multiValue = false, None, 1, Nil, Option(exportOrdinal), allowExport)
+    } else {
+      cm.CustomMetadata(name, None, Option(fullName), Supplied, None, Text, editable = false, multiValue = false, None, 1, Nil, Option(exportOrdinal), allowExport)
+    }
+  }
 
   override def beforeEach(): Unit = {
     wiremockServer.start()
@@ -44,14 +51,17 @@ class DownloadMetadataControllerSpec extends FrontEndTestHelper {
 
   "DownloadMetadataController downloadMetadataCsv GET" should {
     "download the csv for a multiple properties and rows" in {
+      val lastModified = LocalDateTime.parse("2021-02-03T10:33:30.414")
       val customProperties = List(
         customMetadata("TestProperty1", "Test Property 1"),
         customMetadata("TestProperty2", "Test Property 2"),
+        customMetadata("DateTimeProperty", "DateTime Property"),
         customMetadata("FileName", "File Name")
       )
       val metadataFileOne = List(
         FileMetadata("TestProperty1", "TestValue1File1"),
         FileMetadata("TestProperty2", "TestValue2File1"),
+        FileMetadata("DateTimeProperty", lastModified.format(DateTimeFormatter.ISO_DATE_TIME)),
         FileMetadata("FileName", "FileName1")
       )
       val metadataFileTwo = List(
@@ -69,6 +79,7 @@ class DownloadMetadataControllerSpec extends FrontEndTestHelper {
       csvList.size must equal(2)
       csvList.head("Test Property 1") must equal("TestValue1File1")
       csvList.head("Test Property 2") must equal("TestValue2File1")
+      csvList.head("DateTime Property") must equal("2021-02-03T10:33:30")
       csvList.head("File Name") must equal("FileName1")
       csvList.last("Test Property 1") must equal("TestValue1File2")
       csvList.last("Test Property 2") must equal("TestValue2File2")
@@ -127,6 +138,30 @@ class DownloadMetadataControllerSpec extends FrontEndTestHelper {
       csvList.size must equal(1)
       csvList.head("Test Property 1") must equal("TestValue1File1")
       csvList.head("Test Property 2") must equal("TestValue2File1|TestValue3File1")
+      csvList.head("File Name") must equal("FileName1")
+    }
+
+    "download the csv for datetime rows to include the seconds to the file when the input seconds are zero" in {
+      val lastModified = LocalDateTime.parse("2021-02-03T10:33:00.0")
+      val customProperties = List(
+        customMetadata("TestProperty1", "Test Property 1"),
+        customMetadata("DateTimeProperty", "DateTime Property"),
+        customMetadata("FileName", "File Name")
+      )
+      val metadataFileOne = List(
+        FileMetadata("TestProperty1", "TestValue1File1"),
+        FileMetadata("DateTimeProperty", lastModified.format(DateTimeFormatter.ISO_DATE_TIME)),
+        FileMetadata("FileName", "FileName1")
+      )
+      val files = List(
+        gcfm.GetConsignment.Files(UUID.randomUUID(), Some("FileName"), metadataFileOne),
+      )
+
+      val csvList: List[Map[String, String]] = getCsvFromController(customProperties, files).toLazyListWithHeaders().toList
+
+      csvList.size must equal(1)
+      csvList.head("Test Property 1") must equal("TestValue1File1")
+      csvList.head("DateTime Property") must equal("2021-02-03T10:33:00")
       csvList.head("File Name") must equal("FileName1")
     }
 

--- a/test/controllers/DownloadMetadataControllerSpec.scala
+++ b/test/controllers/DownloadMetadataControllerSpec.scala
@@ -33,7 +33,7 @@ class DownloadMetadataControllerSpec extends FrontEndTestHelper {
   val checkPageForStaticElements = new CheckPageForStaticElements()
 
   def customMetadata(name: String, fullName: String, exportOrdinal: Int = Int.MaxValue, allowExport: Boolean = true): cm.CustomMetadata = {
-    if(name == "DateTimeProperty"){
+    if (name == "DateTimeProperty") {
       cm.CustomMetadata(name, None, Option(fullName), Supplied, None, DateTime, editable = false, multiValue = false, None, 1, Nil, Option(exportOrdinal), allowExport)
     } else {
       cm.CustomMetadata(name, None, Option(fullName), Supplied, None, Text, editable = false, multiValue = false, None, 1, Nil, Option(exportOrdinal), allowExport)
@@ -154,7 +154,7 @@ class DownloadMetadataControllerSpec extends FrontEndTestHelper {
         FileMetadata("FileName", "FileName1")
       )
       val files = List(
-        gcfm.GetConsignment.Files(UUID.randomUUID(), Some("FileName"), metadataFileOne),
+        gcfm.GetConsignment.Files(UUID.randomUUID(), Some("FileName"), metadataFileOne)
       )
 
       val csvList: List[Map[String, String]] = getCsvFromController(customProperties, files).toLazyListWithHeaders().toList


### PR DESCRIPTION
Similar to how the bagit export handles datetime fields. This allows the date fields to be viewable in the downloaded csv