### PR TITLE
Replace file list button with span.

### DIFF
--- a/app/views/standard/additionalMetadataNavigation.scala.html
+++ b/app/views/standard/additionalMetadataNavigation.scala.html
@@ -19,9 +19,9 @@
   } else {
     <li class="tna-tree__node-item-radios" role="treeitem" id="radios-list-@file.id" aria-expanded="false" aria-selected="false" aria-level="@level" aria-setsize="@size" aria-posinset="@pos" tabindex="0">
       <div class="tna-tree__node-item__container">
-        <button class="tna-tree__expander js-tree__expander--radios" tabindex="-1" id="radios-expander-@file.id">
+        <span class="tna-tree__expander js-tree__expander--radios" tabindex="-1" id="radios-expander-@file.id">
           <span class="govuk-visually-hidden">Expand</span>
-        </button>
+        </span>
 
         <div class="js-radios-directory tna-radios-directory">
           <span class="govuk-label tna-radios-directory__label">

--- a/test/controllers/AdditionalMetadataNavigationControllerSpec.scala
+++ b/test/controllers/AdditionalMetadataNavigationControllerSpec.scala
@@ -264,9 +264,9 @@ class AdditionalMetadataNavigationControllerSpec extends FrontEndTestHelper {
   private def getExpectedFolderHtml(id: UUID, label: String): String = {
     s"""
         |<div class="tna-tree__node-item__container">
-        |        <button class="tna-tree__expander js-tree__expander--radios" tabindex="-1" id="radios-expander-$id">
+        |        <span class="tna-tree__expander js-tree__expander--radios" tabindex="-1" id="radios-expander-$id">
         |          <span class="govuk-visually-hidden">Expand</span>
-        |        </button>
+        |        </span>
         |
         |        <div class="js-radios-directory tna-radios-directory">
         |          <span class="govuk-label tna-radios-directory__label">


### PR DESCRIPTION
The expander icon in the file list page was a button. If this was
clicked before the js loaded which changed its behaviour, it would
submit the form when clicked.

This has been replaced by a span which won't submit the form.
