### PR TITLE
Collapse folder beforehand preventing delayed collapsing after page load

### DIFF
--- a/app/views/standard/additionalMetadataNavigation.scala.html
+++ b/app/views/standard/additionalMetadataNavigation.scala.html
@@ -16,7 +16,7 @@
       </div>
     </li>
   } else {
-    <li class="tna-tree__node-item-radios" role="treeitem" id="radios-list-@file.id" aria-expanded="true" aria-selected="false" aria-level="@level" aria-setsize="@size" aria-posinset="@pos" tabindex="0">
+    <li class="tna-tree__node-item-radios" role="treeitem" id="radios-list-@file.id" aria-expanded="false" aria-selected="false" aria-level="@level" aria-setsize="@size" aria-posinset="@pos" tabindex="0">
       <div class="tna-tree__node-item__container">
         <button class="tna-tree__expander js-tree__expander--radios" tabindex="-1" id="radios-expander-@file.id">
           <span class="govuk-visually-hidden">Expand</span>


### PR DESCRIPTION
Previously, when you load the page, the folder is expanded then the JavaScript (once the page has loaded) will collapse it; this is annoying because when you go to click a file, the folder then collapses