### PR TITLE
Display correct column name for "TitleAlternate" on the summary page

### DIFF
--- a/app/controllers/AdditionalMetadataSummaryController.scala
+++ b/app/controllers/AdditionalMetadataSummaryController.scala
@@ -62,7 +62,7 @@ class AdditionalMetadataSummaryController @Inject() (
 
     filteredMetadata.map { case (displayProperty, metadataValue) =>
       FileMetadata(
-        displayProperty.displayName,
+        getDisplayName(displayProperty),
         displayProperty.dataType match {
           case DateTime => formatter.format(Timestamp.valueOf(metadataValue))
           case Boolean =>
@@ -74,6 +74,11 @@ class AdditionalMetadataSummaryController @Inject() (
         }
       )
     }
+  }
+
+  private def getDisplayName(displayProperty: DisplayProperty) = {
+    val fieldsWithAlternativeName = List("TitleAlternate")
+    if (fieldsWithAlternativeName.contains(displayProperty.propertyName)) displayProperty.alternativeName else displayProperty.displayName
   }
 }
 

--- a/test/controllers/AdditionalMetadataSummaryControllerSpec.scala
+++ b/test/controllers/AdditionalMetadataSummaryControllerSpec.scala
@@ -49,6 +49,7 @@ class AdditionalMetadataSummaryControllerSpec extends FrontEndTestHelper {
       val closureStartDate = LocalDateTime.of(1990, 12, 1, 10, 0)
       val fileMetadata = List(
         GetConsignment.Files.FileMetadata("TitleClosed", "true"),
+        GetConsignment.Files.FileMetadata("TitleAlternate", "An alternative title"),
         GetConsignment.Files.FileMetadata("ClosurePeriod", "4"),
         GetConsignment.Files.FileMetadata("FoiExemptionCode", "1"),
         GetConsignment.Files.FileMetadata("FoiExemptionCode", "2"),
@@ -72,7 +73,13 @@ class AdditionalMetadataSummaryControllerSpec extends FrontEndTestHelper {
       contentType(response) mustBe Some("text/html")
 
       checkPageForStaticElements.checkContentOfPagesThatUseMainScala(closureMetadataSummaryPage, userType = "standard")
-      val metadataFields = List(("Is the title closed?", "Yes"), ("Closure Period", "4 years"), ("Closure Start Date", "01/12/1990"), ("FOI exemption code(s)", "1, 2 "))
+      val metadataFields = List(
+        ("Is the title closed?", "Yes"),
+        ("Closure Period", "4 years"),
+        ("Closure Start Date", "01/12/1990"),
+        ("FOI exemption code(s)", "1, 2 "),
+        ("Alternative Title2", "An alternative title ")
+      )
 
       verifySummaryPage(closureMetadataSummaryPage, consignmentId.toString, closureMetadataType, metadataFields)
       wiremockServer.verify(postRequestedFor(urlEqualTo("/graphql")))

--- a/test/testUtils/FrontEndTestHelper.scala
+++ b/test/testUtils/FrontEndTestHelper.scala
@@ -552,7 +552,8 @@ trait FrontEndTestHelper extends PlaySpec with MockitoSugar with Injecting with 
           dp.DisplayProperties.Attributes("Editable", Some("true"), Boolean),
           dp.DisplayProperties.Attributes("Group", Some("3"), Text),
           dp.DisplayProperties.Attributes("MultiValue", Some("false"), Boolean),
-          dp.DisplayProperties.Attributes("PropertyType", Some("Closure"), Text)
+          dp.DisplayProperties.Attributes("PropertyType", Some("Closure"), Text),
+          dp.DisplayProperties.Attributes("AlternativeName", Some("Alternative Title2"), Text)
         )
       ),
       dp.DisplayProperties(


### PR DESCRIPTION
The `fieldsWithAlternativeName` variable is for properties that we want to display the alternative name. There are cases whereby a property for example FoiExemptionAsserted will have an alternativeName but we still want to display the original name.