### PR TITLE
Add email addresses to Messages file

### DIFF
--- a/app/views/contact.scala.html
+++ b/app/views/contact.scala.html
@@ -7,7 +7,7 @@
             <p class="govuk-body">If you have got feedback, ideas or questions get in touch with the Transfer Digital Records team</p>
 
             <h1 class="govuk-heading-l">Email</h1>
-            <p class="govuk-body"><a class="govuk-link" href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")" data-hsupport="email">@Messages("nationalArchives.emailForHtmlTemplates")</a></p>
+            <p class="govuk-body"><a class="govuk-link" href="mailto:@Messages("nationalArchives.email")" data-hsupport="email">@Messages("nationalArchives.email")</a></p>
 
         </div>
     </div>

--- a/app/views/contact.scala.html
+++ b/app/views/contact.scala.html
@@ -7,7 +7,7 @@
             <p class="govuk-body">If you have got feedback, ideas or questions get in touch with the Transfer Digital Records team</p>
 
             <h1 class="govuk-heading-l">Email</h1>
-            <p class="govuk-body"><a class="govuk-link" href="mailto:tdr@@nationalarchives.gov.uk" data-hsupport="email">tdr@@nationalarchives.gov.uk</a></p>
+            <p class="govuk-body"><a class="govuk-link" href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")" data-hsupport="email">@Messages("nationalArchives.emailForHtmlTemplates")</a></p>
 
         </div>
     </div>

--- a/app/views/faq.scala.html
+++ b/app/views/faq.scala.html
@@ -47,12 +47,12 @@
 
             <h3 id="sign-in-email" class="govuk-heading-s">Which email should I use to sign-in?</h3>
             <p class="govuk-body">
-                Use the email that you used to create your account. If your email address changes, send full details of the change to <a href="mailto:tdr@@nationalarchives.gov.uk">tdr@@nationalarchives.gov.uk</a>.
+                Use the email that you used to create your account. If your email address changes, send full details of the change to <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">@Messages("nationalArchives.emailForHtmlTemplates")</a>.
             </p>
 
             <h3 id="password-not-working" class="govuk-heading-s">My password does not work</h3>
             <p class="govuk-body">
-                If you forget your password or need to reset it, click the ‘Forgot your password?’ link on the sign in page to request a reset and follow the on-screen instructions. For any other password issue, email <a href="mailto:tdr@@nationalarchives.gov.uk">tdr@@nationalarchives.gov.uk</a>.
+                If you forget your password or need to reset it, click the ‘Forgot your password?’ link on the sign in page to request a reset and follow the on-screen instructions. For any other password issue, email <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">@Messages("nationalArchives.emailForHtmlTemplates")</a>.
             </p>
 
             <h3 id="what-is-mfa" class="govuk-heading-s">What is multi-factor authentication (MFA)?</h3>
@@ -114,7 +114,7 @@
 
             <h3 class="govuk-heading-s">My link has expired</h3>
             <p class="govuk-body">
-                If your link has expired before use, email <a href="mailto:tdr@@nationalarchives.gov.uk">tdr@@nationalarchives.gov.uk</a> from your work email account and ask for a new link. Allow up to 2 working days for your request to be processed.
+                If your link has expired before use, email <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">@Messages("nationalArchives.emailForHtmlTemplates")</a> from your work email account and ask for a new link. Allow up to 2 working days for your request to be processed.
             </p>
 
             <h3 class="govuk-heading-s">Can I share my sign-in information?</h3>
@@ -128,8 +128,8 @@
 
             <h3 class="govuk-heading-s">I cannot choose my series reference</h3>
             <p class="govuk-body">
-                If you cannot find your series reference in the dropdown list on the ‘Series reference’ page when you begin the transfer process, contact <a href="mailto:tdr@@nationalarchives.gov.uk">
-                tdr@@nationalarchives.gov.uk</a>.
+                If you cannot find your series reference in the dropdown list on the ‘Series reference’ page when you begin the transfer process, contact <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">
+                @Messages("nationalArchives.emailForHtmlTemplates")</a>.
             </p>
 
             <h3 class="govuk-heading-s">What is a consignment reference?</h3>
@@ -149,15 +149,15 @@
 
             <h3 id="other-languages" class="govuk-heading-s">The records I wish to transfer are in another language (for example, Welsh)</h3>
             <p class="govuk-body">
-                The National Archives accepts records in any language. However, during this initial private beta stage, TDR can only accept records that are in English. Contact <a href="mailto:tdr@@nationalarchives.gov.uk">
-                tdr@@nationalarchives.gov.uk</a> to discuss the best way to transfer records that are not in English.
+                The National Archives accepts records in any language. However, during this initial private beta stage, TDR can only accept records that are in English. Contact <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">
+                @Messages("nationalArchives.emailForHtmlTemplates")</a> to discuss the best way to transfer records that are not in English.
             </p>
 
             <h3 class="govuk-heading-s">What file formats are accepted?</h3>
             <p class="govuk-body">We cannot accept files that are password protected or encrypted.</p>
             <p class="govuk-body">
-                We also cannot currently accept zip files via TDR. Contact <a href="mailto:tdr@@nationalarchives.gov.uk">
-                tdr@@nationalarchives.gov.uk</a> if you wish to transfer these.
+                We also cannot currently accept zip files via TDR. Contact <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">
+                @Messages("nationalArchives.emailForHtmlTemplates")</a> if you wish to transfer these.
             </p>
 
             <h3 class="govuk-heading-s">How do I identify system files, password protected files, executable files, or zip files and folders within my consignment?</h3>
@@ -175,13 +175,13 @@
                 The <a href="https://www.nationalarchives.gov.uk/information-management/manage-information/preserving-digital-records/droid/">
                 DROID tool</a> can help with identifying these files, particularly password protected files which are not immediately obvious by extension alone. File format extensions can also be useful for determining file types, however this can be an unreliable approach, since they can be changed easily. Extensions are the end part of a filename that typically look similar to '.jpg' or '.docx'. They are often hidden by default, but can usually be made visible to help with determining file type. Speak with your local IT Support team if you require assistance with this.
             </p>
-            <p class="govuk-body">Contact <a href="mailto:tdr@@nationalarchives.gov.uk">
-                tdr@@nationalarchives.gov.uk</a> if you have any uncertainty about the file formats you have selected for transfer.
+            <p class="govuk-body">Contact <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">
+                @Messages("nationalArchives.emailForHtmlTemplates")</a> if you have any uncertainty about the file formats you have selected for transfer.
             </p>
 
             <h3 class="govuk-heading-s">Why can’t I drag and drop or upload files?</h3>
             <p class="govuk-body">
-                This may happen for several reasons. To try to resolve the issue, first check your internet connection is sufficient and stable. It may also help to refresh the page (though this might mean you have to begin the transfer process again). You can also check your folder is not corrupted or damaged by opening it on your computer. If you still cannot upload your files, contact <a href="mailto:tdr@@nationalarchives.gov.uk">tdr@@nationalarchives.gov.uk</a> describing the issue and any steps taken.
+                This may happen for several reasons. To try to resolve the issue, first check your internet connection is sufficient and stable. It may also help to refresh the page (though this might mean you have to begin the transfer process again). You can also check your folder is not corrupted or damaged by opening it on your computer. If you still cannot upload your files, contact <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">@Messages("nationalArchives.emailForHtmlTemplates")</a> describing the issue and any steps taken.
             </p>
 
             <h3 class="govuk-heading-s">Can I upload multiple folders?</h3>
@@ -194,13 +194,13 @@
                 We recommend that each file is no more than 2GB and that you upload no more than 500 files per consignment.
                 Uploading more than the recommended size increases the likelihood of errors occurring and may take longer
                 to be uploaded and checked. If your files are very large and cannot be uploaded, contact
-                <a href="mailto:tdr@@nationalarchives.gov.uk">tdr@@nationalarchives.gov.uk</a>.
+                <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">@Messages("nationalArchives.emailForHtmlTemplates")</a>.
             </p>
 
             <h3 class="govuk-heading-s">Can I upload a folder via OneDrive/ Google Drive/ SharePoint?</h3>
             <p class="govuk-body">
-                While we are developing the service (Private Beta stage), TDR can only accept records transferred from a hard or network drive. Contact <a href="mailto:tdr@@nationalarchives.gov.uk">
-                tdr@@nationalarchives.gov.uk</a> to discuss the best way to transfer records if they are not stored on a physical or networked drive.
+                While we are developing the service (Private Beta stage), TDR can only accept records transferred from a hard or network drive. Contact <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">
+                @Messages("nationalArchives.emailForHtmlTemplates")</a> to discuss the best way to transfer records if they are not stored on a physical or networked drive.
             </p>
             <p class="govuk-body">
                 In the future, TDR will begin accepting consignments transferred directly from the cloud.
@@ -208,8 +208,8 @@
 
             <h3 class="govuk-heading-s">I’ve uploaded files that I do not wish to be transferred</h3>
             <p class="govuk-body">
-                During private beta, if you upload files you do not wish to transfer you will need to contact <a href="mailto:tdr@@nationalarchives.gov.uk">
-                tdr@@nationalarchives.gov.uk</a> and begin the process again. Prior to upload, check that each of the files are intended to be uploaded and transferred. The easiest way to remove files you do not wish to be transferred, is to remove those files prior to upload. TDR does not currently allow you to amend your files once the transfer process has begun.
+                During private beta, if you upload files you do not wish to transfer you will need to contact <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">
+                @Messages("nationalArchives.emailForHtmlTemplates")</a> and begin the process again. Prior to upload, check that each of the files are intended to be uploaded and transferred. The easiest way to remove files you do not wish to be transferred, is to remove those files prior to upload. TDR does not currently allow you to amend your files once the transfer process has begun.
             </p>
 
             <h3 class="govuk-heading-s">The session timed out before I completed the upload process</h3>
@@ -249,8 +249,8 @@
                 <li>Your internet connection</li>
                 <li>That your consignment does not contain records we cannot accept.</li>
             </ul>
