### PR TITLE
Make the metadata file selection work without js

### DIFF
--- a/app/controllers/AdditionalMetadataNavigationController.scala
+++ b/app/controllers/AdditionalMetadataNavigationController.scala
@@ -27,11 +27,10 @@ class AdditionalMetadataNavigationController @Inject() (
 
   def submitFiles(consignmentId: UUID, metadataType: String): Action[AnyContent] = standardTypeAction(consignmentId) { implicit request: Request[AnyContent] =>
     val fileIds = request.body.asFormUrlEncoded
-      .getOrElse(Map())
-      .keys
+      .flatMap(_.get("nested-navigation"))
+      .getOrElse(Nil)
+      .map(UUID.fromString)
       .toList
-      .filter(_ != "csrfToken")
-      .map(p => UUID.fromString(p.substring("radios-list-".length)))
 
     if (fileIds.nonEmpty) {
       submitAndRedirectToNextPage(metadataType, fileIds, consignmentId)

--- a/app/views/standard/additionalMetadataNavigation.scala.html
+++ b/app/views/standard/additionalMetadataNavigation.scala.html
@@ -10,14 +10,14 @@
   @if(file.fileType.contains("File")) {
     <li class="tna-tree__item govuk-radios--small" role="treeitem" id="radios-list-@file.id" aria-level="@level" aria-setsize="@size" aria-posinset="@pos" aria-selected="false">
       <div class="tna-tree__node-item__radio govuk-radios__item">
-        <span class="govuk-radios__input" aria-hidden="true" id="radio-@file.id" name="nested-navigation"></span>
-        <span class="govuk-label govuk-radios__label">
+        <input type="radio" name="nested-navigation" class="govuk-radios__input" id="radio-@file.id" value="@file.id"/>
+        <label class="govuk-label govuk-radios__label" for="radio-@file.id">
           @file.name @displayStatusTag(file.statusTag)
-        </span>
+        </label>
       </div>
     </li>
   } else {
-    <li class="tna-tree__node-item-radios" role="treeitem" id="radios-list-@file.id" aria-expanded="false" aria-selected="false" aria-level="@level" aria-setsize="@size" aria-posinset="@pos" tabindex="0">
+    <li class="tna-tree__node-item-radios" role="treeitem" id="radios-list-@file.id" aria-expanded="true" aria-selected="false" aria-level="@level" aria-setsize="@size" aria-posinset="@pos" tabindex="0">
       <div class="tna-tree__node-item__container">
         <span class="tna-tree__expander js-tree__expander--radios" tabindex="-1" id="radios-expander-@file.id">
           <span class="govuk-visually-hidden">Expand</span>
@@ -68,7 +68,6 @@
       <div class="govuk-grid-column-two-thirds">
         <span class="govuk-caption-l">@metadataType.capitalize metadata</span>
         <h1 class="govuk-heading-l">Choose a file</h1>
-        <p class="govuk-body">Select the file you wish to add or edit @metadataType metadata.</p>
       </div>
     </div>
     <div class="govuk-grid-row">
@@ -81,9 +80,14 @@
         <form method="post" action="@routes.AdditionalMetadataNavigationController.submitFiles(consignmentId, metadataType)">
           @CSRF.formField
           <div class="tna-tree" id="file-selection">
-            <ul tabindex="0" class="tna-tree__root-list" id="radio-tree" role="tree">
-              @display(files, 1, files.children.length, 1)
-            </ul>
+            <fieldset class="govuk-fieldset">
+              <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+                <p class="govuk-body">Select the file you wish to add or edit @metadataType metadata.</p>
+              </legend>
+              <ul tabindex="0" class="tna-tree__root-list" id="radio-tree" role="tree">
+                @display(files, 1, files.children.length, 1)
+              </ul>
+            </fieldset>
           </div>
           <div class="govuk-button-group">
             <button class="govuk-button" type="submit" value="edit" data-module="govuk-button" draggable="false">

--- a/npm/src/index.ts
+++ b/npm/src/index.ts
@@ -122,33 +122,6 @@ export const renderModules = async () => {
       const nestedNavigation = new NestedNavigation(tree)
       nestedNavigation.initialiseFormListeners(InputType.radios)
     })
-    const form = document.querySelector("form")
-    if (form) {
-      form.addEventListener("submit", async (ev) => {
-        ev.preventDefault()
-        const body = new URLSearchParams()
-        document
-          .querySelectorAll("li[aria-checked=true]")
-          .forEach((el, _, __) => {
-            body.set(el.id, "on")
-          })
-        const csrfInput: HTMLInputElement | null = document.querySelector(
-          "input[name='csrfToken']"
-        )
-        fetch(form.action, {
-          body,
-          method: "POST",
-          headers: {
-            "Content-Type": "application/x-www-form-urlencoded",
-            "Csrf-Token": csrfInput!.value,
-            "X-Requested-With": "XMLHttpRequest"
-          },
-          redirect: "follow"
-        }).then((res) => {
-          window.location.replace(res.url)
-        })
-      })
-    }
   }
   if (multiSelectSearch) {
     const rootElement: HTMLElement | null = document.querySelector(

--- a/test/controllers/AdditionalMetadataNavigationControllerSpec.scala
+++ b/test/controllers/AdditionalMetadataNavigationControllerSpec.scala
@@ -176,7 +176,7 @@ class AdditionalMetadataNavigationControllerSpec extends FrontEndTestHelper {
           .submitFiles(consignmentId, "closure")
           .apply(
             FakeRequest(POST, s"/consignment/$consignmentId/additional-metadata/files/${metadataType(0)}")
-              .withFormUrlEncodedBody(Seq((s"radios-list-$fileId", "checked")): _*)
+              .withFormUrlEncodedBody(Seq((s"nested-navigation", fileId.toString)): _*)
               .withCSRFToken
           )
 
@@ -203,7 +203,7 @@ class AdditionalMetadataNavigationControllerSpec extends FrontEndTestHelper {
           .submitFiles(consignmentId, metadataType(0))
           .apply(
             FakeRequest(POST, s"/consignment/$consignmentId/additional-metadata/files/${metadataType(0)}")
-              .withFormUrlEncodedBody(Seq((s"radios-list-$fileId", "checked")): _*)
+              .withFormUrlEncodedBody(Seq((s"nested-navigation", fileId)): _*)
               .withCSRFToken
           )
         playStatus(result) must equal(SEE_OTHER)
@@ -221,7 +221,7 @@ class AdditionalMetadataNavigationControllerSpec extends FrontEndTestHelper {
           .submitFiles(consignmentId, "descriptive")
           .apply(
             FakeRequest(POST, s"/consignment/$consignmentId/additional-metadata/files/descriptive/")
-              .withFormUrlEncodedBody(Seq((s"radios-list-$fileId", "checked")): _*)
+              .withFormUrlEncodedBody(Seq((s"nested-navigation", fileId)): _*)
               .withCSRFToken
           )
         playStatus(result) must equal(SEE_OTHER)
@@ -298,10 +298,10 @@ class AdditionalMetadataNavigationControllerSpec extends FrontEndTestHelper {
     s"""
         |<li class="tna-tree__item govuk-radios--small" role="treeitem" id="radios-list-$id" aria-level="3" aria-setsize="3" aria-posinset="$ariaPosinset" aria-selected="false">
         |      <div class="tna-tree__node-item__radio govuk-radios__item">
-        |        <span class="govuk-radios__input" aria-hidden="true" id="radio-$id" name="nested-navigation"></span>
-        |        <span class="govuk-label govuk-radios__label">
+        |        <input type="radio" name="nested-navigation" class="govuk-radios__input" id="radio-$id" value="$id"/>
+        |        <label class="govuk-label govuk-radios__label" for="radio-$id">
         |        $label$tag
-        |        </span>
+        |        </label>
         |      </div>
         |    </li>
         |""".stripMargin.replaceAll("\n", "").replaceAll(" ", "")


### PR DESCRIPTION
I've set the file list to be expanded on default. This returns the
flicker problem where you see the expanded list and the js closes it but
I've raised a seperate ticket to deal with that.

I've changed here:
* The spans for the radio buttons and labels are now `<input>` and  `<label>` This allows them to be checked and allows them to be submitted in the form post.
* Removed the submit handler for this form from the js.
* Updated the controller to take the fileIds from the form. This is  the same behaviour whether js is enabled or not which keeps things consistent
* Moved the "Select the file.." text to the `<legend>` for a `fieldset` as the accessibility tools show warnings if these are missing.
* Updated the tests for the html
