### PR TITLE
Remove deprecated headers

### DIFF
--- a/conf/application.base.conf
+++ b/conf/application.base.conf
@@ -35,6 +35,8 @@ play {
   modules.enabled += "modules.SecurityModule"
   modules.enabled += "play.api.cache.redis.RedisCacheModule"
 
+  # Remove deprecated X-XSS-Protection header
+  filters.headers.xssProtection = null
   # Add custom Content Security Policy to every page
   filters.enabled += play.filters.csp.CSPFilter
   filters.csp.directives {


### PR DESCRIPTION
The pen test has found the front end is returning a deprecated header
X-XSS-Protection

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection

https://www.playframework.com/documentation/2.8.x/SecurityHeaders#Configuring-the-security-headers