-            <p class="govuk-body">If you can confirm the above then try again. If your consignment has still failed, contact <a href="mailto:tdr@@nationalarchives.gov.uk">
-                tdr@@nationalarchives.gov.uk</a>.
+            <p class="govuk-body">If you can confirm the above then try again. If your consignment has still failed, contact <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">
+                @Messages("nationalArchives.emailForHtmlTemplates")</a>.
             </p>
 
             <h3 class="govuk-heading-s">Once I have uploaded my records does that mean TNA now has them?</h3>
@@ -283,8 +283,8 @@
 
             <h3 class="govuk-heading-s">Why are you asking me to add descriptive metadata?</h3>
             <p class="govuk-body">
-                During the upload process, TDR runs DROID to capture basic file-level metadata. However, if you have additional information about your records, you should add this. We strongly recommend that you supply this information to us. It can include anything from descriptions to additional dates and any additional data that will provide context to the record and make it easier to find in the future. To do this during private beta, you will need to download DROID and create a metadata CSV which contains the additional metadata. For further assistance, contact <a href="mailto:tdr@@nationalarchives.gov.uk">
-                tdr@@nationalarchives.gov.uk</a>.
+                During the upload process, TDR runs DROID to capture basic file-level metadata. However, if you have additional information about your records, you should add this. We strongly recommend that you supply this information to us. It can include anything from descriptions to additional dates and any additional data that will provide context to the record and make it easier to find in the future. To do this during private beta, you will need to download DROID and create a metadata CSV which contains the additional metadata. For further assistance, contact <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">
+                @Messages("nationalArchives.emailForHtmlTemplates")</a>.
             </p>
 
             <h3 class="govuk-heading-s">Why do I need to export my records when I have already uploaded them to TDR?</h3>
@@ -301,14 +301,14 @@
 
             <h2 class="govuk-heading-m">General</h2>
             <h3 class="govuk-heading-s">Who can I contact if I have a query?</h3>
-            <p class="govuk-body">Contact <a href="mailto:tdr@@nationalarchives.gov.uk">
-                tdr@@nationalarchives.gov.uk</a> if your query is regarding the transfer process, the status of your transfer or to report an error or issue you have encountered. You can also contact us if you have more general queries regarding the suitability of records for transfer, file format or transfer agreement criteria.
+            <p class="govuk-body">Contact <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">
+                @Messages("nationalArchives.emailForHtmlTemplates")</a> if your query is regarding the transfer process, the status of your transfer or to report an error or issue you have encountered. You can also contact us if you have more general queries regarding the suitability of records for transfer, file format or transfer agreement criteria.
             </p>
 
             <h3 class="govuk-heading-s">I have not received an email to notify me that my records are in the archive</h3>
             <p class="govuk-body">
-                This process can take up to 90 days. If you do not receive an email after this time, contact <a href="mailto:tdr@@nationalarchives.gov.uk">
-                tdr@@nationalarchives.gov.uk</a>.
+                This process can take up to 90 days. If you do not receive an email after this time, contact <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">
+                @Messages("nationalArchives.emailForHtmlTemplates")</a>.
             </p>
 
             <h3 class="govuk-heading-s">Where can I see the history of my consignments?</h3>

--- a/app/views/faq.scala.html
+++ b/app/views/faq.scala.html
@@ -47,12 +47,12 @@
 
             <h3 id="sign-in-email" class="govuk-heading-s">Which email should I use to sign-in?</h3>
             <p class="govuk-body">
-                Use the email that you used to create your account. If your email address changes, send full details of the change to <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">@Messages("nationalArchives.emailForHtmlTemplates")</a>.
+                Use the email that you used to create your account. If your email address changes, send full details of the change to <a href="mailto:@Messages("nationalArchives.email")">@Messages("nationalArchives.email")</a>.
             </p>
 
             <h3 id="password-not-working" class="govuk-heading-s">My password does not work</h3>
             <p class="govuk-body">
-                If you forget your password or need to reset it, click the ‘Forgot your password?’ link on the sign in page to request a reset and follow the on-screen instructions. For any other password issue, email <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">@Messages("nationalArchives.emailForHtmlTemplates")</a>.
+                If you forget your password or need to reset it, click the ‘Forgot your password?’ link on the sign in page to request a reset and follow the on-screen instructions. For any other password issue, email <a href="mailto:@Messages("nationalArchives.email")">@Messages("nationalArchives.email")</a>.
             </p>
 
             <h3 id="what-is-mfa" class="govuk-heading-s">What is multi-factor authentication (MFA)?</h3>
@@ -114,7 +114,7 @@
 
             <h3 class="govuk-heading-s">My link has expired</h3>
             <p class="govuk-body">
-                If your link has expired before use, email <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">@Messages("nationalArchives.emailForHtmlTemplates")</a> from your work email account and ask for a new link. Allow up to 2 working days for your request to be processed.
+                If your link has expired before use, email <a href="mailto:@Messages("nationalArchives.email")">@Messages("nationalArchives.email")</a> from your work email account and ask for a new link. Allow up to 2 working days for your request to be processed.
             </p>
 
             <h3 class="govuk-heading-s">Can I share my sign-in information?</h3>
@@ -128,8 +128,8 @@
 
             <h3 class="govuk-heading-s">I cannot choose my series reference</h3>
             <p class="govuk-body">
-                If you cannot find your series reference in the dropdown list on the ‘Series reference’ page when you begin the transfer process, contact <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">
-                @Messages("nationalArchives.emailForHtmlTemplates")</a>.
+                If you cannot find your series reference in the dropdown list on the ‘Series reference’ page when you begin the transfer process, contact <a href="mailto:@Messages("nationalArchives.email")">
+                @Messages("nationalArchives.email")</a>.
             </p>
 
             <h3 class="govuk-heading-s">What is a consignment reference?</h3>
@@ -149,15 +149,15 @@
 
             <h3 id="other-languages" class="govuk-heading-s">The records I wish to transfer are in another language (for example, Welsh)</h3>
             <p class="govuk-body">
-                The National Archives accepts records in any language. However, during this initial private beta stage, TDR can only accept records that are in English. Contact <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">
-                @Messages("nationalArchives.emailForHtmlTemplates")</a> to discuss the best way to transfer records that are not in English.
+                The National Archives accepts records in any language. However, during this initial private beta stage, TDR can only accept records that are in English. Contact <a href="mailto:@Messages("nationalArchives.email")">
+                @Messages("nationalArchives.email")</a> to discuss the best way to transfer records that are not in English.
             </p>
 
             <h3 class="govuk-heading-s">What file formats are accepted?</h3>
             <p class="govuk-body">We cannot accept files that are password protected or encrypted.</p>
             <p class="govuk-body">
-                We also cannot currently accept zip files via TDR. Contact <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">
-                @Messages("nationalArchives.emailForHtmlTemplates")</a> if you wish to transfer these.
+                We also cannot currently accept zip files via TDR. Contact <a href="mailto:@Messages("nationalArchives.email")">
+                @Messages("nationalArchives.email")</a> if you wish to transfer these.
             </p>
 
             <h3 class="govuk-heading-s">How do I identify system files, password protected files, executable files, or zip files and folders within my consignment?</h3>
@@ -175,13 +175,13 @@
                 The <a href="https://www.nationalarchives.gov.uk/information-management/manage-information/preserving-digital-records/droid/">
                 DROID tool</a> can help with identifying these files, particularly password protected files which are not immediately obvious by extension alone. File format extensions can also be useful for determining file types, however this can be an unreliable approach, since they can be changed easily. Extensions are the end part of a filename that typically look similar to '.jpg' or '.docx'. They are often hidden by default, but can usually be made visible to help with determining file type. Speak with your local IT Support team if you require assistance with this.
             </p>
-            <p class="govuk-body">Contact <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">
-                @Messages("nationalArchives.emailForHtmlTemplates")</a> if you have any uncertainty about the file formats you have selected for transfer.
+            <p class="govuk-body">Contact <a href="mailto:@Messages("nationalArchives.email")">
+                @Messages("nationalArchives.email")</a> if you have any uncertainty about the file formats you have selected for transfer.
             </p>
 
             <h3 class="govuk-heading-s">Why can’t I drag and drop or upload files?</h3>
             <p class="govuk-body">
-                This may happen for several reasons. To try to resolve the issue, first check your internet connection is sufficient and stable. It may also help to refresh the page (though this might mean you have to begin the transfer process again). You can also check your folder is not corrupted or damaged by opening it on your computer. If you still cannot upload your files, contact <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">@Messages("nationalArchives.emailForHtmlTemplates")</a> describing the issue and any steps taken.
+                This may happen for several reasons. To try to resolve the issue, first check your internet connection is sufficient and stable. It may also help to refresh the page (though this might mean you have to begin the transfer process again). You can also check your folder is not corrupted or damaged by opening it on your computer. If you still cannot upload your files, contact <a href="mailto:@Messages("nationalArchives.email")">@Messages("nationalArchives.email")</a> describing the issue and any steps taken.
             </p>
 
             <h3 class="govuk-heading-s">Can I upload multiple folders?</h3>
@@ -194,13 +194,13 @@
                 We recommend that each file is no more than 2GB and that you upload no more than 500 files per consignment.
                 Uploading more than the recommended size increases the likelihood of errors occurring and may take longer
                 to be uploaded and checked. If your files are very large and cannot be uploaded, contact
-                <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">@Messages("nationalArchives.emailForHtmlTemplates")</a>.
+                <a href="mailto:@Messages("nationalArchives.email")">@Messages("nationalArchives.email")</a>.
             </p>
 
             <h3 class="govuk-heading-s">Can I upload a folder via OneDrive/ Google Drive/ SharePoint?</h3>
             <p class="govuk-body">
