### PR TITLE
Add ambiguous naming of redacted files to possible reasons.

### DIFF
--- a/app/views/partials/fileCheckGenericErrorMessage.scala.html
+++ b/app/views/partials/fileCheckGenericErrorMessage.scala.html
@@ -9,4 +9,5 @@
     <li>Password protected files</li>
     <li>Zip files</li>
     <li>Corrupted files</li>
+    <li>Ambiguous naming of redacted files</li>
 </ul>

--- a/test/controllers/FileChecksResultsControllerSpec.scala
+++ b/test/controllers/FileChecksResultsControllerSpec.scala
@@ -113,6 +113,7 @@ class FileChecksResultsControllerSpec extends FrontEndTestHelper {
             |    <li>Password protected files</li>
             |    <li>Zip files</li>
             |    <li>Corrupted files</li>
+            |    <li>Ambiguous naming of redacted files</li>
             |</ul>""".stripMargin
         )
         // scalastyle:on line.size.limit


### PR DESCRIPTION
This is from https://national-archives.atlassian.net/browse/TDR-2899

I've added this to the list. The e2e tests don't seem to be checking for
this so they don't need to be updated.
