### PR TITLE
Add descriptive metadata card details.

### DIFF
--- a/app/views/standard/additionalMetadataStart.scala.html
+++ b/app/views/standard/additionalMetadataStart.scala.html
@@ -1,6 +1,8 @@
 @import views.html.partials.{notificationBanner, progressIndicator, transferReference, warningMessage}
+@import services.Details
 
 @import java.util.UUID
+@import views.html.partials.details
 @(consignmentRef: String, consignmentId: UUID, name: String, closurePropertiesSummaries: List[String], descriptivePropertiesSummaries: List[String])(implicit messages: Messages, request: RequestHeader)
 @main(title = "Descriptive and closure metadata", name = name) {
     @defining(play.core.PlayVersion.current) { version =>
@@ -63,6 +65,9 @@
           </ul>
         </div>
       </details>
+      @if(name.toLowerCase == "descriptive metadata") {
+        @details(Details("Records with sensitive descriptions", Messages("additionalMetadata.descriptive.sensitive")))
+      }
     </div>
   </div>
 }

--- a/conf/messages
+++ b/conf/messages
@@ -54,3 +54,5 @@ judgmentProgress.totalSteps=3
 notification.savedProgress.title=Important
 notification.savedProgress.heading=Your progress has been saved
 notification.savedProgress.metadataInfo=Your records and any metadata you added has been saved. You can leave at any time and return to this transfer by visiting the <a class="govuk-notification-banner__link" href="{0}">{1}</a> page.
+
+additionalMetadata.descriptive.sensitive=If the description of a record contains sensitive information, you must enter the full uncensored version on the Descriptive metadata page before entering an alternative description on the Closure metadata page.

--- a/test/controllers/AdditionalMetadataControllerSpec.scala
+++ b/test/controllers/AdditionalMetadataControllerSpec.scala
@@ -199,6 +199,15 @@ class AdditionalMetadataControllerSpec extends FrontEndTestHelper {
           |<Spaces>
           |          </ul>""".stripMargin.replace("<Spaces>", "            ")
       )
+      page must include(
+        """<details class="govuk-details govuk-!-margin-bottom-2" data-module="govuk-details">
+          |  <summary class="govuk-details__summary">
+          |    <span class="govuk-details__summary-text">Records with sensitive descriptions</span>
+          |  </summary>
+          |  <div class="govuk-details__text">
+          |    <p class="govuk-body">additionalMetadata.descriptive.sensitive</p>
+          |  </div>""".stripMargin
+      )
     }
   }
 }


### PR DESCRIPTION
This is another details component which describes what to do if there is
a sensitive description.

This relies on changes in https://github.com/nationalarchives/tdr-transfer-frontend/pull/2693