-                While we are developing the service (Private Beta stage), TDR can only accept records transferred from a hard or network drive. Contact <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">
-                @Messages("nationalArchives.emailForHtmlTemplates")</a> to discuss the best way to transfer records if they are not stored on a physical or networked drive.
+                While we are developing the service (Private Beta stage), TDR can only accept records transferred from a hard or network drive. Contact <a href="mailto:@Messages("nationalArchives.email")">
+                @Messages("nationalArchives.email")</a> to discuss the best way to transfer records if they are not stored on a physical or networked drive.
             </p>
             <p class="govuk-body">
                 In the future, TDR will begin accepting consignments transferred directly from the cloud.
@@ -208,8 +208,8 @@
 
             <h3 class="govuk-heading-s">I’ve uploaded files that I do not wish to be transferred</h3>
             <p class="govuk-body">
-                During private beta, if you upload files you do not wish to transfer you will need to contact <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">
-                @Messages("nationalArchives.emailForHtmlTemplates")</a> and begin the process again. Prior to upload, check that each of the files are intended to be uploaded and transferred. The easiest way to remove files you do not wish to be transferred, is to remove those files prior to upload. TDR does not currently allow you to amend your files once the transfer process has begun.
+                During private beta, if you upload files you do not wish to transfer you will need to contact <a href="mailto:@Messages("nationalArchives.email")">
+                @Messages("nationalArchives.email")</a> and begin the process again. Prior to upload, check that each of the files are intended to be uploaded and transferred. The easiest way to remove files you do not wish to be transferred, is to remove those files prior to upload. TDR does not currently allow you to amend your files once the transfer process has begun.
             </p>
 
             <h3 class="govuk-heading-s">The session timed out before I completed the upload process</h3>
@@ -249,8 +249,8 @@
                 <li>Your internet connection</li>
                 <li>That your consignment does not contain records we cannot accept.</li>
             </ul>
-            <p class="govuk-body">If you can confirm the above then try again. If your consignment has still failed, contact <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">
-                @Messages("nationalArchives.emailForHtmlTemplates")</a>.
+            <p class="govuk-body">If you can confirm the above then try again. If your consignment has still failed, contact <a href="mailto:@Messages("nationalArchives.email")">
+                @Messages("nationalArchives.email")</a>.
             </p>
 
             <h3 class="govuk-heading-s">Once I have uploaded my records does that mean TNA now has them?</h3>
@@ -283,8 +283,8 @@
 
             <h3 class="govuk-heading-s">Why are you asking me to add descriptive metadata?</h3>
             <p class="govuk-body">
-                During the upload process, TDR runs DROID to capture basic file-level metadata. However, if you have additional information about your records, you should add this. We strongly recommend that you supply this information to us. It can include anything from descriptions to additional dates and any additional data that will provide context to the record and make it easier to find in the future. To do this during private beta, you will need to download DROID and create a metadata CSV which contains the additional metadata. For further assistance, contact <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">
-                @Messages("nationalArchives.emailForHtmlTemplates")</a>.
+                During the upload process, TDR runs DROID to capture basic file-level metadata. However, if you have additional information about your records, you should add this. We strongly recommend that you supply this information to us. It can include anything from descriptions to additional dates and any additional data that will provide context to the record and make it easier to find in the future. To do this during private beta, you will need to download DROID and create a metadata CSV which contains the additional metadata. For further assistance, contact <a href="mailto:@Messages("nationalArchives.email")">
+                @Messages("nationalArchives.email")</a>.
             </p>
 
             <h3 class="govuk-heading-s">Why do I need to export my records when I have already uploaded them to TDR?</h3>
@@ -301,14 +301,14 @@
 
             <h2 class="govuk-heading-m">General</h2>
             <h3 class="govuk-heading-s">Who can I contact if I have a query?</h3>
-            <p class="govuk-body">Contact <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">
-                @Messages("nationalArchives.emailForHtmlTemplates")</a> if your query is regarding the transfer process, the status of your transfer or to report an error or issue you have encountered. You can also contact us if you have more general queries regarding the suitability of records for transfer, file format or transfer agreement criteria.
+            <p class="govuk-body">Contact <a href="mailto:@Messages("nationalArchives.email")">
+                @Messages("nationalArchives.email")</a> if your query is regarding the transfer process, the status of your transfer or to report an error or issue you have encountered. You can also contact us if you have more general queries regarding the suitability of records for transfer, file format or transfer agreement criteria.
             </p>
 
             <h3 class="govuk-heading-s">I have not received an email to notify me that my records are in the archive</h3>
             <p class="govuk-body">
-                This process can take up to 90 days. If you do not receive an email after this time, contact <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">
-                @Messages("nationalArchives.emailForHtmlTemplates")</a>.
+                This process can take up to 90 days. If you do not receive an email after this time, contact <a href="mailto:@Messages("nationalArchives.email")">
+                @Messages("nationalArchives.email")</a>.
             </p>
 
             <h3 class="govuk-heading-s">Where can I see the history of my consignments?</h3>

