### PR TITLE
TDR-2811 summary description preserves spacing and line breaks

### DIFF
--- a/app/controllers/util/FormField.scala
+++ b/app/controllers/util/FormField.scala
@@ -62,7 +62,7 @@ case class TextAreaField(
     isRequired: Boolean,
     fieldErrors: List[String] = Nil,
     rows: String = "5",
-    wrap: String = "hard",
+    wrap: String = "soft",
     characterLimit: Int = 8000,
     override val dependencies: Map[String, List[FormField]] = Map.empty
 ) extends FormField {

--- a/app/views/standard/additionalMetadataSummary.scala.html
+++ b/app/views/standard/additionalMetadataSummary.scala.html
@@ -46,7 +46,7 @@
               @metadata.name
               </dt>
               <dd class="govuk-summary-list__value">
-              @metadata.value
+              <pre>@metadata.value</pre>
               </dd>
             </div>
           }

--- a/npm/css-src/sass/main.scss
+++ b/npm/css-src/sass/main.scss
@@ -92,3 +92,9 @@ a {
   padding: 15px 0 0 129px;
   position: relative;
 }
+
+pre {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  white-space: pre-wrap;
+}

--- a/test/controllers/AdditionalMetadataSummaryControllerSpec.scala
+++ b/test/controllers/AdditionalMetadataSummaryControllerSpec.scala
@@ -260,7 +260,7 @@ class AdditionalMetadataSummaryControllerSpec extends FrontEndTestHelper {
            |              ${field._1}
            |              </dt>
            |              <dd class="govuk-summary-list__value">
-           |              ${field._2}
+           |              <pre>${field._2}</pre>
            |              </dd>
            |            </div>
            |""".stripMargin

--- a/test/controllers/util/DisplayPropertiesUtilsSpec.scala
+++ b/test/controllers/util/DisplayPropertiesUtilsSpec.scala
@@ -121,7 +121,7 @@ class DisplayPropertiesUtilsSpec extends AnyFlatSpec with MockitoSugar with Befo
     textAreaField.isRequired should equal(false)
     textAreaField.multiValue should equal(false)
     textAreaField.rows should equal("5")
-    textAreaField.wrap should equal("hard")
+    textAreaField.wrap should equal("soft")
     textAreaField.characterLimit should equal(8000)
     textAreaField.nameAndValue.name should equal("TextField")
     textAreaField.nameAndValue.value should equal("defaultValue")

--- a/test/testUtils/DefaultMockFormOptions.scala
+++ b/test/testUtils/DefaultMockFormOptions.scala
@@ -44,7 +44,7 @@ object DefaultMockFormOptions {
       id = "inputtextarea-description",
       fieldType = "inputTextArea",
       rows = "5",
-      wrap = "hard",
+      wrap = "soft",
       maxLength = "8000"
     ),
     MockInputOption(


### PR DESCRIPTION
The description seems to already be saved correctly to the database. So this just uses the `<pre>` tag to preserve the line breaks and white spaces.

![Screenshot from 2023-02-06 11-52-55](https://user-images.githubusercontent.com/9700622/216965943-23c7d7d4-c15c-421f-b4a7-d728ad5f7df5.png)

I have also changed the `textarea` field wrap to `soft` because a hard wrap inserts actual line breaks in the text at wrap points which was why the description had line breaks when copied to a text editor from the form.