--- a/app/views/fileChecksResultsFailed.scala.html
+++ b/app/views/fileChecksResultsFailed.scala.html
@@ -20,8 +20,8 @@
           <div class="govuk-error-summary__body">
             @if(isJudgmentUser) {
               <p class="govuk-body">Your file has failed our checks. Please try again. If this continues, contact us at
-                <a class="govuk-link" href="mailto:tdr@@nationalarchives.gov.uk" data-hsupport="email">
-                  tdr@@nationalarchives.gov.uk
+                <a class="govuk-link" href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")" data-hsupport="email">
+                  @Messages("nationalArchives.emailForHtmlTemplates")
                 </a>
               </p>
             } else {

--- a/app/views/fileChecksResultsFailed.scala.html
+++ b/app/views/fileChecksResultsFailed.scala.html
@@ -20,8 +20,8 @@
           <div class="govuk-error-summary__body">
             @if(isJudgmentUser) {
               <p class="govuk-body">Your file has failed our checks. Please try again. If this continues, contact us at
-                <a class="govuk-link" href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")" data-hsupport="email">
-                  @Messages("nationalArchives.emailForHtmlTemplates")
+                <a class="govuk-link" href="mailto:@Messages("nationalArchives.email")" data-hsupport="email">
+                  @Messages("nationalArchives.email")
                 </a>
               </p>
             } else {

--- a/app/views/help.scala.html
+++ b/app/views/help.scala.html
@@ -117,7 +117,7 @@
 
             <h3 class="govuk-heading-s" id="contact">Contact us</h3>
             <p class="govuk-body">
-                If you have a query regarding the transfer process, the status of your transfer or to report an error or issue you have encountered, please contact <a href="mailto:tdr@@nationalarchives.gov.uk">tdr@@nationalarchives.gov.uk</a>
+                If you have a query regarding the transfer process, the status of your transfer or to report an error or issue you have encountered, please contact <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">@Messages("nationalArchives.emailForHtmlTemplates")</a>
             </p>
             <p class="govuk-body">
                 You can also contact us if you have more general queries regarding the suitability of records for transfer, file format or transfer agreement criteria.
@@ -126,12 +126,12 @@
             <h2 class="govuk-heading-m" id="registering-new-account">Registering for a new account</h2>
             <h3 class="govuk-heading-s" id="new-user-email">Part 1: New user email</h3>
             <ol class="govuk-list govuk-list--number">
-                <li>If you want to register for a new TDR account, email <a href="mailto:tdr@@nationalarchives.gov.uk">tdr@@nationalarchives.gov.uk</a> from your work email account and ask to register as a new user, stating clearly your first name and surname.
+                <li>If you want to register for a new TDR account, email <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">@Messages("nationalArchives.emailForHtmlTemplates")</a> from your work email account and ask to register as a new user, stating clearly your first name and surname.
                     Allow up to 2 working days for your request to be processed.</li>
                 <li>Once you have been validated for an account, you will be sent an email with the subject 'Register for your Transfer Digital Records (TDR) account - ACTION REQUIRED' which contains important registration instructions.</li>
                 <li>You will receive an email shortly after with the subject 'Update Your Account', containing a link that expires after 12 hours.
                     Please click the link before it expires to begin your registration.
-                    <span class="govuk-!-font-weight-bold">If your link has expired before you could use it, email <a href="mailto:tdr@@nationalarchives.gov.uk">tdr@@nationalarchives.gov.uk</a> and request a new registration link.</span></li>
+                    <span class="govuk-!-font-weight-bold">If your link has expired before you could use it, email <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">@Messages("nationalArchives.emailForHtmlTemplates")</a> and request a new registration link.</span></li>
                 <li>The link will take you to this page:</li>
                 <img src="@routes.Assets.versioned("images/configure-otp-password-page.png")" class="screenshots" alt="Sign in page with a link to setup MFA and password" />
                 <li>Click on the 'Configure OTP, Update Password' link to set up your 'One-time password' (OTP), sometimes referred to as 'One-time PIN', for secure sign in using multi-factor authentication.</li>
@@ -231,7 +231,7 @@
                 <img src="@routes.Assets.versioned("images/standard-selected-series-page.png")" class="screenshots" alt="TDR series selected page" />
             </ol>
             <p class="govuk-body">
-                If you cannot see the correct series reference please contact <a href="mailto:tdr@@nationalarchives.gov.uk">tdr@@nationalarchives.gov.uk</a>.
+                If you cannot see the correct series reference please contact <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">@Messages("nationalArchives.emailForHtmlTemplates")</a>.
             </p>
 
             <h3 class="govuk-heading-s" id="transfer-agreement">Step two: Transfer agreement</h3>
@@ -349,7 +349,7 @@
             </p>
             <p class="govuk-body">
                 During private beta, this process can take up to 90 days.
-                If you do not receive an email after this time, please contact <a href="mailto:tdr@@nationalarchives.gov.uk">tdr@@nationalarchives.gov.uk</a>.
+                If you do not receive an email after this time, please contact <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">@Messages("nationalArchives.emailForHtmlTemplates")</a>.
             </p>
 
             <h2 class="govuk-heading-m" id="glossary">Glossary</h2>

--- a/app/views/help.scala.html
+++ b/app/views/help.scala.html
@@ -117,7 +117,7 @@
 
             <h3 class="govuk-heading-s" id="contact">Contact us</h3>
             <p class="govuk-body">
-                If you have a query regarding the transfer process, the status of your transfer or to report an error or issue you have encountered, please contact <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">@Messages("nationalArchives.emailForHtmlTemplates")</a>
+                If you have a query regarding the transfer process, the status of your transfer or to report an error or issue you have encountered, please contact <a href="mailto:@Messages("nationalArchives.email")">@Messages("nationalArchives.email")</a>
             </p>
             <p class="govuk-body">
                 You can also contact us if you have more general queries regarding the suitability of records for transfer, file format or transfer agreement criteria.
@@ -126,12 +126,12 @@
             <h2 class="govuk-heading-m" id="registering-new-account">Registering for a new account</h2>
             <h3 class="govuk-heading-s" id="new-user-email">Part 1: New user email</h3>
             <ol class="govuk-list govuk-list--number">
-                <li>If you want to register for a new TDR account, email <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">@Messages("nationalArchives.emailForHtmlTemplates")</a> from your work email account and ask to register as a new user, stating clearly your first name and surname.
+                <li>If you want to register for a new TDR account, email <a href="mailto:@Messages("nationalArchives.email")">@Messages("nationalArchives.email")</a> from your work email account and ask to register as a new user, stating clearly your first name and surname.
                     Allow up to 2 working days for your request to be processed.</li>
                 <li>Once you have been validated for an account, you will be sent an email with the subject 'Register for your Transfer Digital Records (TDR) account - ACTION REQUIRED' which contains important registration instructions.</li>
                 <li>You will receive an email shortly after with the subject 'Update Your Account', containing a link that expires after 12 hours.
                     Please click the link before it expires to begin your registration.
-                    <span class="govuk-!-font-weight-bold">If your link has expired before you could use it, email <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">@Messages("nationalArchives.emailForHtmlTemplates")</a> and request a new registration link.</span></li>
+                    <span class="govuk-!-font-weight-bold">If your link has expired before you could use it, email <a href="mailto:@Messages("nationalArchives.email")">@Messages("nationalArchives.email")</a> and request a new registration link.</span></li>
                 <li>The link will take you to this page:</li>
                 <img src="@routes.Assets.versioned("images/configure-otp-password-page.png")" class="screenshots" alt="Sign in page with a link to setup MFA and password" />
                 <li>Click on the 'Configure OTP, Update Password' link to set up your 'One-time password' (OTP), sometimes referred to as 'One-time PIN', for secure sign in using multi-factor authentication.</li>
@@ -231,7 +231,7 @@
                 <img src="@routes.Assets.versioned("images/standard-selected-series-page.png")" class="screenshots" alt="TDR series selected page" />
             </ol>
             <p class="govuk-body">
-                If you cannot see the correct series reference please contact <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">@Messages("nationalArchives.emailForHtmlTemplates")</a>.
+                If you cannot see the correct series reference please contact <a href="mailto:@Messages("nationalArchives.email")">@Messages("nationalArchives.email")</a>.
             </p>
 
             <h3 class="govuk-heading-s" id="transfer-agreement">Step two: Transfer agreement</h3>
@@ -349,7 +349,7 @@
             </p>
             <p class="govuk-body">
                 During private beta, this process can take up to 90 days.
-                If you do not receive an email after this time, please contact <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">@Messages("nationalArchives.emailForHtmlTemplates")</a>.
+                If you do not receive an email after this time, please contact <a href="mailto:@Messages("nationalArchives.email")">@Messages("nationalArchives.email")</a>.
             </p>
 
             <h2 class="govuk-heading-m" id="glossary">Glossary</h2>

--- a/app/views/judgment/judgmentBeforeUploading.scala.html
+++ b/app/views/judgment/judgmentBeforeUploading.scala.html
@@ -12,7 +12,7 @@
       <p class="govuk-body govuk-!-margin-bottom-1">Your upload must contain the following information:</p>
       <p class="govuk-body govuk-!-margin-bottom-1">neutral citation, name(s) of judge(s), name(s) of parties, court and judgment date.</p>
 
-      <h2 class="govuk-heading-s">Select <a href="mailto:@Messages("nationalArchives.judgmentEmailForHtmlTemplates")?subject=Ref: @consignmentRef">@Messages("nationalArchives.judgmentEmailForHtmlTemplates")</a>
+      <h2 class="govuk-heading-s">Select <a href="mailto:@Messages("nationalArchives.judgmentsEmail")?subject=Ref: @consignmentRef">@Messages("nationalArchives.judgmentsEmail")</a>
           to generate an automatic email, with the transfer reference included, in order to:
       </h2>
     <ul class="govuk-list govuk-list--bullet">

--- a/app/views/judgment/judgmentBeforeUploading.scala.html
+++ b/app/views/judgment/judgmentBeforeUploading.scala.html
@@ -12,7 +12,7 @@
       <p class="govuk-body govuk-!-margin-bottom-1">Your upload must contain the following information:</p>
       <p class="govuk-body govuk-!-margin-bottom-1">neutral citation, name(s) of judge(s), name(s) of parties, court and judgment date.</p>
 
-      <h2 class="govuk-heading-s">Select <a href="mailto:judgments@@nationalarchives.gov.uk?subject=Ref: @consignmentRef">judgments@@nationalarchives.gov.uk</a>
+      <h2 class="govuk-heading-s">Select <a href="mailto:@Messages("nationalArchives.judgmentEmailForHtmlTemplates")?subject=Ref: @consignmentRef">@Messages("nationalArchives.judgmentEmailForHtmlTemplates")</a>
           to generate an automatic email, with the transfer reference included, in order to:
       </h2>
     <ul class="govuk-list govuk-list--bullet">

--- a/app/views/judgment/judgmentFaq.scala.html
+++ b/app/views/judgment/judgmentFaq.scala.html
@@ -26,7 +26,7 @@
                 Your department may coordinate new account registration for you, in which case you will be notified and receive an emailed link, that will expire after 12 hours of receipt.
             </p>
             <p class="govuk-body">
-                If you are a new user wanting to register for an account, please email the <span class="govuk-!-font-weight-bold">Judiciary Office Judgments Helpdesk</span> at <a href="mailto:Judgments@@judiciary.uk">Judgments@@judiciary.uk</a> and request to register as a new user, stating clearly your first name and surname.
+                If you are a new user wanting to register for an account, please email the <span class="govuk-!-font-weight-bold">Judiciary Office Judgments Helpdesk</span> at <a href="mailto:@Messages("judiciary.emailForHtmlTemplates")">@Messages("judiciary.emailForHtmlTemplates")</a> and request to register as a new user, stating clearly your first name and surname.
             </p>
             <p class="govuk-body">
                 Once you have been validated for an account, sign-in instructions will be emailed to you. Allow up to 2 working days for your request to be processed.
@@ -40,12 +40,12 @@
 
             <h3 class="govuk-heading-s" id="which-email-to-use-to-sign-in">Which email should I use to sign-in?</h3>
             <p class="govuk-body">
-                Use the email that you used to create your account. If your email address changes, send full details of the change to <a href="mailto:tdr@@nationalarchives.gov.uk">tdr@@nationalarchives.gov.uk</a>.
+                Use the email that you used to create your account. If your email address changes, send full details of the change to <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">@Messages("nationalArchives.emailForHtmlTemplates")</a>.
             </p>
 
             <h3 class="govuk-heading-s" id="password-does-not-work">My password does not work</h3>
             <p class="govuk-body">
-                If you forget your password or need to reset it, click the 'Forgot your password?' link on the sign in page to request a reset and follow the on-screen instructions. For any other password issue, email <a href="mailto:tdr@@nationalarchives.gov.uk">tdr@@nationalarchives.gov.uk</a>.
+                If you forget your password or need to reset it, click the 'Forgot your password?' link on the sign in page to request a reset and follow the on-screen instructions. For any other password issue, email <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">@Messages("nationalArchives.emailForHtmlTemplates")</a>.
             </p>
 
             <h3 class="govuk-heading-s" id="what-is-mfa">What is multi-factor authentication (MFA)?</h3>
@@ -107,7 +107,7 @@
 
             <h3 class="govuk-heading-s" id="my-link-has-expired">My link has expired</h3>
             <p class="govuk-body">
-                If your link has expired before use, email <a href="mailto:tdr@@nationalarchives.gov.uk">tdr@@nationalarchives.gov.uk</a> from your work email account and ask for a new link. Allow up to 2 working days for your request to be processed.
+                If your link has expired before use, email <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">@Messages("nationalArchives.emailForHtmlTemplates")</a> from your work email account and ask for a new link. Allow up to 2 working days for your request to be processed.
             </p>
 
             <h3 class="govuk-heading-s" id="can-share-my-sign-in-information">Can I share my sign-in information?</h3>
@@ -123,7 +123,7 @@
 
             <h3 class="govuk-heading-s" id="why-cant-drag-and-drop-or-upload-file">Why can’t I drag and drop or upload a file?</h3>
             <p class="govuk-body">
-                This may happen for several reasons. To try to resolve this issue, first check if your internet connection is sufficient and stable. It may also help to refresh the page (though this might mean you have to begin the transfer process again). You can also check your file is not corrupted or damaged by opening it on your computer. If you still cannot upload your file, contact <a href="mailto:tdr@@nationalarchives.gov.uk">tdr@@nationalarchives.gov.uk</a> describing the issue and any steps taken.
+                This may happen for several reasons. To try to resolve this issue, first check if your internet connection is sufficient and stable. It may also help to refresh the page (though this might mean you have to begin the transfer process again). You can also check your file is not corrupted or damaged by opening it on your computer. If you still cannot upload your file, contact <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">@Messages("nationalArchives.emailForHtmlTemplates")</a> describing the issue and any steps taken.
             </p>
 
             <h3 class="govuk-heading-s" id="can-upload-multiple-files">Can I upload multiple files?</h3>
@@ -138,7 +138,7 @@
 
             <h3 class="govuk-heading-s" id="can-upload-a-file-via-one-drive">Can I upload a file via OneDrive, Google Drive or SharePoint?</h3>
             <p class="govuk-body">
-                While we are developing the service (Private Beta stage), TDR can only accept records transferred from a hard or network drive. Please contact the <span class="govuk-!-font-weight-bold">Judiciary Office Judgments Helpdesk</span> at <a href="mailto:Judgments@@judiciary.uk">Judgments@@judiciary.uk</a> to discuss the best way to transfer records if they are not stored on a physical or networked drive.
+                While we are developing the service (Private Beta stage), TDR can only accept records transferred from a hard or network drive. Please contact the <span class="govuk-!-font-weight-bold">Judiciary Office Judgments Helpdesk</span> at <a href="mailto:@Messages("judiciary.emailForHtmlTemplates")">@Messages("judiciary.emailForHtmlTemplates")</a> to discuss the best way to transfer records if they are not stored on a physical or networked drive.
             </p>
             <p class="govuk-body">
                 In the future, TDR will begin accepting judgments transferred directly from the cloud.
@@ -146,7 +146,7 @@
 
             <h3 class="govuk-heading-s" id="want-to-upload-additional-documents">I want to upload additional documents alongside a judgment</h3>
             <p class="govuk-body">
-                At the moment, this service is for uploading approved judgment documents only. If you need to add supplementary material, email the documents to <a href="mailto:judgments@@nationalarchives.gov.uk">judgments@@nationalarchives.gov.uk</a>, quoting the transfer reference of your judgment.
+                At the moment, this service is for uploading approved judgment documents only. If you need to add supplementary material, email the documents to <a href="mailto:@Messages("nationalArchives.judgmentEmailForHtmlTemplates")">@Messages("nationalArchives.judgmentEmailForHtmlTemplates")</a>, quoting the transfer reference of your judgment.
             </p>
             <p class="govuk-body">
                 You can use the email link on the TDR “Check your file before uploading” to automatically generate an email with the transfer reference in the subject field via your default email account.
@@ -200,7 +200,7 @@
                 <li>That your file is not password protected or encrypted</li>
             </ul>
             <p class="govuk-body">
-                If you can confirm the above then try again. If your file still fails, contact <a href="mailto:tdr@@nationalarchives.gov.uk">tdr@@nationalarchives.gov.uk</a> describing the issue and any steps taken.
+                If you can confirm the above then try again. If your file still fails, contact <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">@Messages("nationalArchives.emailForHtmlTemplates")</a> describing the issue and any steps taken.
             </p>
 
             <h3 class="govuk-heading-s" id="successfuly-checked-does-it-mean-judgment-transferred">When my judgment has been successfully checked, does that mean it has been transferred?</h3>
@@ -228,29 +228,29 @@
 
             <h3 class="govuk-heading-s" id="what-happens-if-editorial-error-in-judgment">What happens if there is an editorial error in my judgment?</h3>
             <p class="govuk-body">
-                Judgments do not undergo editorial checks within TDR. This is done by the Case Law editorial team after we receive the judgment. If errors are identified, we will contact you. If you are aware of any errors before upload, amend the judgment before you begin the upload into TDR. If you notice an error after the judgment has been transferred from TDR, contact <a href="mailto:judgments@@nationalarchives.gov.uk">judgments@@nationalarchives.gov.uk</a> with the neutral citation and transfer reference.
+                Judgments do not undergo editorial checks within TDR. This is done by the Case Law editorial team after we receive the judgment. If errors are identified, we will contact you. If you are aware of any errors before upload, amend the judgment before you begin the upload into TDR. If you notice an error after the judgment has been transferred from TDR, contact <a href="mailto:@Messages("nationalArchives.judgmentEmailForHtmlTemplates")">@Messages("nationalArchives.judgmentEmailForHtmlTemplates")</a> with the neutral citation and transfer reference.
             </p>
 
             <h2 class="govuk-heading-s" id="not-been-notified-judgment-published">I have not been notified that my judgment has been published</h2>
             <p class="govuk-body">
-                If you do not receive confirmation that your judgment has been accepted for preservation after 5 working days, contact <a href="mailto:judgments@@nationalarchives.gov.uk">judgments@@nationalarchives.gov.uk</a>.
+                If you do not receive confirmation that your judgment has been accepted for preservation after 5 working days, contact <a href="mailto:@Messages("nationalArchives.judgmentEmailForHtmlTemplates")">@Messages("nationalArchives.judgmentEmailForHtmlTemplates")</a>.
             </p>
 
             <h2 class="govuk-heading-m" id="general">General</h2>
 
             <h3 class="govuk-heading-s" id="contact-for-general-judgment-process-query">Who can I contact if I have a general query about the judgment process?</h3>
             <p class="govuk-body">
-                Contact the <span class="govuk-!-font-weight-bold">Judiciary Office Judgments Helpdesk</span> at <a href="mailto:Judgments@@judiciary.uk">Judgments@@judiciary.uk</a> for queries regarding the transfer process, what templates to use, how to sign up for TDR, or more general queries regarding the suitability of records for transfer.
+                Contact the <span class="govuk-!-font-weight-bold">Judiciary Office Judgments Helpdesk</span> at <a href="mailto:@Messages("judiciary.emailForHtmlTemplates")">@Messages("judiciary.emailForHtmlTemplates")</a> for queries regarding the transfer process, what templates to use, how to sign up for TDR, or more general queries regarding the suitability of records for transfer.
             </p>
 
             <h3 class="govuk-heading-s" id="contaxct-for-published-judgments-query">Who can I contact if I have a query about published judgments at TNA?</h3>
             <p class="govuk-body">
-                Contact <a href="mailto:judgments@@nationalarchives.gov.uk">judgments@@nationalarchives.gov.uk</a> for queries about completed transfers, supplementary documents, replacing a judgment with an updated version, anonymisation order instructions, or other general queries about the Find Case Law service.
+                Contact <a href="mailto:@Messages("nationalArchives.judgmentEmailForHtmlTemplates")">@Messages("nationalArchives.judgmentEmailForHtmlTemplates")</a> for queries about completed transfers, supplementary documents, replacing a judgment with an updated version, anonymisation order instructions, or other general queries about the Find Case Law service.
             </p>
 
             <h3 class="govuk-heading-s" id="tdr-technical-issue-query">Who can I contact if I have a technical issue with TDR?</h3>
             <p class="govuk-body">
-                Contact <a href="mailto:tdr@@nationalarchives.gov.uk">tdr@@nationalarchives.gov.uk</a> for queries regarding the upload or transfer performance, the status of a transfer within TDR, or to report an issue encountered within TDR.
+                Contact <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">@Messages("nationalArchives.emailForHtmlTemplates")</a> for queries regarding the upload or transfer performance, the status of a transfer within TDR, or to report an issue encountered within TDR.
             </p>
 
             <h3 class="govuk-heading-s" id="tdr-how-secure-judgments">When using TDR, how secure are my judgments?</h3>

--- a/app/views/judgment/judgmentFaq.scala.html
+++ b/app/views/judgment/judgmentFaq.scala.html
@@ -26,7 +26,7 @@
                 Your department may coordinate new account registration for you, in which case you will be notified and receive an emailed link, that will expire after 12 hours of receipt.
             </p>
             <p class="govuk-body">
-                If you are a new user wanting to register for an account, please email the <span class="govuk-!-font-weight-bold">Judiciary Office Judgments Helpdesk</span> at <a href="mailto:@Messages("judiciary.emailForHtmlTemplates")">@Messages("judiciary.emailForHtmlTemplates")</a> and request to register as a new user, stating clearly your first name and surname.
+                If you are a new user wanting to register for an account, please email the <span class="govuk-!-font-weight-bold">Judiciary Office Judgments Helpdesk</span> at <a href="mailto:@Messages("judiciary.email")">@Messages("judiciary.email")</a> and request to register as a new user, stating clearly your first name and surname.
             </p>
             <p class="govuk-body">
                 Once you have been validated for an account, sign-in instructions will be emailed to you. Allow up to 2 working days for your request to be processed.
@@ -40,12 +40,12 @@
 
             <h3 class="govuk-heading-s" id="which-email-to-use-to-sign-in">Which email should I use to sign-in?</h3>
             <p class="govuk-body">
-                Use the email that you used to create your account. If your email address changes, send full details of the change to <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">@Messages("nationalArchives.emailForHtmlTemplates")</a>.
+                Use the email that you used to create your account. If your email address changes, send full details of the change to <a href="mailto:@Messages("nationalArchives.email")">@Messages("nationalArchives.email")</a>.
             </p>
 
             <h3 class="govuk-heading-s" id="password-does-not-work">My password does not work</h3>
             <p class="govuk-body">
-                If you forget your password or need to reset it, click the 'Forgot your password?' link on the sign in page to request a reset and follow the on-screen instructions. For any other password issue, email <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">@Messages("nationalArchives.emailForHtmlTemplates")</a>.
+                If you forget your password or need to reset it, click the 'Forgot your password?' link on the sign in page to request a reset and follow the on-screen instructions. For any other password issue, email <a href="mailto:@Messages("nationalArchives.email")">@Messages("nationalArchives.email")</a>.
             </p>
 
             <h3 class="govuk-heading-s" id="what-is-mfa">What is multi-factor authentication (MFA)?</h3>
@@ -107,7 +107,7 @@
 
             <h3 class="govuk-heading-s" id="my-link-has-expired">My link has expired</h3>
             <p class="govuk-body">
-                If your link has expired before use, email <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">@Messages("nationalArchives.emailForHtmlTemplates")</a> from your work email account and ask for a new link. Allow up to 2 working days for your request to be processed.
+                If your link has expired before use, email <a href="mailto:@Messages("nationalArchives.email")">@Messages("nationalArchives.email")</a> from your work email account and ask for a new link. Allow up to 2 working days for your request to be processed.
             </p>
 
             <h3 class="govuk-heading-s" id="can-share-my-sign-in-information">Can I share my sign-in information?</h3>
@@ -123,7 +123,7 @@
 
             <h3 class="govuk-heading-s" id="why-cant-drag-and-drop-or-upload-file">Why can’t I drag and drop or upload a file?</h3>
             <p class="govuk-body">
-                This may happen for several reasons. To try to resolve this issue, first check if your internet connection is sufficient and stable. It may also help to refresh the page (though this might mean you have to begin the transfer process again). You can also check your file is not corrupted or damaged by opening it on your computer. If you still cannot upload your file, contact <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">@Messages("nationalArchives.emailForHtmlTemplates")</a> describing the issue and any steps taken.
+                This may happen for several reasons. To try to resolve this issue, first check if your internet connection is sufficient and stable. It may also help to refresh the page (though this might mean you have to begin the transfer process again). You can also check your file is not corrupted or damaged by opening it on your computer. If you still cannot upload your file, contact <a href="mailto:@Messages("nationalArchives.email")">@Messages("nationalArchives.email")</a> describing the issue and any steps taken.
             </p>
 
             <h3 class="govuk-heading-s" id="can-upload-multiple-files">Can I upload multiple files?</h3>
@@ -138,7 +138,7 @@
 
             <h3 class="govuk-heading-s" id="can-upload-a-file-via-one-drive">Can I upload a file via OneDrive, Google Drive or SharePoint?</h3>
             <p class="govuk-body">
-                While we are developing the service (Private Beta stage), TDR can only accept records transferred from a hard or network drive. Please contact the <span class="govuk-!-font-weight-bold">Judiciary Office Judgments Helpdesk</span> at <a href="mailto:@Messages("judiciary.emailForHtmlTemplates")">@Messages("judiciary.emailForHtmlTemplates")</a> to discuss the best way to transfer records if they are not stored on a physical or networked drive.
+                While we are developing the service (Private Beta stage), TDR can only accept records transferred from a hard or network drive. Please contact the <span class="govuk-!-font-weight-bold">Judiciary Office Judgments Helpdesk</span> at <a href="mailto:@Messages("judiciary.email")">@Messages("judiciary.email")</a> to discuss the best way to transfer records if they are not stored on a physical or networked drive.
             </p>
             <p class="govuk-body">
                 In the future, TDR will begin accepting judgments transferred directly from the cloud.
@@ -146,7 +146,7 @@
 
             <h3 class="govuk-heading-s" id="want-to-upload-additional-documents">I want to upload additional documents alongside a judgment</h3>
             <p class="govuk-body">
-                At the moment, this service is for uploading approved judgment documents only. If you need to add supplementary material, email the documents to <a href="mailto:@Messages("nationalArchives.judgmentEmailForHtmlTemplates")">@Messages("nationalArchives.judgmentEmailForHtmlTemplates")</a>, quoting the transfer reference of your judgment.
+                At the moment, this service is for uploading approved judgment documents only. If you need to add supplementary material, email the documents to <a href="mailto:@Messages("nationalArchives.judgmentsEmail")">@Messages("nationalArchives.judgmentsEmail")</a>, quoting the transfer reference of your judgment.
             </p>
             <p class="govuk-body">
                 You can use the email link on the TDR “Check your file before uploading” to automatically generate an email with the transfer reference in the subject field via your default email account.
@@ -200,7 +200,7 @@
                 <li>That your file is not password protected or encrypted</li>
             </ul>
             <p class="govuk-body">
-                If you can confirm the above then try again. If your file still fails, contact <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">@Messages("nationalArchives.emailForHtmlTemplates")</a> describing the issue and any steps taken.
+                If you can confirm the above then try again. If your file still fails, contact <a href="mailto:@Messages("nationalArchives.email")">@Messages("nationalArchives.email")</a> describing the issue and any steps taken.
             </p>
 
             <h3 class="govuk-heading-s" id="successfuly-checked-does-it-mean-judgment-transferred">When my judgment has been successfully checked, does that mean it has been transferred?</h3>
@@ -228,29 +228,29 @@
 
             <h3 class="govuk-heading-s" id="what-happens-if-editorial-error-in-judgment">What happens if there is an editorial error in my judgment?</h3>
             <p class="govuk-body">
-                Judgments do not undergo editorial checks within TDR. This is done by the Case Law editorial team after we receive the judgment. If errors are identified, we will contact you. If you are aware of any errors before upload, amend the judgment before you begin the upload into TDR. If you notice an error after the judgment has been transferred from TDR, contact <a href="mailto:@Messages("nationalArchives.judgmentEmailForHtmlTemplates")">@Messages("nationalArchives.judgmentEmailForHtmlTemplates")</a> with the neutral citation and transfer reference.
+                Judgments do not undergo editorial checks within TDR. This is done by the Case Law editorial team after we receive the judgment. If errors are identified, we will contact you. If you are aware of any errors before upload, amend the judgment before you begin the upload into TDR. If you notice an error after the judgment has been transferred from TDR, contact <a href="mailto:@Messages("nationalArchives.judgmentsEmail")">@Messages("nationalArchives.judgmentsEmail")</a> with the neutral citation and transfer reference.
             </p>
 
             <h2 class="govuk-heading-s" id="not-been-notified-judgment-published">I have not been notified that my judgment has been published</h2>
             <p class="govuk-body">
-                If you do not receive confirmation that your judgment has been accepted for preservation after 5 working days, contact <a href="mailto:@Messages("nationalArchives.judgmentEmailForHtmlTemplates")">@Messages("nationalArchives.judgmentEmailForHtmlTemplates")</a>.
+                If you do not receive confirmation that your judgment has been accepted for preservation after 5 working days, contact <a href="mailto:@Messages("nationalArchives.judgmentsEmail")">@Messages("nationalArchives.judgmentsEmail")</a>.
             </p>
 
             <h2 class="govuk-heading-m" id="general">General</h2>
 
             <h3 class="govuk-heading-s" id="contact-for-general-judgment-process-query">Who can I contact if I have a general query about the judgment process?</h3>
             <p class="govuk-body">
-                Contact the <span class="govuk-!-font-weight-bold">Judiciary Office Judgments Helpdesk</span> at <a href="mailto:@Messages("judiciary.emailForHtmlTemplates")">@Messages("judiciary.emailForHtmlTemplates")</a> for queries regarding the transfer process, what templates to use, how to sign up for TDR, or more general queries regarding the suitability of records for transfer.
+                Contact the <span class="govuk-!-font-weight-bold">Judiciary Office Judgments Helpdesk</span> at <a href="mailto:@Messages("judiciary.email")">@Messages("judiciary.email")</a> for queries regarding the transfer process, what templates to use, how to sign up for TDR, or more general queries regarding the suitability of records for transfer.
             </p>
 
             <h3 class="govuk-heading-s" id="contaxct-for-published-judgments-query">Who can I contact if I have a query about published judgments at TNA?</h3>
             <p class="govuk-body">
-                Contact <a href="mailto:@Messages("nationalArchives.judgmentEmailForHtmlTemplates")">@Messages("nationalArchives.judgmentEmailForHtmlTemplates")</a> for queries about completed transfers, supplementary documents, replacing a judgment with an updated version, anonymisation order instructions, or other general queries about the Find Case Law service.
+                Contact <a href="mailto:@Messages("nationalArchives.judgmentsEmail")">@Messages("nationalArchives.judgmentsEmail")</a> for queries about completed transfers, supplementary documents, replacing a judgment with an updated version, anonymisation order instructions, or other general queries about the Find Case Law service.
             </p>
 
             <h3 class="govuk-heading-s" id="tdr-technical-issue-query">Who can I contact if I have a technical issue with TDR?</h3>
             <p class="govuk-body">
-                Contact <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">@Messages("nationalArchives.emailForHtmlTemplates")</a> for queries regarding the upload or transfer performance, the status of a transfer within TDR, or to report an issue encountered within TDR.
+                Contact <a href="mailto:@Messages("nationalArchives.email")">@Messages("nationalArchives.email")</a> for queries regarding the upload or transfer performance, the status of a transfer within TDR, or to report an issue encountered within TDR.
             </p>
 
             <h3 class="govuk-heading-s" id="tdr-how-secure-judgments">When using TDR, how secure are my judgments?</h3>

--- a/app/views/judgment/judgmentHelp.scala.html
+++ b/app/views/judgment/judgmentHelp.scala.html
@@ -69,7 +69,7 @@
           Double-check your judgment prior to upload to ensure you are sending us the correct file.
         </p>
         <p class="govuk-body">
-          Only upload a single Microsoft Word (.docx) document per transfer, using the template supplied by the Judiciary Office Judgments Helpdesk, contactable at <a href="mailto:@Messages("judiciary.emailForHtmlTemplates")">@Messages("judiciary.emailForHtmlTemplates")</a>
+          Only upload a single Microsoft Word (.docx) document per transfer, using the template supplied by the Judiciary Office Judgments Helpdesk, contactable at <a href="mailto:@Messages("judiciary.email")">@Messages("judiciary.email")</a>
         </p>
         <p class="govuk-body">
           During upload and checking, if we detect a file we cannot accept, you will be notified on screen.
@@ -83,21 +83,21 @@
 
         <h3 class="govuk-heading-s" id="contact-us">Contact us</h3>
         <p class="govuk-body">
-          If you have a query regarding asking for a TDR account, the transfer process, the status of your transfer, or more general queries regarding the suitability of records for transfer, file format or transfer agreement criteria, email the Judiciary Office Judgments Helpdesk at <a href="mailto:@Messages("judiciary.emailForHtmlTemplates")">
-          @Messages("judiciary.emailForHtmlTemplates")</a>.
+          If you have a query regarding asking for a TDR account, the transfer process, the status of your transfer, or more general queries regarding the suitability of records for transfer, file format or transfer agreement criteria, email the Judiciary Office Judgments Helpdesk at <a href="mailto:@Messages("judiciary.email")">
+          @Messages("judiciary.email")</a>.
         </p>
 
         <h2 class="govuk-heading-m" id="register-new-account">Registering for a new account</h2>
         <h3 class="govuk-heading-s" id="new-user-email">Part 1: New user email</h3>
         <ol class="govuk-body">
           <li>
-            If you want to register for a new TDR account, email the <span class="govuk-!-font-weight-bold">Judiciary   Office   Judgments   Helpdesk</span> <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">
-            @Messages("nationalArchives.emailForHtmlTemplates")</a>
+            If you want to register for a new TDR account, email the <span class="govuk-!-font-weight-bold">Judiciary   Office   Judgments   Helpdesk</span> <a href="mailto:@Messages("nationalArchives.email")">
+            @Messages("nationalArchives.email")</a>
             from your work email account and ask to register as a new user, stating clearly your first name and surname. Allow up to 2 working days for your request to be processed. </li>
           <li>
             Once you have been validated for an account, you will be sent an email with the subject <span class="govuk-!-font-weight-bold">"Register for your Transfer Digital Records (TDR) account - ACTION REQUIRED"</span> which contains important registration instructions.</li>
           <li>
-            You will receive an email shortly after with the subject <span class="govuk-!-font-weight-bold">"Update Your Account"</span>, containing <span class="govuk-!-font-weight-bold">a link that expires after 12 hours.</span> Please click the link before it expires to begin your registration. <em>If your link has expired before you could use it, email <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">@Messages("nationalArchives.emailForHtmlTemplates")</a> and request a new registration link.</em></li>
+            You will receive an email shortly after with the subject <span class="govuk-!-font-weight-bold">"Update Your Account"</span>, containing <span class="govuk-!-font-weight-bold">a link that expires after 12 hours.</span> Please click the link before it expires to begin your registration. <em>If your link has expired before you could use it, email <a href="mailto:@Messages("nationalArchives.email")">@Messages("nationalArchives.email")</a> and request a new registration link.</em></li>
           <li>The link will take you to this page:</li>
           <img src="@routes.Assets.versioned("images/configure-otp-password-page.png")" class="screenshots" alt="Sign in page with a link to setup MFA and password" />
           <li>
@@ -212,8 +212,8 @@
 
         <h3 class="govuk-heading-s" id="supp-material">Supplementary material</h3>
         <p class="govuk-body">
-          If you need to include additional documents with your judgment, you currently <u>cannot</u> upload them with your judgment as part of the transfer. Instead, click on the <a href="mailto:@Messages("nationalArchives.judgmentEmailForHtmlTemplates")">
-          @Messages("nationalArchives.judgmentEmailForHtmlTemplates")</a>
+          If you need to include additional documents with your judgment, you currently <u>cannot</u> upload them with your judgment as part of the transfer. Instead, click on the <a href="mailto:@Messages("nationalArchives.judgmentsEmail")">
+          @Messages("nationalArchives.judgmentsEmail")</a>
           link located in the middle of the screen to generate an automatic email with the transfer reference as the subject. Attach your supplementary documents and add any other relevant information before sending.
         </p>
         <p class="govuk-body">
@@ -296,8 +296,8 @@
           <li>Your file is not corrupted or password protected by checking you can open it on your own computer</li>
         </ul>
         <p class="govuk-body">
-          If you have confirmed yes to all then try again. If your file still fails, contact <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">
-          @Messages("nationalArchives.emailForHtmlTemplates")</a> with details of the judgment you have tried to upload.
+          If you have confirmed yes to all then try again. If your file still fails, contact <a href="mailto:@Messages("nationalArchives.email")">
+          @Messages("nationalArchives.email")</a> with details of the judgment you have tried to upload.
         </p>
 
         <h3 class="govuk-heading-s" id="step-4">Step 4: Transfer complete</h3>

--- a/app/views/judgment/judgmentHelp.scala.html
+++ b/app/views/judgment/judgmentHelp.scala.html
@@ -69,7 +69,7 @@
           Double-check your judgment prior to upload to ensure you are sending us the correct file.
         </p>
         <p class="govuk-body">
-          Only upload a single Microsoft Word (.docx) document per transfer, using the template supplied by the Judiciary Office Judgments Helpdesk, contactable at <a href="mailto:Judgments@@judiciary.uk">Judgments@@judiciary.uk</a>
+          Only upload a single Microsoft Word (.docx) document per transfer, using the template supplied by the Judiciary Office Judgments Helpdesk, contactable at <a href="mailto:@Messages("judiciary.emailForHtmlTemplates")">@Messages("judiciary.emailForHtmlTemplates")</a>
         </p>
         <p class="govuk-body">
           During upload and checking, if we detect a file we cannot accept, you will be notified on screen.
@@ -83,21 +83,21 @@
 
         <h3 class="govuk-heading-s" id="contact-us">Contact us</h3>
         <p class="govuk-body">
-          If you have a query regarding asking for a TDR account, the transfer process, the status of your transfer, or more general queries regarding the suitability of records for transfer, file format or transfer agreement criteria, email the Judiciary Office Judgments Helpdesk at <a href="mailto:Judgments@@judiciary.uk">
-          Judgments@@judiciary.uk</a>.
+          If you have a query regarding asking for a TDR account, the transfer process, the status of your transfer, or more general queries regarding the suitability of records for transfer, file format or transfer agreement criteria, email the Judiciary Office Judgments Helpdesk at <a href="mailto:@Messages("judiciary.emailForHtmlTemplates")">
+          @Messages("judiciary.emailForHtmlTemplates")</a>.
         </p>
 
         <h2 class="govuk-heading-m" id="register-new-account">Registering for a new account</h2>
         <h3 class="govuk-heading-s" id="new-user-email">Part 1: New user email</h3>
         <ol class="govuk-body">
           <li>
-            If you want to register for a new TDR account, email the <span class="govuk-!-font-weight-bold">Judiciary   Office   Judgments   Helpdesk</span> <a href="mailto:tdr@@nationalarchives.gov.uk">
-            tdr@@nationalarchives.gov.uk</a>
+            If you want to register for a new TDR account, email the <span class="govuk-!-font-weight-bold">Judiciary   Office   Judgments   Helpdesk</span> <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">
+            @Messages("nationalArchives.emailForHtmlTemplates")</a>
             from your work email account and ask to register as a new user, stating clearly your first name and surname. Allow up to 2 working days for your request to be processed. </li>
           <li>
             Once you have been validated for an account, you will be sent an email with the subject <span class="govuk-!-font-weight-bold">"Register for your Transfer Digital Records (TDR) account - ACTION REQUIRED"</span> which contains important registration instructions.</li>
           <li>
-            You will receive an email shortly after with the subject <span class="govuk-!-font-weight-bold">"Update Your Account"</span>, containing <span class="govuk-!-font-weight-bold">a link that expires after 12 hours.</span> Please click the link before it expires to begin your registration. <em>If your link has expired before you could use it, email <a href="mailto:tdr@@nationalarchives.gov.uk">tdr@@nationalarchives.gov.uk</a> and request a new registration link.</em></li>
+            You will receive an email shortly after with the subject <span class="govuk-!-font-weight-bold">"Update Your Account"</span>, containing <span class="govuk-!-font-weight-bold">a link that expires after 12 hours.</span> Please click the link before it expires to begin your registration. <em>If your link has expired before you could use it, email <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">@Messages("nationalArchives.emailForHtmlTemplates")</a> and request a new registration link.</em></li>
           <li>The link will take you to this page:</li>
           <img src="@routes.Assets.versioned("images/configure-otp-password-page.png")" class="screenshots" alt="Sign in page with a link to setup MFA and password" />
           <li>
@@ -212,8 +212,8 @@
 
         <h3 class="govuk-heading-s" id="supp-material">Supplementary material</h3>
         <p class="govuk-body">
-          If you need to include additional documents with your judgment, you currently <u>cannot</u> upload them with your judgment as part of the transfer. Instead, click on the <a href="mailto:judgments@@nationalarchives.gov.uk">
-          judgments@@nationalarchives.gov.uk</a>
+          If you need to include additional documents with your judgment, you currently <u>cannot</u> upload them with your judgment as part of the transfer. Instead, click on the <a href="mailto:@Messages("nationalArchives.judgmentEmailForHtmlTemplates")">
+          @Messages("nationalArchives.judgmentEmailForHtmlTemplates")</a>
           link located in the middle of the screen to generate an automatic email with the transfer reference as the subject. Attach your supplementary documents and add any other relevant information before sending.
         </p>
         <p class="govuk-body">
@@ -296,8 +296,8 @@
           <li>Your file is not corrupted or password protected by checking you can open it on your own computer</li>
         </ul>
         <p class="govuk-body">
-          If you have confirmed yes to all then try again. If your file still fails, contact <a href="mailto:tdr@@nationalarchives.gov.uk">
-          tdr@@nationalarchives.gov.uk</a> with details of the judgment you have tried to upload.
+          If you have confirmed yes to all then try again. If your file still fails, contact <a href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")">
+          @Messages("nationalArchives.emailForHtmlTemplates")</a> with details of the judgment you have tried to upload.
         </p>
 
         <h3 class="govuk-heading-s" id="step-4">Step 4: Transfer complete</h3>

--- a/app/views/partials/fileCheckErrorMessage.scala.html
+++ b/app/views/partials/fileCheckErrorMessage.scala.html
@@ -1,5 +1,6 @@
 @import views.html.partials.fileCheckGenericErrorMessage
-@(fileStatuses: List[String] = Nil, consignmentRef: String)
+
+@(fileStatuses: List[String] = Nil, consignmentRef: String)(implicit messages: Messages)
 @{
     val isPasswordProtected = fileStatuses.contains("PasswordProtected")
     val isZip = fileStatuses.contains("Zip")

--- a/app/views/partials/fileCheckGenericErrorMessage.scala.html
+++ b/app/views/partials/fileCheckGenericErrorMessage.scala.html
@@ -1,7 +1,7 @@
-@(consignmentRef: String)
+@(consignmentRef: String)(implicit messages: Messages)
 <p class="govuk-body">
     One or more files you uploaded have failed our checks. Contact us at
-    <a class="govuk-link" href="mailto:tdr@@nationalachives.gov.uk?subject=Ref: @consignmentRef - Problem with Results of checks">tdr@@nationalachives.gov.uk</a>
+    <a class="govuk-link" href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")?subject=Ref: @consignmentRef - Problem with Results of checks">@Messages("nationalArchives.emailForHtmlTemplates")</a>
     if the problem persists.
 </p>
 <p class="govuk-body">Possible failure causes:</p>

--- a/app/views/partials/fileCheckGenericErrorMessage.scala.html
+++ b/app/views/partials/fileCheckGenericErrorMessage.scala.html
@@ -1,7 +1,7 @@
 @(consignmentRef: String)(implicit messages: Messages)
 <p class="govuk-body">
     One or more files you uploaded have failed our checks. Contact us at
-    <a class="govuk-link" href="mailto:@Messages("nationalArchives.emailForHtmlTemplates")?subject=Ref: @consignmentRef - Problem with Results of checks">@Messages("nationalArchives.emailForHtmlTemplates")</a>
+    <a class="govuk-link" href="mailto:@Messages("nationalArchives.email")?subject=Ref: @consignmentRef - Problem with Results of checks">@Messages("nationalArchives.email")</a>
     if the problem persists.
 </p>
 <p class="govuk-body">Possible failure causes:</p>

--- a/conf/messages
+++ b/conf/messages
@@ -1,7 +1,7 @@
 # https://www.playframework.com/documentation/latest/ScalaI18N
 
 nationalArchives.email=tdr@nationalarchives.gov.uk
-nationalArchives.judgmentsEmail=tdr@nationalarchives.gov.uk
+nationalArchives.judgmentsEmail=judgments@nationalarchives.gov.uk
 judiciary.email=Judgments@@judiciary.uk
 
 transferAgreement.warning=This service is in private beta. During this time, the Transfer Digital Records service can only accept records that are in English, are Public Records and are Crown Copyright. For more information, please see our <a href="/faq" target="_blank" rel="noopener noreferrer" class="govuk-link">FAQ (opens in new tab)</a> if you need to transfer records that this service cannot currently handle.

--- a/conf/messages
+++ b/conf/messages
@@ -1,8 +1,8 @@
 # https://www.playframework.com/documentation/latest/ScalaI18N
 
-nationalArchives.emailForHtmlTemplates=tdr@nationalarchives.gov.uk
-nationalArchives.judgmentsEmailForHtmlTemplates=tdr@nationalarchives.gov.uk
-judiciary.emailForHtmlTemplates=Judgments@@judiciary.uk
+nationalArchives.email=tdr@nationalarchives.gov.uk
+nationalArchives.judgmentsEmail=tdr@nationalarchives.gov.uk
+judiciary.email=Judgments@@judiciary.uk
 
 transferAgreement.warning=This service is in private beta. During this time, the Transfer Digital Records service can only accept records that are in English, are Public Records and are Crown Copyright. For more information, please see our <a href="/faq" target="_blank" rel="noopener noreferrer" class="govuk-link">FAQ (opens in new tab)</a> if you need to transfer records that this service cannot currently handle.
 

--- a/conf/messages
+++ b/conf/messages
@@ -1,5 +1,9 @@
 # https://www.playframework.com/documentation/latest/ScalaI18N
 
+nationalArchives.emailForHtmlTemplates=tdr@nationalarchives.gov.uk
+nationalArchives.judgmentsEmailForHtmlTemplates=tdr@nationalarchives.gov.uk
+judiciary.emailForHtmlTemplates=Judgments@@judiciary.uk
+
 transferAgreement.warning=This service is in private beta. During this time, the Transfer Digital Records service can only accept records that are in English, are Public Records and are Crown Copyright. For more information, please see our <a href="/faq" target="_blank" rel="noopener noreferrer" class="govuk-link">FAQ (opens in new tab)</a> if you need to transfer records that this service cannot currently handle.
 
 upload.dragAndDropFolderErrorMessage=You can only drop a single folder.

--- a/conf/messages
+++ b/conf/messages
@@ -2,7 +2,7 @@
 
 nationalArchives.email=tdr@nationalarchives.gov.uk
 nationalArchives.judgmentsEmail=judgments@nationalarchives.gov.uk
-judiciary.email=Judgments@@judiciary.uk
+judiciary.email=Judgments@judiciary.uk
 
 transferAgreement.warning=This service is in private beta. During this time, the Transfer Digital Records service can only accept records that are in English, are Public Records and are Crown Copyright. For more information, please see our <a href="/faq" target="_blank" rel="noopener noreferrer" class="govuk-link">FAQ (opens in new tab)</a> if you need to transfer records that this service cannot currently handle.
 

--- a/test/controllers/BeforeUploadingControllerSpec.scala
+++ b/test/controllers/BeforeUploadingControllerSpec.scala
@@ -53,7 +53,7 @@ class BeforeUploadingControllerSpec extends FrontEndTestHelper {
       )
       // scalastyle:off line.size.limit
       beforeUploadingPageAsString must include(
-        """<h2 class="govuk-heading-s">Select <a href="mailto:judgments@nationalarchives.gov.uk?subject=Ref: TEST-TDR-2021-GB">judgments@nationalarchives.gov.uk</a>"""
+        """<h2 class="govuk-heading-s">Select <a href="mailto:nationalArchives.judgmentEmailForHtmlTemplates?subject=Ref: TEST-TDR-2021-GB">nationalArchives.judgmentEmailForHtmlTemplates</a>"""
       )
       // scalastyle:on line.size.limit
       beforeUploadingPageAsString must include(

--- a/test/controllers/BeforeUploadingControllerSpec.scala
+++ b/test/controllers/BeforeUploadingControllerSpec.scala
@@ -53,7 +53,7 @@ class BeforeUploadingControllerSpec extends FrontEndTestHelper {
       )
       // scalastyle:off line.size.limit
       beforeUploadingPageAsString must include(
-        """<h2 class="govuk-heading-s">Select <a href="mailto:nationalArchives.judgmentEmailForHtmlTemplates?subject=Ref: TEST-TDR-2021-GB">nationalArchives.judgmentEmailForHtmlTemplates</a>"""
+        """<h2 class="govuk-heading-s">Select <a href="mailto:nationalArchives.judgmentsEmail?subject=Ref: TEST-TDR-2021-GB">nationalArchives.judgmentsEmail</a>"""
       )
       // scalastyle:on line.size.limit
       beforeUploadingPageAsString must include(

--- a/test/controllers/FileChecksResultsControllerSpec.scala
+++ b/test/controllers/FileChecksResultsControllerSpec.scala
@@ -75,8 +75,8 @@ class FileChecksResultsControllerSpec extends FrontEndTestHelper {
             |                    </button>
             |                </form>""".stripMargin,
           """              <p class="govuk-body">Your file has failed our checks. Please try again. If this continues, contact us at
-            |                <a class="govuk-link" href="mailto:nationalArchives.emailForHtmlTemplates" data-hsupport="email">
-            |                  nationalArchives.emailForHtmlTemplates
+            |                <a class="govuk-link" href="mailto:nationalArchives.email" data-hsupport="email">
+            |                  nationalArchives.email
             |                </a>
             |              </p>""".stripMargin
         )
@@ -94,7 +94,7 @@ class FileChecksResultsControllerSpec extends FrontEndTestHelper {
              |                </a>""".stripMargin,
           """              <p class="govuk-body">
             |    One or more files you uploaded have failed our checks. Contact us at
-            |    <a class="govuk-link" href="mailto:nationalArchives.emailForHtmlTemplates?subject=Ref: TEST-TDR-2021-GB - Problem with Results of checks">nationalArchives.emailForHtmlTemplates</a>
+            |    <a class="govuk-link" href="mailto:nationalArchives.email?subject=Ref: TEST-TDR-2021-GB - Problem with Results of checks">nationalArchives.email</a>
             |    if the problem persists.
             |</p>
             |<p class="govuk-body">Possible failure causes:</p>

--- a/test/controllers/FileChecksResultsControllerSpec.scala
+++ b/test/controllers/FileChecksResultsControllerSpec.scala
@@ -75,8 +75,8 @@ class FileChecksResultsControllerSpec extends FrontEndTestHelper {
             |                    </button>
             |                </form>""".stripMargin,
           """              <p class="govuk-body">Your file has failed our checks. Please try again. If this continues, contact us at
-            |                <a class="govuk-link" href="mailto:tdr@nationalarchives.gov.uk" data-hsupport="email">
-            |                  tdr@nationalarchives.gov.uk
+            |                <a class="govuk-link" href="mailto:nationalArchives.emailForHtmlTemplates" data-hsupport="email">
+            |                  nationalArchives.emailForHtmlTemplates
             |                </a>
             |              </p>""".stripMargin
         )
@@ -94,7 +94,7 @@ class FileChecksResultsControllerSpec extends FrontEndTestHelper {
              |                </a>""".stripMargin,
           """              <p class="govuk-body">
             |    One or more files you uploaded have failed our checks. Contact us at
-            |    <a class="govuk-link" href="mailto:tdr@nationalachives.gov.uk?subject=Ref: TEST-TDR-2021-GB - Problem with Results of checks">tdr@nationalachives.gov.uk</a>
+            |    <a class="govuk-link" href="mailto:nationalArchives.emailForHtmlTemplates?subject=Ref: TEST-TDR-2021-GB - Problem with Results of checks">nationalArchives.emailForHtmlTemplates</a>
             |    if the problem persists.
             |</p>
             |<p class="govuk-body">Possible failure causes:</p>


### PR DESCRIPTION
There was a spelling mistake in one of the email addresses so it's probably best to have them all in one place to avoid users' emails bouncing or (theoretically worse) being delivered to someone else.