### PR TITLE
Update page titles.

### DIFF
--- a/app/views/contact.scala.html
+++ b/app/views/contact.scala.html
@@ -1,14 +1,16 @@
 @(isLoggedIn: Boolean, name: String, isJudgmentUser: Boolean)(implicit messages: Messages, request: RequestHeader)
+@defining("Get in touch") { title =>
+  @main(title, isLoggedIn = isLoggedIn, name = name, isJudgmentUser = isJudgmentUser) {
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+                <h1 class="govuk-heading-l">@title</h1>
+                <p class="govuk-body">
+                    If you have got feedback, ideas or questions get in touch with the Transfer Digital Records team</p>
 
-@main("Contact", isLoggedIn = isLoggedIn, name = name, isJudgmentUser = isJudgmentUser) {
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-            <h1 class="govuk-heading-l">Get in touch</h1>
-            <p class="govuk-body">If you have got feedback, ideas or questions get in touch with the Transfer Digital Records team</p>
+                <h1 class="govuk-heading-l">Email</h1>
+                <p class="govuk-body"><a class="govuk-link" href="mailto:@Messages("nationalArchives.email")" data-hsupport="email">@Messages("nationalArchives.email")</a></p>
 
-            <h1 class="govuk-heading-l">Email</h1>
-            <p class="govuk-body"><a class="govuk-link" href="mailto:@Messages("nationalArchives.email")" data-hsupport="email">@Messages("nationalArchives.email")</a></p>
-
+            </div>
         </div>
-    </div>
+    }
 }

--- a/app/views/faq.scala.html
+++ b/app/views/faq.scala.html
@@ -1,384 +1,407 @@
 @(isLoggedIn: Boolean, name: String)(implicit messages: Messages, request: RequestHeader)
+@defining("Frequently Asked Questions") { title =>
+  @main(title, isLoggedIn = isLoggedIn, name = name) {
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+                <h1 class="govuk-heading-l">@title</h1>
 
-@main("FAQ", isLoggedIn = isLoggedIn, name = name) {
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-            <h1 class="govuk-heading-l">Frequently Asked Questions</h1>
+                <h2 id="getting-started" class="govuk-heading-m">Getting started</h2>
+                <p class="govuk-body">
+                    Before reading the TDR FAQs, we recommend that you read through the TDR User Guide first.
+                </p>
 
-            <h2 id="getting-started" class="govuk-heading-m">Getting started</h2>
-            <p class="govuk-body">
-                Before reading the TDR FAQs, we recommend that you read through the TDR User Guide first.
-            </p>
+                <h3 class="govuk-heading-s">What is TDR?</h3>
+                <p class="govuk-body">
+                    Transfer Digital Records (TDR) is a secure digital transfer service from The National Archives (TNA) that enables Public Record Bodies to upload, prepare and then transfer selected digital Public Records to TNA for permanent preservation and publication.
+                </p>
+                <p class="govuk-body">
+                    TDR is a preparation area where records are uploaded to prepare for transfer. Whilst records remain uploaded in TDR, they continue to be the responsibility of and owned by the transferring body. For example, while records are in TDR the transferring body will still be accountable for any requests such as FOI. The custody of records is only transferred to TNA when exported during the final stage of the TDR process.
+                </p>
 
-            <h3 class="govuk-heading-s">What is TDR?</h3>
-            <p class="govuk-body">
-                Transfer Digital Records (TDR) is a secure digital transfer service from The National Archives (TNA) that enables Public Record Bodies to upload, prepare and then transfer selected digital Public Records to TNA for permanent preservation and publication.
-            </p>
-            <p class="govuk-body">
-                TDR is a preparation area where records are uploaded to prepare for transfer. Whilst records remain uploaded in TDR, they continue to be the responsibility of and owned by the transferring body. For example, while records are in TDR the transferring body will still be accountable for any requests such as FOI. The custody of records is only transferred to TNA when exported during the final stage of the TDR process.
-            </p>
+                <h3 class="govuk-heading-s">What are selected digital public records?</h3>
+                <p class="govuk-body">
+                    These are records of historical value and enduring public interest that have been selected for permanent preservation.
+                </p>
+                <p class="govuk-body">
+                    Transferring departments have a statutory responsibility to appraise, select and sensitivity review records prior to transferring records to The National Archives.
+                </p>
+                <p class="govuk-body">
+                    If there are any issues detected with the appraisal, selection and sensitivity review of records, The National Archives reserves the right to pause the transfer and refer to the Strategic Compliance team.
+                </p>
+                <p class="govuk-body">
+                    If you would like more information about this, contact <a href="mailto:@Messages("nationalArchives.governmentHelpPointEmail")">@Messages("nationalArchives.governmentHelpPointEmail")</a>
+                    .
+                </p>
 
-            <h3 class="govuk-heading-s">What are selected digital public records?</h3>
-            <p class="govuk-body">
-                These are records of historical value and enduring public interest that have been selected for permanent preservation.
-            </p>
-            <p class="govuk-body">
-                Transferring departments have a statutory responsibility to appraise, select and sensitivity review records prior to transferring records to The National Archives.
-            </p>
-            <p class="govuk-body">
-                If there are any issues detected with the appraisal, selection and sensitivity review of records, The National Archives reserves the right to pause the transfer and refer to the Strategic Compliance team.
-            </p>
-            <p class="govuk-body">
-                If you would like more information about this, contact <a href="mailto:@Messages("nationalArchives.governmentHelpPointEmail")">@Messages("nationalArchives.governmentHelpPointEmail")</a>.
-            </p>
+                <h3 class="govuk-heading-s">How does TDR work?</h3>
+                <p class="govuk-body">A digital records transfer using TDR involves the following steps:</p>
+                <ol class="govuk-list govuk-list--number">
+                    <li>Users select the series reference for their transfer and confirm service agreement requirements.</li>
+                    <li>Users upload selected digital records to TDR</li>
+                    <li>TDR checks that the records are free of computer viruses or other malware</li>
+                    <li>Users add, edit or delete descriptive and closure metadata.</li>
+                    <li>Users are asked to confirm that the records have been selected, sensitivity reviewed and meet TNA's requirements for transfer</li>
+                    <li>If all checks have been passed, users can formally transfer custody of the records to TNA on the Confirm Transfer page by clicking 'Transfer your records'.</li>
+                    <li>On successful transfer to TNA the user is informed that they have arrived securely for onwards processing at TNA.</li>
+                </ol>
+                <p class="govuk-body">
+                    TNA takes formal custody and becomes legally responsible for the records at step 7 of the process.
+                </p>
+                <p class="govuk-body">
+                    Once received at The National Archives, the records will be preserved and where appropriate released on the public catalogue.
+                </p>
 
-            <h3 class="govuk-heading-s">How does TDR work?</h3>
-            <p class="govuk-body">A digital records transfer using TDR involves the following steps:</p>
-            <ol class="govuk-list govuk-list--number">
-                <li>Users select the series reference for their transfer and confirm service agreement requirements.</li>
-                <li>Users upload selected digital records to TDR</li>
-                <li>TDR checks that the records are free of computer viruses or other malware</li>
-                <li>Users add, edit or delete descriptive and closure metadata.</li>
-                <li>Users are asked to confirm that the records have been selected, sensitivity reviewed and meet TNA's requirements for transfer</li>
-                <li>If all checks have been passed, users can formally transfer custody of the records to TNA on the Confirm Transfer page by clicking 'Transfer your records'.</li>
-                <li>On successful transfer to TNA the user is informed that they have arrived securely for onwards processing at TNA.</li>
-            </ol>
-            <p class="govuk-body">
-                TNA takes formal custody and becomes legally responsible for the records at step 7 of the process.
-            </p>
-            <p class="govuk-body">
-                Once received at The National Archives, the records will be preserved and where appropriate released on the public catalogue.
-            </p>
+                <h3 id="beta" class="govuk-heading-s">What is beta?</h3>
+                <p class="govuk-body">
+                    TDR is being built using an agile approach. Beta is an early agile stage where the service is still being developed and does not yet offer the full range of features that we intend to support. For example, TDR can currently only accept records that are Crown Copyright.
+                </p>
+                <p class="govuk-body">
+                    At this development stage, the service is also only available to pre-approved users. Over time, we will make TDR available to more departments and will continue to develop the service in consultation with our users. If you would like to user TDR contact our transfer advisors on <a href="mailto:@Messages("nationalArchives.email")">@Messages("nationalArchives.email")</a>
+                    .
+                </p>
 
-            <h3 id="beta" class="govuk-heading-s">What is beta?</h3>
-            <p class="govuk-body">
-                TDR is being built using an agile approach. Beta is an early agile stage where the service is still being developed and does not yet offer the full range of features that we intend to support. For example, TDR can currently only accept records that are Crown Copyright.
-            </p>
-            <p class="govuk-body">
-                At this development stage, the service is also only available to pre-approved users. Over time, we will make TDR available to more departments and will continue to develop the service in consultation with our users. If you would like to user TDR contact our transfer advisors on <a href="mailto:@Messages("nationalArchives.email")">@Messages("nationalArchives.email")</a>.
-            </p>
+                <h2 id="accessing-tdr-account" class="govuk-heading-m">Accessing my TDR account</h2>
+                <h3 id="browsers-supported" class="govuk-heading-s">What browsers are supported?</h3>
+                <p class="govuk-body">
+                    We do not support Internet Explorer. We advise you to use latest browser version of Edge, Chrome, or Firefox to ensure you can use this service and all of its features.
+                </p>
 
-            <h2 id="accessing-tdr-account" class="govuk-heading-m">Accessing my TDR account</h2>
-            <h3 id="browsers-supported" class="govuk-heading-s">What browsers are supported?</h3>
-            <p class="govuk-body">
-                We do not support Internet Explorer. We advise you to use latest browser version of Edge, Chrome, or Firefox to ensure you can use this service and all of its features.
-            </p>
+                <h3 id="sign-in-email" class="govuk-heading-s">Which email should I use to sign-in?</h3>
+                <p class="govuk-body">
+                    Use the email that you used to create your account. If your email address changes, send full details of the change to <a href="mailto:@Messages("nationalArchives.email")">@Messages("nationalArchives.email")</a>.
+                </p>
 
-            <h3 id="sign-in-email" class="govuk-heading-s">Which email should I use to sign-in?</h3>
-            <p class="govuk-body">
-                Use the email that you used to create your account. If your email address changes, send full details of the change to <a href="mailto:@Messages("nationalArchives.email")">@Messages("nationalArchives.email")</a>.
-            </p>
+                <h3 id="password-not-working" class="govuk-heading-s">My password does not work</h3>
+                <p class="govuk-body">
+                    If you forget your password or need to reset it, click the ‘Forgot your password?’ link on the sign in page to request a reset and follow the on-screen instructions. For any other password issue, email <a href="mailto:@Messages("nationalArchives.email")">@Messages("nationalArchives.email")</a>.
+                </p>
 
-            <h3 id="password-not-working" class="govuk-heading-s">My password does not work</h3>
-            <p class="govuk-body">
-                If you forget your password or need to reset it, click the ‘Forgot your password?’ link on the sign in page to request a reset and follow the on-screen instructions. For any other password issue, email <a href="mailto:@Messages("nationalArchives.email")">@Messages("nationalArchives.email")</a>.
-            </p>
+                <h3 id="what-is-mfa" class="govuk-heading-s">What is Multi-Factor Authentication (MFA)?</h3>
+                <p class="govuk-body">
+                    To keep the service and your account secure, you are required to sign-in each time using Multi-Factor Authentication (MFA). This uses two separate pieces of information to authenticate and grant access to the service. In TDR you must sign in each time using your password and a unique generated 'one-time password' (OTP) code that confirms who you are. This can be set up with a free-to-download authenticator app on your smartphone device, such as Google Authenticator, Microsoft Authenticator, or FreeOTP. Other authenticators are also available.
+                </p>
+                <p class="govuk-body">
+                    Free-to-download apps are available from the App Store for iPhone, or 'Google Play' and 'Play Store' for Android.
+                </p>
 
-            <h3 id="what-is-mfa" class="govuk-heading-s">What is Multi-Factor Authentication (MFA)?</h3>
-            <p class="govuk-body">
-                To keep the service and your account secure, you are required to sign-in each time using Multi-Factor Authentication (MFA). This uses two separate pieces of information to authenticate and grant access to the service. In TDR you must sign in each time using your password and a unique generated 'one-time password' (OTP) code that confirms who you are. This can be set up with a free-to-download authenticator app on your smartphone device, such as Google Authenticator, Microsoft Authenticator, or FreeOTP. Other authenticators are also available.
-            </p>
-            <p class="govuk-body">
-                Free-to-download apps are available from the App Store for iPhone, or 'Google Play' and 'Play Store' for Android.
-            </p>
+                <h3 id="set-up-mfa-otp" class="govuk-heading-s">How do I set up MFA and my one-time password (OTP)?</h3>
+                <p class="govuk-body">
+                    When you register as a new TDR user, follow the registration steps in the TDR <a class="govuk-link" href="@routes.HelpController.help()">
+                    User Guide</a>
+                    in order to set up a TDR account in the authenticator app on a smartphone device that you have access to. You only need to configure this once for it to generate a code for each time you sign in.
+                </p>
 
-            <h3 id="set-up-mfa-otp" class="govuk-heading-s">How do I set up MFA and my one-time password (OTP)?</h3>
-            <p class="govuk-body">
-                When you register as a new TDR user, follow the registration steps in the TDR <a class="govuk-link" href="@routes.HelpController.help()">User Guide</a> in order to set up a TDR account in the authenticator app on a smartphone device that you have access to. You only need to configure this once for it to generate a code for each time you sign in.
-            </p>
+                <h3 id="where-to-get-otp-code" class="govuk-heading-s">Where do I get my OTP code?</h3>
+                <p class="govuk-body">
+                    Click on the TDR account that you set up in the authenticator app to see a one-time passcode being generated every 30 to 60 seconds. Ensure you have enough time to use the code to complete the sign-in process before the code refreshes.
+                </p>
 
-            <h3 id="where-to-get-otp-code" class="govuk-heading-s">Where do I get my OTP code?</h3>
-            <p class="govuk-body">
-                Click on the TDR account that you set up in the authenticator app to see a one-time passcode being generated every 30 to 60 seconds. Ensure you have enough time to use the code to complete the sign-in process before the code refreshes.
-            </p>
+                <h3 class="govuk-heading-s">
+                    When setting up the authenticator app, my configuration has failed - what should I do?</h3>
+                <p class="govuk-body">
+                    If the authentication app fails to configure when adding a new account for TDR on your device, delete the failed TDR account within the app and try again. For guidance on how to do this on each device, follow the instructions below.
+                </p>
+                <p class="govuk-body">
+                    For Android:
+                </p>
+                <ol class="govuk-list govuk-list--number">
+                    <li>Open the authenticator app on the device and tap 'Generate code'.</li>
+                    <li>In the 'Generate code' screen, press and hold the account you want to remove.</li>
+                    <li>When prompted, tap remove.</li>
+                </ol>
+                <p class="govuk-body">
+                    For iOS:
+                </p>
+                <ol class="govuk-list govuk-list--number">
+                    <li>Open the authenticator app on the device and tap 'Generate code'.</li>
+                    <li>On the Generate code screen, press the account you wish to remove and swipe it to the left.</li>
+                    <li>If you are using the Microsoft Authenticator, look for the settings cog in the top corner and tap it to see the option that says 'Remove account'</li>
+                </ol>
+                <p class="govuk-body">
+                    If you need further support on the app, your local IT support desk may be able to assist.
+                </p>
 
-            <h3 class="govuk-heading-s">When setting up the authenticator app, my configuration has failed - what should I do?</h3>
-            <p class="govuk-body">
-                If the authentication app fails to configure when adding a new account for TDR on your device, delete the failed TDR account within the app and try again. For guidance on how to do this on each device, follow the instructions below.
-            </p>
-            <p class="govuk-body">
-                For Android:
-            </p>
-            <ol class="govuk-list govuk-list--number">
-                <li>Open the authenticator app on the device and tap 'Generate code'.</li>
-                <li>In the 'Generate code' screen, press and hold the account you want to remove.</li>
-                <li>When prompted, tap remove.</li>
-            </ol>
-            <p class="govuk-body">
-                For iOS:
-            </p>
-            <ol class="govuk-list govuk-list--number">
-                <li>Open the authenticator app on the device and tap 'Generate code'.</li>
-                <li>On the Generate code screen, press the account you wish to remove and swipe it to the left.</li>
-                <li>If you are using the Microsoft Authenticator, look for the settings cog in the top corner and tap it to see the option that says 'Remove account'</li>
-            </ol>
-            <p class="govuk-body">
-                If you need further support on the app, your local IT support desk may be able to assist.
-            </p>
+                <h3 class="govuk-heading-s">I can’t use my phone camera to scan the QR code</h3>
+                <p class="govuk-body">
+                    Some device users may need to enable access to the camera in Settings.
+                </p>
+                <p class="govuk-body">
+                    Alternatively, a 9-digit key code, can be manually entered into the app. You can find guidance on how to get a 9-digit key code in 'Part 2: Step 2' of the TDR User Guide. Once you have the code, you can enter it into the app. To do this:
+                </p>
+                <ol class="govuk-list govuk-list--number">
+                    <li>First generate a code, by clicking on the 'I want to enter a key instead' link underneath the QR code displayed on the page.</li>
+                    <li>Within your authenticator app click the 'Enter a setup key' option.</li>
+                    <li>Enter the key code as shown into the app and it should create your unique OTP account for TDR sign-in.</li>
+                    <li>You should now be able to see a 6-digit code that will refresh at regular intervals.</li>
+                    <li>Continue to follow instructions from 'Part 2: Step 3' of the TDR User Guide.</li>
+                </ol>
 
-            <h3 class="govuk-heading-s">I can’t use my phone camera to scan the QR code</h3>
-            <p class="govuk-body">
-                Some device users may need to enable access to the camera in Settings.
-            </p>
-            <p class="govuk-body">
-                Alternatively, a 9-digit key code, can be manually entered into the app. You can find guidance on how to get a 9-digit key code in 'Part 2: Step 2' of the TDR User Guide. Once you have the code, you can enter it into the app. To do this:
-            </p>
-            <ol class="govuk-list govuk-list--number">
-                <li>First generate a code, by clicking on the 'I want to enter a key instead' link underneath the QR code displayed on the page.</li>
-                <li>Within your authenticator app click the 'Enter a setup key' option.</li>
-                <li>Enter the key code as shown into the app and it should create your unique OTP account for TDR sign-in.</li>
-                <li>You should now be able to see a 6-digit code that will refresh at regular intervals.</li>
-                <li>Continue to follow instructions from 'Part 2: Step 3' of the TDR User Guide.</li>
-            </ol>
+                <h3 class="govuk-heading-s">My link has expired</h3>
+                <p class="govuk-body">
+                    If your link has expired before use, email <a href="mailto:@Messages("nationalArchives.email")">@Messages("nationalArchives.email")</a>
+                    from your work email account and ask for a new link. Allow up to two working days for your request to be processed.
+                </p>
 
-            <h3 class="govuk-heading-s">My link has expired</h3>
-            <p class="govuk-body">
-                If your link has expired before use, email <a href="mailto:@Messages("nationalArchives.email")">@Messages("nationalArchives.email")</a> from your work email account and ask for a new link. Allow up to two working days for your request to be processed.
-            </p>
+                <h3 class="govuk-heading-s">Can I share my sign-in information?</h3>
+                <p class="govuk-body">
+                    No, never share your personal sign-in information with anyone else. Always keep your details safe and secure.</p>
 
-            <h3 class="govuk-heading-s">Can I share my sign-in information?</h3>
-            <p class="govuk-body">No, never share your personal sign-in information with anyone else. Always keep your details safe and secure.</p>
+                <h2 id="upload-process" class="govuk-heading-m">The upload process</h2>
+                <h3 class="govuk-heading-s">What is a series reference?</h3>
+                <p class="govuk-body">
+                    A series reference is a label assigned to a set of archived records. Series references generally contain letters that indicate the creating department followed by numbers referring to the series, for example 'DCMS-1234'. The Cataloguing Department at The National Archives allocates the series references.
+                </p>
 
-            <h2 id="upload-process" class="govuk-heading-m">The upload process</h2>
-            <h3 class="govuk-heading-s">What is a series reference?</h3>
-            <p class="govuk-body">
-                A series reference is a label assigned to a set of archived records. Series references generally contain letters that indicate the creating department followed by numbers referring to the series, for example 'DCMS-1234'. The Cataloguing Department at The National Archives allocates the series references.
-            </p>
-
-            <h3 class="govuk-heading-s">I cannot choose my series reference</h3>
-            <p class="govuk-body">
-                If you cannot find your series reference in the dropdown list on the ‘Series reference’ page, or you are unsure what your series reference should be when you begin the transfer process, contact <a href="mailto:@Messages("nationalArchives.email")">
+                <h3 class="govuk-heading-s">I cannot choose my series reference</h3>
+                <p class="govuk-body">
+                    If you cannot find your series reference in the dropdown list on the ‘Series reference’ page, or you are unsure what your series reference should be when you begin the transfer process, contact <a href="mailto:@Messages("nationalArchives.email")">
                 @Messages("nationalArchives.email")</a>.
-            </p>
+                </p>
 
-            <h3 class="govuk-heading-s">What is a consignment reference?</h3>
-            <p class="govuk-body">
-                A consignment reference is a unique label assigned to each consignment (batch) of digital records that have been uploaded to TDR, for example 'MOCK-123-TDR'. The View Transfers page will show you your consignment reference. It will also be displayed in the top right-hand corner of your screen once you have begun a transfer.
-            </p>
+                <h3 class="govuk-heading-s">What is a consignment reference?</h3>
+                <p class="govuk-body">
+                    A consignment reference is a unique label assigned to each consignment (batch) of digital records that have been uploaded to TDR, for example 'MOCK-123-TDR'. The View Transfers page will show you your consignment reference. It will also be displayed in the top right-hand corner of your screen once you have begun a transfer.
+                </p>
 
-            <h3 class="govuk-heading-s">What are Public Records?</h3>
-            <p class="govuk-body">
-                Public Records are records created or held by any UK government department or related body. The National Archives can usually only accept Public Records.
-            </p>
+                <h3 class="govuk-heading-s">What are Public Records?</h3>
+                <p class="govuk-body">
+                    Public Records are records created or held by any UK government department or related body. The National Archives can usually only accept Public Records.
+                </p>
 
-            <h3 class="govuk-heading-s">How do I know if my records are Crown Copyright?</h3>
-            <p class="govuk-body">
-                Works created by officers or servants of the Crown during the course of their duties are Crown Copyright. This includes material created by ministers, civil servants, government departments and agencies. In the future The National Archives will accept Public Records that are not Crown Copyright, however during this initial development stage, you cannot use TDR to transfer them to us.
-            </p>
+                <h3 class="govuk-heading-s">How do I know if my records are Crown Copyright?</h3>
+                <p class="govuk-body">
+                    Works created by officers or servants of the Crown during the course of their duties are Crown Copyright. This includes material created by ministers, civil servants, government departments and agencies. In the future The National Archives will accept Public Records that are not Crown Copyright, however during this initial development stage, you cannot use TDR to transfer them to us.
+                </p>
 
-            <h3 id="other-languages" class="govuk-heading-s">The records I wish to transfer are in another language (for example, Welsh)</h3>
-            <p class="govuk-body">
-                The National Archives accepts records in any language.
-            </p>
+                <h3 id="other-languages" class="govuk-heading-s">
+                    The records I wish to transfer are in another language (for example, Welsh)</h3>
+                <p class="govuk-body">
+                    The National Archives accepts records in any language.
+                </p>
 
-            <h3 class="govuk-heading-s">What file formats are accepted?</h3>
-            <p class="govuk-body">We cannot accept files that are password protected or encrypted.</p>
-            <p class="govuk-body">We cannot accept files with slashes (/ and \) in the name.</p>
-            <p class="govuk-body">
-                We also cannot currently accept zip files via TDR. Contact <a href="mailto:@Messages("nationalArchives.email")">
+                <h3 class="govuk-heading-s">What file formats are accepted?</h3>
+                <p class="govuk-body">We cannot accept files that are password protected or encrypted.</p>
+                <p class="govuk-body">We cannot accept files with slashes (/ and \) in the name.</p>
+                <p class="govuk-body">
+                    We also cannot currently accept zip files via TDR. Contact <a href="mailto:@Messages("nationalArchives.email")">
                 @Messages("nationalArchives.email")</a> if you wish to transfer these.
-            </p>
-            <p class="govuk-body">If you upload an empty folder it will not be transferred.</p>
+                </p>
+                <p class="govuk-body">If you upload an empty folder it will not be transferred.</p>
 
-            <h3 class="govuk-heading-s">Do you accept system files, password protected files, executable files, or zip files and folders and how do I identify them?</h3>
-            <p class="govuk-body">
-                System files, including 'thumbs.db' files, ds_store files, and .lnk files are not usually selected for permanent preservation. We advise you to remove these from your consignment.
-            </p>
-            <p class="govuk-body">Password protected files are not accepted and must be removed prior to transfer.</p>
-            <p class="govuk-body">
-                Executable files, such as those with a .exe or .msi extension are not usually selected for transfer but there may be a good reason for selecting them. Ensure you are certain that you wish to upload such files prior to transfer.
-            </p>
-            <p class="govuk-body">
-                Zips, and similar 'archival container' files including .rar, .7z, .gz and others must be unpacked prior to transfer. Failure to do so will likely cause the transfer to fail. Speak with your local IT Support team if you require assistance with this.
-            </p>
-            <p class="govuk-body">
-                File format extensions can also be useful for determining file types, however this can be an unreliable approach, since they can be changed easily. Extensions are the end part of a filename that typically look similar to '.jpg' or '.docx'. They are often hidden by default, but can usually be made visible to help with determining file type. Speak with your local IT Support team if you require assistance with this.
-            </p>
-            <p class="govuk-body">
-                To identify file formats, search you folder for the file extensions (thumbs.db, .exe and .zip). For password protected files, click to view folder options and select 'hidden files and folders'. These files are usually identified as part of your selection and sensitivity review process.
-            </p>
-            <p class="govuk-body">Contact <a href="mailto:@Messages("nationalArchives.email")">
-                @Messages("nationalArchives.email")</a> if you have any uncertainty about the file formats you have selected for transfer.
-            </p>
+                <h3 class="govuk-heading-s">
+                    Do you accept system files, password protected files, executable files, or zip files and folders and how do I identify them?</h3>
+                <p class="govuk-body">
+                    System files, including 'thumbs.db' files, ds_store files, and .lnk files are not usually selected for permanent preservation. We advise you to remove these from your consignment.
+                </p>
+                <p class="govuk-body">Password protected files are not accepted and must be removed prior to transfer.</p>
+                <p class="govuk-body">
+                    Executable files, such as those with a .exe or .msi extension are not usually selected for transfer but there may be a good reason for selecting them. Ensure you are certain that you wish to upload such files prior to transfer.
+                </p>
+                <p class="govuk-body">
+                    Zips, and similar 'archival container' files including .rar, .7z, .gz and others must be unpacked prior to transfer. Failure to do so will likely cause the transfer to fail. Speak with your local IT Support team if you require assistance with this.
+                </p>
+                <p class="govuk-body">
+                    File format extensions can also be useful for determining file types, however this can be an unreliable approach, since they can be changed easily. Extensions are the end part of a filename that typically look similar to '.jpg' or '.docx'. They are often hidden by default, but can usually be made visible to help with determining file type. Speak with your local IT Support team if you require assistance with this.
+                </p>
+                <p class="govuk-body">
+                    To identify file formats, search you folder for the file extensions (thumbs.db, .exe and .zip). For password protected files, click to view folder options and select 'hidden files and folders'. These files are usually identified as part of your selection and sensitivity review process.
+                </p>
+                <p class="govuk-body">Contact <a href="mailto:@Messages("nationalArchives.email")">
+                @Messages("nationalArchives.email")</a>
+                    if you have any uncertainty about the file formats you have selected for transfer.
+                </p>
 
-            <h3 class="govuk-heading-s">Why can’t I drag and drop or upload my records?</h3>
-            <p class="govuk-body">
-                This may happen for several reasons. To try to resolve the issue, first check your internet connection is sufficient and stable. It may also help to refresh the page though this might mean you have to begin the transfer process again. You can also check your sub-folders and files are not corrupted or damaged by opening them on your computer. If you still cannot upload your files and sub-folders, contact <a href="mailto:@Messages("nationalArchives.email")">@Messages("nationalArchives.email")</a> describing the issue and any steps taken.
-            </p>
+                <h3 class="govuk-heading-s">Why can’t I drag and drop or upload my records?</h3>
+                <p class="govuk-body">
+                    This may happen for several reasons. To try to resolve the issue, first check your internet connection is sufficient and stable. It may also help to refresh the page though this might mean you have to begin the transfer process again. You can also check your sub-folders and files are not corrupted or damaged by opening them on your computer. If you still cannot upload your files and sub-folders, contact <a href="mailto:@Messages("nationalArchives.email")">@Messages("nationalArchives.email")</a>
+                    describing the issue and any steps taken.
+                </p>
 
-            <h3 class="govuk-heading-s">Can I upload multiple folders?</h3>
-            <p class="govuk-body">
-                You can only upload one content folder per consignment. However, that folder can contain multiple files and sub-folders.
-            </p>
+                <h3 class="govuk-heading-s">Can I upload multiple folders?</h3>
+                <p class="govuk-body">
+                    You can only upload one content folder per consignment. However, that folder can contain multiple files and sub-folders.
+                </p>
 
-            <h3 class="govuk-heading-s">Is there an upload limit?</h3>
-            <p class="govuk-body">
-                We recommend that each file is no more than 2GB and that you upload no more than 500 files per consignment.
-                Uploading more than the recommended size increases the likelihood of errors occurring and may take longer
-                to be uploaded and checked. If your files are very large and cannot be uploaded, contact
-                <a href="mailto:@Messages("nationalArchives.email")">@Messages("nationalArchives.email")</a>.
-            </p>
+                <h3 class="govuk-heading-s">Is there an upload limit?</h3>
+                <p class="govuk-body">
+                    We recommend that each file is no more than 2GB and that you upload no more than 500 files per consignment.
+                    Uploading more than the recommended size increases the likelihood of errors occurring and may take longer
+                    to be uploaded and checked. If your files are very large and cannot be uploaded, contact
+                    <a href="mailto:@Messages("nationalArchives.email")">@Messages("nationalArchives.email")</a>.
+                </p>
 
-            <h3 class="govuk-heading-s">Can I upload a folder via OneDrive/ Google Drive/ SharePoint?</h3>
-            <p class="govuk-body">
-                While we are developing the service (Private Beta stage), TDR can only accept records transferred from a hard or network drive. Contact <a href="mailto:@Messages("nationalArchives.email")">
-                @Messages("nationalArchives.email")</a> to discuss the best way to transfer records if they are not stored on a physical or networked drive.
-            </p>
-            <p class="govuk-body">
-                In the future, TDR will accept consignments transferred directly from the cloud.
-            </p>
+                <h3 class="govuk-heading-s">Can I upload a folder via OneDrive/ Google Drive/ SharePoint?</h3>
+                <p class="govuk-body">
+                    While we are developing the service (Private Beta stage), TDR can only accept records transferred from a hard or network drive. Contact <a href="mailto:@Messages("nationalArchives.email")">
+                @Messages("nationalArchives.email")</a>
+                    to discuss the best way to transfer records if they are not stored on a physical or networked drive.
+                </p>
+                <p class="govuk-body">
+                    In the future, TDR will accept consignments transferred directly from the cloud.
+                </p>
 
-            <h3 class="govuk-heading-s">I’ve uploaded files or sub-folders that I do not wish to be transferred</h3>
-            <p class="govuk-body">
-                Currently, if you upload files or sub-folders you do not wish to transfer you will need to contact <a href="mailto:@Messages("nationalArchives.email")">
-                @Messages("nationalArchives.email")</a> and begin the process again. Prior to upload, check that each of the files and sub-folders are intended to be uploaded and transferred. TDR does not currently allow you to amend your files once the transfer process has begun.
-            </p>
+                <h3 class="govuk-heading-s">I’ve uploaded files or sub-folders that I do not wish to be transferred</h3>
+                <p class="govuk-body">
+                    Currently, if you upload files or sub-folders you do not wish to transfer you will need to contact <a href="mailto:@Messages("nationalArchives.email")">
+                @Messages("nationalArchives.email")</a>
+                    and begin the process again. Prior to upload, check that each of the files and sub-folders are intended to be uploaded and transferred. TDR does not currently allow you to amend your files once the transfer process has begun.
+                </p>
 
-            <h3 class="govuk-heading-s">The session timed out before I completed the upload process</h3>
-            <p class="govuk-body">
-                A session can time out during the upload process if your internet connection is weak or if your files are very large. If so, you can continue with your transfer if your records were uploaded successfully via the View Transfers page. If your records were not uploaded successfully you must begin the process again. To avoid the session timing out, ensure you have a sufficiently stable and strong internet connection.
-            </p>
+                <h3 class="govuk-heading-s">The session timed out before I completed the upload process</h3>
+                <p class="govuk-body">
+                    A session can time out during the upload process if your internet connection is weak or if your files are very large. If so, you can continue with your transfer if your records were uploaded successfully via the View Transfers page. If your records were not uploaded successfully you must begin the process again. To avoid the session timing out, ensure you have a sufficiently stable and strong internet connection.
+                </p>
 
-            <h3 class="govuk-heading-s">What happens if I close my browser accidentally during upload?</h3>
-            <p class="govuk-body">
-                If you close your browser during upload your records may not be uploaded successfully. You will need to return to the start and begin the upload process again.
-            </p>
+                <h3 class="govuk-heading-s">What happens if I close my browser accidentally during upload?</h3>
+                <p class="govuk-body">
+                    If you close your browser during upload your records may not be uploaded successfully. You will need to return to the start and begin the upload process again.
+                </p>
 
-            <h3 id="progress-checks" class="govuk-heading-s">What checks are carried out?</h3>
-            <p class="govuk-body">
-                During upload, files are checked to ensure they can be transferred. The following checks are performed:
-            </p>
-            <ul class="govuk-list govuk-list--bullet">
-                <li >Antivirus</li>
+                <h3 id="progress-checks" class="govuk-heading-s">What checks are carried out?</h3>
+                <p class="govuk-body">
+                    During upload, files are checked to ensure they can be transferred. The following checks are performed:
+                </p>
+                <ul class="govuk-list govuk-list--bullet">
+                    <li >Antivirus</li>
                     <p class="govuk-body">
                         A check performed to scan for viruses and other malware. We cannot accept infected files.
                     </p>
-                <li>File format identification</li>
+                    <li>File format identification</li>
                     <p class="govuk-body">
                         A check performed to identify the file format and confirm that the file is suitable for transfer. We accept most types of formats, but ones we haven’t seen before may need further investigation. You may be contacted if your transfer contains unidentified file formats. See 'What file formats are accepted' for guidance on what types of files we can accept.
                     </p>
-                <li>Data integrity validation</li>
+                    <li>Data integrity validation</li>
                     <p class="govuk-body">
                         A check performed to ensure files have not been corrupted as they move between your shared drive and TDR during the upload process. The data integrity check uses checksums which are like a digital fingerprint. For TDR we use SHA256.
                     </p>
                     <p class="govuk-body">
-                        More information can be found in the <a class="govuk-link" href="@routes.HelpController.help()#glossary">Glossary</a> of the TDR User Guide.
+                        More information can be found in the <a class="govuk-link" href="@routes.HelpController.help()#glossary">
+                        Glossary</a> of the TDR User Guide.
                     </p>
-            </ul>
+                </ul>
 
-            <h3 class="govuk-heading-s">What happens if my files fail?</h3>
-            <p class="govuk-body">
-                If you receive a notification that your records have failed our checks, please check the following:
-            </p>
-            <ul class="govuk-list govuk-list--bullet">
-                <li>Your internet connection is stable and strong</li>
-                <li>That your consignment does not contain records we cannot accept.</li>
-            </ul>
-            <p class="govuk-body">If you can confirm the above then try again. If your consignment has still failed, contact <a href="mailto:@Messages("nationalArchives.email")">
-                @Messages("nationalArchives.email")</a>.
-            </p>
-
-            <h3 class="govuk-heading-s">Once I have uploaded my records does that mean TNA now has them?</h3>
+                <h3 class="govuk-heading-s">What happens if my files fail?</h3>
                 <p class="govuk-body">
-                    Upload and export are two completely different stages within the transfer process. Uploading records into TDR <span class="govuk-!-font-weight-bold">does not</span> mean that The National Archives has them. When files have only been uploaded, checks are carried out on your records to help you confirm that they are suitable for transfer. At this point you are still responsible for them, including responsibility for FOI requests.
+                    If you receive a notification that your records have failed our checks, please check the following:
+                </p>
+                <ul class="govuk-list govuk-list--bullet">
+                    <li>Your internet connection is stable and strong</li>
+                    <li>That your consignment does not contain records we cannot accept.</li>
+                </ul>
+                <p class="govuk-body">
+                    If you can confirm the above then try again. If your consignment has still failed, contact <a href="mailto:@Messages("nationalArchives.email")">
+                @Messages("nationalArchives.email")</a>.
+                </p>
+
+                <h3 class="govuk-heading-s">Once I have uploaded my records does that mean TNA now has them?</h3>
+                <p class="govuk-body">
+                    Upload and export are two completely different stages within the transfer process. Uploading records into TDR <span class="govuk-!-font-weight-bold">
+                    does not</span>
+                    mean that The National Archives has them. When files have only been uploaded, checks are carried out on your records to help you confirm that they are suitable for transfer. At this point you are still responsible for them, including responsibility for FOI requests.
                 </p>
                 <p class="govuk-body">
                     Once the checks are completed, you will be prompted to confirm that you wish to transfer custody of the records to The National Archives. This is the export stage. We only take custody of your records once you confirm the transfer of custody at the export and final stage of the process.
                 </p>
 
-            <h3 class="govuk-heading-s">At what point have I transferred the records?</h3>
-            <p class="govuk-body">
-                Once your records have been uploaded and checked, you will be prompted to confirm that you wish to transfer them to The National Archives. You should keep a copy of your records until we confirm preservation at The National Archives. We will endeavour to complete this within 90 days, however it could take longer. We will also notify you when your records have been released to the public.
-            </p>
+                <h3 class="govuk-heading-s">At what point have I transferred the records?</h3>
+                <p class="govuk-body">
+                    Once your records have been uploaded and checked, you will be prompted to confirm that you wish to transfer them to The National Archives. You should keep a copy of your records until we confirm preservation at The National Archives. We will endeavour to complete this within 90 days, however it could take longer. We will also notify you when your records have been released to the public.
+                </p>
 
-            <h3 id="metadata-captured" class="govuk-heading-s">What metadata will be captured in TDR?</h3>
-            <p class="govuk-body">
-                During the upload process, TDR  captures the following metadata from the consignment:
-            </p>
-            <ul class="govuk-list govuk-list--bullet">
-                <li>File path</li>
-                <li>File name</li>
-                <li>Date (usually last modified)</li>
-                <li>Type (distinction between folder and file)</li>
-                <li>Checksum</li>
-            </ul>
-            <p class="govuk-body">
-                The format of the file is also identified using <a href="https://www.nationalarchives.gov.uk/information-management/manage-information/preserving-digital-records/droid/">DROID</a> which was developed by The National Archives.
-            </p>
+                <h3 id="metadata-captured" class="govuk-heading-s">What metadata will be captured in TDR?</h3>
+                <p class="govuk-body">
+                    During the upload process, TDR  captures the following metadata from the consignment:
+                </p>
+                <ul class="govuk-list govuk-list--bullet">
+                    <li>File path</li>
+                    <li>File name</li>
+                    <li>Date (usually last modified)</li>
+                    <li>Type (distinction between folder and file)</li>
+                    <li>Checksum</li>
+                </ul>
+                <p class="govuk-body">
+                    The format of the file is also identified using <a href="https://www.nationalarchives.gov.uk/information-management/manage-information/preserving-digital-records/droid/">
+                    DROID</a> which was developed by The National Archives.
+                </p>
 
-            <h3 class="govuk-heading-s">Why are you asking me to add descriptive metadata?</h3>
-            <p class="govuk-body">
-                During the upload process, TDR captures basic file-level metadata. If you have additional information about your records, we recommend that you add this. It can include anything from descriptions to dates and any additional data that will provide context to the record and make it easier to find in the future. For further assistance, contact <a href="mailto:@Messages("nationalArchives.email")">
+                <h3 class="govuk-heading-s">Why are you asking me to add descriptive metadata?</h3>
+                <p class="govuk-body">
+                    During the upload process, TDR captures basic file-level metadata. If you have additional information about your records, we recommend that you add this. It can include anything from descriptions to dates and any additional data that will provide context to the record and make it easier to find in the future. For further assistance, contact <a href="mailto:@Messages("nationalArchives.email")">
                 @Messages("nationalArchives.email")</a>.
-            </p>
+                </p>
 
-            <h3 class="govuk-heading-s">What do I do if the title or description of my record is sensitive to the public?</h3>
-            <p class="govuk-body">
-                If the title or description of your record is sensitive to the public, you can provide an alternative when adding closure metadata. The alternative will be visible on the public catalogue. You may wish to do one of the following:
-            </p>
-            <ul class="govuk-list govuk-list--bullet">
-                <li>Redact - remove the sensitive words. For example: 'Correspondence with [name withheld]'.</li>
-                <li>Sanitise - replace the sensitive word. For example: 'UK military exercises in xx' (where 'military' has replaced 'Special Forces').</li>
-                <li>Withhold the title or description without providing an alternative. For example: '[Title withheld]' and or '[description withheld]'</li>
-            </ul>
-            
-            <h3 class="govuk-heading-s">Why do I need to export my records when I have already uploaded them to TDR?</h3>
-            <p class="govuk-body">
-                TDR is a service that prepares records to be transferred. When you upload your records, you still have legal custody over them and are still responsible for any requests such as FOI. At the final stage of TDR you will be asked to confirm that you wish to transfer custody of your records to TNA. When confirmed, both the records and legal custody will be exported to TNA.
-            </p>
-            <p class="govuk-body">
-                Until you are notified that your records have been successfully preserved and are live on the public catalogue, it is important that you keep your records safe and do not delete them or alternatively, keep a copy of your records.
-            </p>
+                <h3 class="govuk-heading-s">
+                    What do I do if the title or description of my record is sensitive to the public?</h3>
+                <p class="govuk-body">
+                    If the title or description of your record is sensitive to the public, you can provide an alternative when adding closure metadata. The alternative will be visible on the public catalogue. You may wish to do one of the following:
+                </p>
+                <ul class="govuk-list govuk-list--bullet">
+                    <li>Redact - remove the sensitive words. For example: 'Correspondence with [name withheld]'.</li>
+                    <li>Sanitise - replace the sensitive word. For example: 'UK military exercises in xx' (where 'military' has replaced 'Special Forces').</li>
+                    <li>Withhold the title or description without providing an alternative. For example: '[Title withheld]' and or '[description withheld]'</li>
+                </ul>
 
-            <h3 class="govuk-heading-s">
-                Do I need to wait for a notification before I can transfer another consignment?
-            </h3>
-            <p class="govuk-body">No, consignments can be uploaded back to back.</p>
+                <h3 class="govuk-heading-s">
+                    Why do I need to export my records when I have already uploaded them to TDR?</h3>
+                <p class="govuk-body">
+                    TDR is a service that prepares records to be transferred. When you upload your records, you still have legal custody over them and are still responsible for any requests such as FOI. At the final stage of TDR you will be asked to confirm that you wish to transfer custody of your records to TNA. When confirmed, both the records and legal custody will be exported to TNA.
+                </p>
+                <p class="govuk-body">
+                    Until you are notified that your records have been successfully preserved and are live on the public catalogue, it is important that you keep your records safe and do not delete them or alternatively, keep a copy of your records.
+                </p>
 
-            <h2 id="general" class="govuk-heading-m">General</h2>
-            <h3 class="govuk-heading-s">Who can I contact if I have a query?</h3>
-            <p class="govuk-body">Contact <a href="mailto:@Messages("nationalArchives.email")">
-                @Messages("nationalArchives.email")</a> if your query is regarding the transfer process, the status of your transfer or to report an error or issue you have encountered. You can also contact us if you have more general queries regarding the suitability of records for transfer, file format or transfer agreement criteria.
-            </p>
+                <h3 class="govuk-heading-s">
+                    Do I need to wait for a notification before I can transfer another consignment?
+                </h3>
+                <p class="govuk-body">No, consignments can be uploaded back to back.</p>
 
-            <h3 class="govuk-heading-s">Who can I contact offline?</h3>
-            <p class="govuk-body">If you need to contact us by post, you can write to us at:</p>
-            <address>
-                <span class="govuk-!-font-weight-bold">Digital Selection and Transfer team c/o</span><br/>
-                <span class="govuk-!-font-weight-bold">Digital Archiving Department</span><br/>
-                <span class="govuk-!-font-weight-bold">The National Archives</span><br/>
-                <span class="govuk-!-font-weight-bold">Bessant Drive</span><br/>
-                <span class="govuk-!-font-weight-bold">Richmond</span><br/>
-                <span class="govuk-!-font-weight-bold">Surrey</span><br/>
-                <span class="govuk-!-font-weight-bold">TW9 4DU</span><br/>
-            </address>
-            <br/>
-            <p class="govuk-body">
-                Describe your query in detail and provide your full contact details for a response. We aim to respond to you within one month. If you have not received a response after one month, contact us again.
-            </p>
-
-            <h3 class="govuk-heading-s">I have not received an email to notify me that my records are in the archive</h3>
-            <p class="govuk-body">
-                We will notify you via email when your records have been transferred, preserved and released to the public. If you would like more information on this process contact <a href="mailto:@Messages("nationalArchives.email")">
+                <h2 id="general" class="govuk-heading-m">General</h2>
+                <h3 class="govuk-heading-s">Who can I contact if I have a query?</h3>
+                <p class="govuk-body">Contact <a href="mailto:@Messages("nationalArchives.email")">
                 @Messages("nationalArchives.email")</a>
-            </p>
+                    if your query is regarding the transfer process, the status of your transfer or to report an error or issue you have encountered. You can also contact us if you have more general queries regarding the suitability of records for transfer, file format or transfer agreement criteria.
+                </p>
 
-            <h3 class="govuk-heading-s">Can I view the progress of my transfers and my consignment history?</h3>
-            <p class="govuk-body">
-                You can view your consignment history and the process of record transfers at any time by visiting the View transfers page. You can access this page via the homepage. On this page you can see the following information:
-            </p>
-            <ul class="govuk-list govuk-list--bullet">
-                <li>Consignment reference.</li>
-                <li>The date the TDR process started.</li>
-                <li>The date the records were transferred.</li>
-                <li>The status of your transfer.</li>
-                <li>Any actions we advise you to take, such as resuming the transfer process.</li>
-            </ul>
+                <h3 class="govuk-heading-s">Who can I contact offline?</h3>
+                <p class="govuk-body">If you need to contact us by post, you can write to us at:</p>
+                <address>
+                    <span class="govuk-!-font-weight-bold">Digital Selection and Transfer team c/o</span><br/>
+                    <span class="govuk-!-font-weight-bold">Digital Archiving Department</span><br/>
+                    <span class="govuk-!-font-weight-bold">The National Archives</span><br/>
+                    <span class="govuk-!-font-weight-bold">Bessant Drive</span><br/>
+                    <span class="govuk-!-font-weight-bold">Richmond</span><br/>
+                    <span class="govuk-!-font-weight-bold">Surrey</span><br/>
+                    <span class="govuk-!-font-weight-bold">TW9 4DU</span><br/>
+                </address>
+                <br/>
+                <p class="govuk-body">
+                    Describe your query in detail and provide your full contact details for a response. We aim to respond to you within one month. If you have not received a response after one month, contact us again.
+                </p>
 
-            <h3 class="govuk-heading-s">When using TDR, how secure are my records?</h3>
-            <p class="govuk-body">
-                Like all of TNA's services, TDR has undergone strict GDS assessments to meet established security and design standards.
-            </p>
+                <h3 class="govuk-heading-s">
+                    I have not received an email to notify me that my records are in the archive</h3>
+                <p class="govuk-body">
+                    We will notify you via email when your records have been transferred, preserved and released to the public. If you would like more information on this process contact <a href="mailto:@Messages("nationalArchives.email")">
+                @Messages("nationalArchives.email")</a>
+                </p>
+
+                <h3 class="govuk-heading-s">Can I view the progress of my transfers and my consignment history?</h3>
+                <p class="govuk-body">
+                    You can view your consignment history and the process of record transfers at any time by visiting the View transfers page. You can access this page via the homepage. On this page you can see the following information:
+                </p>
+                <ul class="govuk-list govuk-list--bullet">
+                    <li>Consignment reference.</li>
+                    <li>The date the TDR process started.</li>
+                    <li>The date the records were transferred.</li>
+                    <li>The status of your transfer.</li>
+                    <li>Any actions we advise you to take, such as resuming the transfer process.</li>
+                </ul>
+
+                <h3 class="govuk-heading-s">When using TDR, how secure are my records?</h3>
+                <p class="govuk-body">
+                    Like all of TNA's services, TDR has undergone strict GDS assessments to meet established security and design standards.
+                </p>
+            </div>
         </div>
-    </div>
+    }
 }

--- a/app/views/forbiddenError.scala.html
+++ b/app/views/forbiddenError.scala.html
@@ -1,12 +1,14 @@
 @(name: String, isLoggedIn: Boolean, isJudgmentUser: Boolean)(implicit messages: Messages, request: RequestHeader)
 
-@main("Page access restricted", name = name, isLoggedIn = isLoggedIn, isJudgmentUser = isJudgmentUser) {
-@defining(play.core.PlayVersion.current) { version =>
-<div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-l">You are not permitted to see this page</h1>
-        <p class="govuk-body">This page is restricted to certain users only.</p>
-    </div>
-</div>
-}
+@defining("You are not permitted to see this page") { title =>
+  @main(title, name = name, isLoggedIn = isLoggedIn, isJudgmentUser = isJudgmentUser) {
+        @defining(play.core.PlayVersion.current) { version =>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-two-thirds">
+                    <h1 class="govuk-heading-l">@title</h1>
+                    <p class="govuk-body">This page is restricted to certain users only.</p>
+                </div>
+            </div>
+        }
+    }
 }

--- a/app/views/help.scala.html
+++ b/app/views/help.scala.html
@@ -1,9 +1,9 @@
 @(isLoggedIn: Boolean, name: String, isJudgmentUser: Boolean)(implicit messages: Messages, request: RequestHeader)
-
-@main("Help", isLoggedIn = isLoggedIn, name = name, isJudgmentUser = isJudgmentUser) {
+@defining("User Help Guide") { title =>
+  @main(title, isLoggedIn = isLoggedIn, name = name, isJudgmentUser = isJudgmentUser) {
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-            <h1 class="govuk-heading-l">User Help Guide</h1>
+            <h1 class="govuk-heading-l">@title</h1>
 
             <h2 class="govuk-heading-m">This user help guide includes:</h2>
             <nav aria-label="List">
@@ -78,7 +78,7 @@
                 At this stage of development, the service is only available to pre-approved users.
                 Over time, TDR will be made available to more Public Record Bodies and will continue to be developed in consultation with our users.
             </p>
-            
+
             <h2 class="govuk-heading-m" id="before-you-begin">Before you begin</h2>
             <p class="govuk-body">
                 Currently we can only accept records that are Crown Copyright, Public Records and from shared drives.
@@ -267,7 +267,7 @@
 
             <h3 class="govuk-heading-s" id="transfer-agreement">Step 2: Transfer agreement</h3>
             <p class="govuk-body">
-                Before you upload records, you must confirm that, to the best of your knowledge, your records meet our criteria. 
+                Before you upload records, you must confirm that, to the best of your knowledge, your records meet our criteria.
             </p>
             <p class="govuk-body">
                 During beta, records must meet the following criteria:
@@ -559,4 +559,5 @@
             </p>
         </div>
     </div>
+}
 }

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -1,27 +1,28 @@
 @(isLoggedIn: Boolean, name: String, isJudgmentUser: Boolean)(implicit messages: Messages, request: RequestHeader)
+@defining("The National Archives Transfer Digital Records") { title =>
+  @main(title, isLoggedIn = isLoggedIn, name = name, isJudgmentUser = isJudgmentUser) {
+    @defining(play.core.PlayVersion.current) { version =>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
 
-@main("Introduction", isLoggedIn = isLoggedIn, name = name, isJudgmentUser = isJudgmentUser) {
-@defining(play.core.PlayVersion.current) { version =>
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+            <!-- Headline -->
+          <h1 class="govuk-heading-l">@title</h1>
 
-    <!-- Headline -->
-    <h1 class="govuk-heading-l">The National Archives Transfer Digital Records</h1>
+          <p class="govuk-body">Use this service to:</p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li>transfer digital records to The National Archives</li>
+            <li>transfer judgments to The National Archives</li>
+          </ul>
 
-    <p class="govuk-body">Use this service to:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>transfer digital records to The National Archives</li>
-      <li>transfer judgments to The National Archives</li>
-    </ul>
+          <a href="@routes.HomepageController.homepage()" role="button" draggable="false" class="govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8" data-module="govuk-button">
+            Start now
+            <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
+              <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
+            </svg>
+          </a>
 
-    <a href="@routes.HomepageController.homepage()" role="button" draggable="false" class="govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8" data-module="govuk-button">
-      Start now
-      <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
-        <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
-      </svg>
-    </a>
-
-  </div>
-</div>
-}
+        </div>
+      </div>
+    }
+  }
 }

--- a/app/views/internalServerError.scala.html
+++ b/app/views/internalServerError.scala.html
@@ -1,12 +1,13 @@
 @(name: String, isLoggedIn: Boolean, isJudgmentUser: Boolean)(implicit messages: Messages, request: RequestHeader)
-
-@main("Service not available", name = name, isLoggedIn = isLoggedIn, isJudgmentUser = isJudgmentUser) {
-@defining(play.core.PlayVersion.current) { version =>
-<div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-l">Sorry, there is a problem with the service</h1>
-        <p class="govuk-body">Please try again later.</p>
-    </div>
-</div>
+@defining("Sorry, there is a problem with the service") { title =>
+  @main(title, name = name, isLoggedIn = isLoggedIn, isJudgmentUser = isJudgmentUser) {
+    @defining(play.core.PlayVersion.current) { version =>
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+                <h1 class="govuk-heading-l">@title</h1>
+                <p class="govuk-body">Please try again later.</p>
+            </div>
+        </div>
+    }
 }
 }

--- a/app/views/judgment/judgmentFaq.scala.html
+++ b/app/views/judgment/judgmentFaq.scala.html
@@ -1,9 +1,9 @@
 @(isLoggedIn: Boolean, name: String)(implicit messages: Messages, request: RequestHeader)
-
-@main("judgmentFAQ", isLoggedIn = isLoggedIn, name = name, isJudgmentUser = true) {
+@defining("Frequently Asked Questions") { title =>
+  @main(title, isLoggedIn = isLoggedIn, name = name, isJudgmentUser = true) {
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-            <h1 class="govuk-heading-l">Frequently Asked Questions</h1>
+            <h1 class="govuk-heading-l">@title</h1>
             <h2 id="getting-started" class="govuk-heading-m">Getting started</h2>
             <h3 class="govuk-heading-s" id="what-is-tdr">What is TDR?</h3>
             <p class="govuk-body">
@@ -260,4 +260,5 @@
         </div>
     </div>
 
+  }
 }

--- a/app/views/judgment/judgmentHelp.scala.html
+++ b/app/views/judgment/judgmentHelp.scala.html
@@ -1,9 +1,9 @@
 @(isLoggedIn: Boolean, name: String)(implicit messages: Messages, request: RequestHeader)
-
-  @main("Help", isLoggedIn = isLoggedIn, name = name, isJudgmentUser = true) {
+@defining("Transferring Judgments to The National Archives") { title =>
+  @main(title, isLoggedIn = isLoggedIn, name = name, isJudgmentUser = true) {
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-l" id="transferring-judgments">Transferring Judgments to The National Archives</h1>
+        <h1 class="govuk-heading-l" id="transferring-judgments">@title</h1>
 
         <h2 class="govuk-heading-m" id="step-by-step-guide">A step-by-step guide to using Transfer Digital Records (TDR)</h2>
         <nav aria-label="List">
@@ -404,3 +404,4 @@
       </div>
     </div>
   }
+}

--- a/app/views/judgment/judgmentHomepage.scala.html
+++ b/app/views/judgment/judgmentHomepage.scala.html
@@ -2,32 +2,33 @@
 @import views.html.helper.form
 @import views.html.partials.viewTransfersBtn
 @(name: String, blockViewTransfers: Boolean)(implicit messages: Messages, request: RequestHeader)
+@defining("Welcome to the Transfer Digital Records service") { title =>
+  @main(title, name = name, isJudgmentUser = true) {
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-l">@title</h1>
 
-@main("Welcome", name = name, isJudgmentUser = true) {
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l">Welcome to the Transfer Digital Records service</h1>
+        <h2 class="govuk-heading-m govuk-!-margin-top-7">Before you start</h2>
 
-      <h2 class="govuk-heading-m govuk-!-margin-top-7">Before you start</h2>
+        <p class="govuk-body">
+          You must upload your judgment as a Microsoft Word (.docx) document. Any other formats will not be accepted.
+        </p>
 
-      <p class="govuk-body">
-        You must upload your judgment as a Microsoft Word (.docx) document. Any other formats will not be accepted.
-      </p>
+        <h2 class="govuk-heading-m govuk-!-margin-top-2">Upload your judgment to start a new transfer</h2>
 
-      <h2 class="govuk-heading-m govuk-!-margin-top-2">Upload your judgment to start a new transfer</h2>
-
-      @form(routes.HomepageController.judgmentHomepageSubmit(), (Symbol("novalidate"), "")) {
-        @CSRF.formField
-        <div class="govuk-button-group">
-          <button data-prevent-double-click="true" class="govuk-button" type="submit" data-module="govuk-button"
-          role="button">
-            Start transfer
-          </button>
-        </div>
-        @if(!blockViewTransfers){
-          @viewTransfersBtn()
+        @form(routes.HomepageController.judgmentHomepageSubmit(), (Symbol("novalidate"), "")) {
+          @CSRF.formField
+          <div class="govuk-button-group">
+            <button data-prevent-double-click="true" class="govuk-button" type="submit" data-module="govuk-button"
+            role="button">
+              Start transfer
+            </button>
+          </div>
+          @if(!blockViewTransfers) {
+            @viewTransfersBtn()
+          }
         }
-      }
+      </div>
     </div>
-  </div>
+  }
 }

--- a/app/views/judgment/judgmentUpload.scala.html
+++ b/app/views/judgment/judgmentUpload.scala.html
@@ -5,7 +5,7 @@
 
 @(consignmentId: UUID, consignmentRef: String, pageHeading1stHalf: String, pageHeading2ndHalf: String, frontEndInfo: FrontEndInfo, name: String)(implicit request: RequestHeader, messages: Messages)
 
-@main("Upload your judgment", name = name, isJudgmentUser = true) {
+@main(pageHeading1stHalf, name = name, isJudgmentUser = true) {
 <noscript>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -12,9 +12,9 @@
 <html lang="en" class="govuk-template">
 <head>
     @if(hasError) {
-      <title>Error: @title</title>
+      <title>Error: @title - Transfer Digital Records - GOV.UK</title>
     } else {
-      <title>@title</title>
+      <title>@title - Transfer Digital Records - GOV.UK</title>
     }
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/app/views/registrationComplete.scala.html
+++ b/app/views/registrationComplete.scala.html
@@ -1,18 +1,21 @@
 @(name: String)(implicit request: RequestHeader, messages: Messages)
-@main("Registration Complete", name = name) {
-@defining(play.core.PlayVersion.current) { version =>
-<div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l">Thank you for completing your registration</h1>
-      <p class="govuk-body govuk-!-margin-bottom-1">You have successfully set up Multi-factor Authentication for Transfer Digital Records.</p>
-      <h2 class="govuk-heading-s">Next Steps</h2>
-      <p class="govuk-body">You will be able to access this service once it becomes live on
-        19 April 2022. If you have any queries or require further assistance,
-        please take a look at our <a href="@routes.FaqController.judgmentFaq()">FAQ</a>
-        or
-        <a href="@routes.HelpController.help()">Help</a> page.
-      </p>
-    </div>
-</div>
-}
+@defining("Thank you for completing your registration") { title =>
+  @main(title, name = name) {
+    @defining(play.core.PlayVersion.current) { version =>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <h1 class="govuk-heading-l">@title</h1>
+          <p class="govuk-body govuk-!-margin-bottom-1">
+            You have successfully set up Multi-factor Authentication for Transfer Digital Records.</p>
+          <h2 class="govuk-heading-s">Next Steps</h2>
+          <p class="govuk-body">You will be able to access this service once it becomes live on
+            19 April 2022. If you have any queries or require further assistance,
+            please take a look at our <a href="@routes.FaqController.judgmentFaq()">FAQ</a>
+            or
+            <a href="@routes.HelpController.help()">Help</a> page.
+          </p>
+        </div>
+      </div>
+    }
+  }
 }

--- a/app/views/signedOut.scala.html
+++ b/app/views/signedOut.scala.html
@@ -1,13 +1,14 @@
 @()(implicit messages: Messages, request: RequestHeader)
-
-@main("Signed out", isLoggedIn = false) {
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l">You have successfully signed out</h1>
-      <p class="govuk-body">Thanks for using the Transfer Digital Records service.</p>
-      <a href="@routes.HomepageController.homepage()" class="govuk-link">
-        Sign in again
-      </a>
+@defining("You have successfully signed out") { title =>
+  @main(title, isLoggedIn = false) {
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-l">@title</h1>
+        <p class="govuk-body">Thanks for using the Transfer Digital Records service.</p>
+        <a href="@routes.HomepageController.homepage()" class="govuk-link">
+          Sign in again
+        </a>
+      </div>
     </div>
-  </div>
+  }
 }

--- a/app/views/standard/addAdditionalMetadata.scala.html
+++ b/app/views/standard/addAdditionalMetadata.scala.html
@@ -7,12 +7,13 @@
 @import java.util.UUID
 @import scala.language.postfixOps
 @(consignmentId: UUID, consignmentRef: String, metadataType: String, fieldsToApplyToFile: List[FormField], name: String, files: List[File])(implicit request: RequestHeader, messages: Messages)
-@main(s"Add or edit $metadataType metadata", name = name) {
+@defining(s"Add or edit $metadataType metadata") { title =>
+  @main(title, name = name) {
   @defining(play.core.PlayVersion.current) { version =>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <span class="govuk-caption-l">@metadataType.capitalize metadata</span>
-        <h1 class="govuk-heading-l">Add or edit metadata</h1>
+        <h1 class="govuk-heading-l">@title</h1>
         @fileNameCard(files.map(_.name), s"You are adding or editing $metadataType metadata for the following file:")
         @errorSummary(
           fieldsToApplyToFile.collect {
@@ -130,4 +131,5 @@
     </div>
 
   }
+}
 }

--- a/app/views/standard/additionalMetadataClosureStatus.scala.html
+++ b/app/views/standard/additionalMetadataClosureStatus.scala.html
@@ -10,15 +10,15 @@
     case Some(formError) => formError.messages
     case None => Nil
 }}
-
-@main(title = "Check closure status", name = name) {
+@defining("Confirm closure status") { title =>
+  @main(title = "Confirm closure status", name = name) {
     @defining(play.core.PlayVersion.current) { version =>
         <span class="govuk-caption-l">@metadataType.capitalize metadata</span>
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
 
                 <h1 class="govuk-heading-l">
-                Confirm closure status
+                @title
                 </h1>
                 @if(areAllFilesClosed) {
                     @warningMessage(Messages(
@@ -87,4 +87,5 @@
             @transferReference(consignmentRef, isJudgmentUser = false)
     </div>
     }
+}
 }

--- a/app/views/standard/additionalMetadataNavigation.scala.html
+++ b/app/views/standard/additionalMetadataNavigation.scala.html
@@ -60,8 +60,8 @@
     <strong class="tdr-tag tdr-tag--@statusTag.get.colour">@statusTag.get.text</strong>
   }
 }
-
-@main("Additional Metadata", name = name, backLink = Some(backLink(routes.AdditionalMetadataController.start(consignmentId).url, "additionalMetadataStart.progress", "Descriptive and closure metadata"))) {
+@defining("Choose a file") { title =>
+  @main(title, name = name, backLink = Some(backLink(routes.AdditionalMetadataController.start(consignmentId).url, "additionalMetadataStart.progress", "Descriptive and closure metadata"))) {
 @*  Only render the noscript if not expanded to prevent a continuous page refresh when no javascript, if hierarchy:
     already expanded then irrelevant if no javascript or not;
     not expanded then expand if no javascript
@@ -75,7 +75,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <span class="govuk-caption-l">@metadataType.capitalize metadata</span>
-        <h1 class="govuk-heading-l">Choose a file</h1>
+        <h1 class="govuk-heading-l">@title</h1>
       </div>
     </div>
     <div class="govuk-grid-row">
@@ -119,4 +119,5 @@
       </div>
     </div>
   }
+}
 }

--- a/app/views/standard/additionalMetadataView.scala.html
+++ b/app/views/standard/additionalMetadataView.scala.html
@@ -12,7 +12,7 @@
     name: String,
     metadataList: List[FileMetadata],
     hasMetadata: Boolean)(implicit messages: Messages, request: RequestHeader)
-@defining(s"View $metadataType metadata") { title =>
+@defining(s"View Metadata") { title =>
   @main(title, name = name) {
     @defining(play.core.PlayVersion.current) { version =>
       <div class="govuk-grid-row">

--- a/app/views/standard/additionalMetadataView.scala.html
+++ b/app/views/standard/additionalMetadataView.scala.html
@@ -12,17 +12,18 @@
     name: String,
     metadataList: List[FileMetadata],
     hasMetadata: Boolean)(implicit messages: Messages, request: RequestHeader)
-@main(title = "View existing metadata", name = name) {
-  @defining(play.core.PlayVersion.current) { version =>
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <span class="govuk-caption-l">@metadataType.capitalize metadata</span>
-        <h1 class="govuk-heading-l"> View @if(metadataType == "descriptive") { existing } metadata </h1>
-        <p class="govuk-body">View existing @metadataType metadata.</p>
+@defining(s"View $metadataType metadata") { title =>
+  @main(title, name = name) {
+    @defining(play.core.PlayVersion.current) { version =>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <span class="govuk-caption-l">@metadataType.capitalize metadata</span>
+          <h1 class="govuk-heading-l">@title</h1>
+          <p class="govuk-body">View existing @metadataType metadata.</p>
 
           @metadata(fileNames, metadataList)
 
-        <div class="govuk-button-group">
+          <div class="govuk-button-group">
           @if(hasMetadata) {
             <a href="@routes.AddAdditionalMetadataController.addAdditionalMetadata(consignmentId, metadataType, fileIds)" role="button" draggable="false" class="govuk-button govuk-!-margin-bottom-4" data-module="govuk-button">
               Edit metadata
@@ -41,16 +42,17 @@
               </a>
             }
           }
-        </div>
+          </div>
 
-        <div class="govuk-button-group">
-          <a href="@routes.AdditionalMetadataNavigationController.getAllFiles(consignmentId, metadataType, expanded = None)" draggable="false" class="govuk-link govuk-link--no-visited-state">
-          Return to all files
-          </a>
+          <div class="govuk-button-group">
+            <a href="@routes.AdditionalMetadataNavigationController.getAllFiles(consignmentId, metadataType, expanded = None)" draggable="false" class="govuk-link govuk-link--no-visited-state">
+              Return to all files
+            </a>
+          </div>
         </div>
+        @transferReference(consignmentRef, isJudgmentUser = false)
+
       </div>
-      @transferReference(consignmentRef, isJudgmentUser = false)
-
-    </div>
+    }
   }
 }

--- a/app/views/standard/homepage.scala.html
+++ b/app/views/standard/homepage.scala.html
@@ -2,26 +2,27 @@
 @import views.html.helper.CSRF
 @import views.html.partials.viewTransfersBtn
 @(name:String, blockViewTransfers: Boolean)(implicit messages: Messages, request: RequestHeader)
+@defining("Welcome to the Transfer Digital Records service") { title =>
+  @main(title, name = name) {
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+                <h1 class="govuk-heading-l">@title</h1>
 
-@main("Welcome", name = name) {
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-            <h1 class="govuk-heading-l">Welcome to the Transfer Digital Records service</h1>
+                <h2 class="govuk-heading-m govuk-!-margin-top-9">Upload your records to start a new transfer</h2>
 
-            <h2 class="govuk-heading-m govuk-!-margin-top-9">Upload your records to start a new transfer</h2>
-
-            @form(routes.HomepageController.homepageSubmit(), (Symbol("novalidate"), "")) {
-                @CSRF.formField
-                <div class="govuk-button-group">
-                    <button data-prevent-double-click="true" class="govuk-button" type="submit" data-module="govuk-button"
-                    role="button">
-                        Start transfer
-                    </button>
-                </div>
-                @if(!blockViewTransfers){
-                    @viewTransfersBtn()
+                @form(routes.HomepageController.homepageSubmit(), (Symbol("novalidate"), "")) {
+                    @CSRF.formField
+                    <div class="govuk-button-group">
+                        <button data-prevent-double-click="true" class="govuk-button" type="submit" data-module="govuk-button"
+                        role="button">
+                            Start transfer
+                        </button>
+                    </div>
+                    @if(!blockViewTransfers) {
+                        @viewTransfersBtn()
+                    }
                 }
-            }
+            </div>
         </div>
-    </div>
+    }
 }

--- a/app/views/standard/seriesDetails.scala.html
+++ b/app/views/standard/seriesDetails.scala.html
@@ -7,56 +7,58 @@
 @import views.html.partials.inputDropdown
 @(consignmentId: UUID, consignmentRef: String, dropdownField: DropdownField, name: String)(implicit request: RequestHeader,
 messages: Messages)
+@defining("Choose a series reference") { title =>
+  @main(title, hasError = dropdownField.fieldErrors.nonEmpty, name = name) {
+        @defining(play.core.PlayVersion.current) { version =>
 
-@main("Series Information", hasError = dropdownField.fieldErrors.nonEmpty, name = name) {
-@defining(play.core.PlayVersion.current) { version =>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-two-thirds">
+                    @progressIndicator(Messages("seriesDetails.progress"))
 
-<div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-        @progressIndicator(Messages("seriesDetails.progress"))
+                <h1 class="govuk-label-wrapper">
+                    <label class="govuk-label govuk-label--l" for="@dropdownField.fieldId">@title</label>
+                </h1>
 
-        <h1 class="govuk-label-wrapper">
-            <label class="govuk-label govuk-label--l" for="@dropdownField.fieldId">Choose a series reference</label>
-        </h1>
-
-        <p class="govuk-body">
-            If you cannot see the correct series reference for the records, you need a new one adding, or you’re transferring records on behalf of another transferring body, contact <a href="mailto:@Messages("nationalArchives.email")">@Messages("nationalArchives.email")</a>.
+                <p class="govuk-body">
+            If you cannot see the correct series reference for the records, you need a new one adding, or you’re transferring records on behalf of another transferring body, contact <a href="mailto:@Messages("nationalArchives.email")">@Messages("nationalArchives.email")</a>
+                    .
         </p>
 
-        @errorSummary(
-            if (dropdownField.fieldErrors.nonEmpty) {
-                List(dropdownField.fieldId -> dropdownField.fieldErrors)
-            } else {
-                Nil
-            }
-        )
+                    @errorSummary(
+                        if(dropdownField.fieldErrors.nonEmpty) {
+                            List(dropdownField.fieldId -> dropdownField.fieldErrors)
+                        } else {
+                            Nil
+                        }
+                    )
 
-        @form(routes.SeriesDetailsController.seriesSubmit(consignmentId), (Symbol("novalidate"), "")) {
-            @CSRF.formField
-            @inputDropdown(
-                dropdownField.fieldId,
-                dropdownField.fieldName,
-                dropdownField.fieldDescription,
-                dropdownField.options,
-                dropdownField.selectedOption,
-                dropdownField.multiValue,
-                Map(
-                    Symbol("_dynamicForm") -> false,
-                ),
-                dropdownField.fieldErrors,
-            )
+                    @form(routes.SeriesDetailsController.seriesSubmit(consignmentId), (Symbol("novalidate"), "")) {
+                        @CSRF.formField
+                        @inputDropdown(
+                            dropdownField.fieldId,
+                            dropdownField.fieldName,
+                            dropdownField.fieldDescription,
+                            dropdownField.options,
+                            dropdownField.selectedOption,
+                            dropdownField.multiValue,
+                            Map(
+                                Symbol("_dynamicForm") -> false,
+                            ),
+                            dropdownField.fieldErrors,
+                        )
 
-        <div class="govuk-button-group">
-            <button data-prevent-double-click="true" class="govuk-button" type="submit" data-module="govuk-button"
-                role="button">
-                Continue
-            </button>
+                        <div class="govuk-button-group">
+                            <button data-prevent-double-click="true" class="govuk-button" type="submit" data-module="govuk-button"
+                            role="button">
+                                Continue
+                            </button>
 
-                <a class="govuk-link" href="@routes.HomepageController.homepage()">Cancel</a>
+                            <a class="govuk-link" href="@routes.HomepageController.homepage()">Cancel</a>
+                        </div>
+                    }
+                </div>
+                @transferReference(consignmentRef, isJudgmentUser = false)
             </div>
-            }
-        </div>
-        @transferReference(consignmentRef, isJudgmentUser = false)
-    </div>
-}
+        }
+    }
 }

--- a/app/views/standard/seriesDetailsAlreadyConfirmed.scala.html
+++ b/app/views/standard/seriesDetailsAlreadyConfirmed.scala.html
@@ -6,14 +6,15 @@
 @(consignmentId: UUID, consignmentRef: String, dropdownField: DropdownField, name: String)(implicit request: RequestHeader,
 messages: Messages)
 @disabledStatus = {disabled}
-@main("Series Information", name = name) {
+@defining("Choose a series") { title =>
+  @main(title, name = name) {
 @defining(play.core.PlayVersion.current) { version =>
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
         @progressIndicator(Messages("seriesDetails.progress"))
 
-        <h1 class="govuk-heading-l">Choose a series</h1>
+        <h1 class="govuk-heading-l">@title</h1>
         <div id="upload-progress-success" class="success-summary" aria-labelledby="success-summary-title"
         role="alert" data-module="success-summary" tabindex="-1">
             <div class="success-summary__body">
@@ -46,4 +47,5 @@ messages: Messages)
     </div>
     @transferReference(consignmentRef, isJudgmentUser = false)
 </div>
+}
 }

--- a/app/views/transferAlreadyCompleted.scala.html
+++ b/app/views/transferAlreadyCompleted.scala.html
@@ -4,30 +4,35 @@
 @import views.html.partials.transferReference
 @import views.html.partials.progressIndicator
 @(consignmentId: UUID, consignmentRef: String, name: String, isJudgmentUser: Boolean=false)(implicit request: RequestHeader, messages: Messages)
-
-@main("Transfer Already Completed", name = name, isJudgmentUser = isJudgmentUser) {
+@defining("Your transfer has already been completed") { title =>
+  @main(title, name = name, isJudgmentUser = isJudgmentUser) {
     @defining(play.core.PlayVersion.current) { version =>
-        <div class="govuk-grid-row">
-            <div class="govuk-grid-column-two-thirds">
-                @if(isJudgmentUser) {
-                    @progressIndicator(Messages("judgmentFileChecksResults.progress"), isJudgmentUser)
-                } else {
-                    @progressIndicator(Messages("confirmTransfer.progress"), isJudgmentUser)
-                }
-                <h1 class="govuk-heading-l">Your transfer has already been completed</h1>
-                <p class="govuk-body">Click 'Continue' to see the confirmation page again or return to the start.</p>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          @if(isJudgmentUser) {
+            @progressIndicator(Messages("judgmentFileChecksResults.progress"), isJudgmentUser)
+          } else {
+            @progressIndicator(Messages("confirmTransfer.progress"), isJudgmentUser)
+          }
+        <h1 class="govuk-heading-l">@title</h1>
+        <p class="govuk-body">Click 'Continue' to see the confirmation page again or return to the start.</p>
 
-                <div>
-                    <a role="button" data-prevent-double-click="true" class="govuk-button" data-module="govuk-button"
-                        href="@{
-                          if(isJudgmentUser) {routes.TransferCompleteController.judgmentTransferComplete(consignmentId)}
-                          else {routes.TransferCompleteController.transferComplete(consignmentId)}
-                        }">Continue
-                    </a>
-                    @returnToHomepage("govuk-button--secondary")
-                </div>
-            </div>
-            @transferReference(consignmentRef, isJudgmentUser)
+        <div>
+          <a role="button" data-prevent-double-click="true" class="govuk-button" data-module="govuk-button"
+          href="@{
+            if(isJudgmentUser) {
+              routes.TransferCompleteController.judgmentTransferComplete(consignmentId)
+            }
+            else {
+              routes.TransferCompleteController.transferComplete(consignmentId)
+            }
+          }">Continue
+          </a>
+          @returnToHomepage("govuk-button--secondary")
         </div>
+        </div>
+        @transferReference(consignmentRef, isJudgmentUser)
+      </div>
     }
+  }
 }

--- a/app/views/unauthenticatedError.scala.html
+++ b/app/views/unauthenticatedError.scala.html
@@ -1,12 +1,13 @@
 @(name: String, isLoggedIn: Boolean, isJudgmentUser: Boolean)(implicit messages: Messages, request: RequestHeader)
-
-@main("Sign-in required", name = name, isLoggedIn = isLoggedIn, isJudgmentUser = isJudgmentUser) {
-@defining(play.core.PlayVersion.current) { version =>
-<div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-l">You must be signed in to see this page</h1>
-        <p class="govuk-body"><a class="govuk-link" href="#">Sign in</a> to continue.</p>
-    </div>
-</div>
-}
+@defining("You must be signed in to see this page") { title =>
+  @main(title, name = name, isLoggedIn = isLoggedIn, isJudgmentUser = isJudgmentUser) {
+    @defining(play.core.PlayVersion.current) { version =>
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+                <h1 class="govuk-heading-l">@title</h1>
+                <p class="govuk-body"><a class="govuk-link" href="#">Sign in</a> to continue.</p>
+            </div>
+        </div>
+    }
+  }
 }

--- a/app/views/uploadHasCompleted.scala.html
+++ b/app/views/uploadHasCompleted.scala.html
@@ -2,7 +2,7 @@
 @import views.html.partials.{progressIndicator, transferReference}
 @(consignmentId: UUID, consignmentRef: String, pageHeading: String, name: String, isJudgmentUser: Boolean)(implicit request: RequestHeader, messages: Messages)
 
-@main("Your records have been uploaded", name = name, isJudgmentUser = isJudgmentUser) {
+@main(pageHeading, name = name, isJudgmentUser = isJudgmentUser) {
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
         @if(isJudgmentUser) {

--- a/app/views/uploadInProgress.scala.html
+++ b/app/views/uploadInProgress.scala.html
@@ -2,7 +2,7 @@
 @import views.html.partials.{progressIndicator, transferReference}
 @(consignmentId: UUID, consignmentRef: String, pageHeading: String, name: String, isJudgmentUser: Boolean)(implicit request: RequestHeader, messages: Messages)
 
-  @main("Upload your records", name = name, isJudgmentUser = isJudgmentUser) {
+  @main(pageHeading, name = name, isJudgmentUser = isJudgmentUser) {
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
           @if(isJudgmentUser) {

--- a/test/controllers/AdditionalMetadataSummaryControllerSpec.scala
+++ b/test/controllers/AdditionalMetadataSummaryControllerSpec.scala
@@ -372,7 +372,7 @@ class AdditionalMetadataSummaryControllerSpec extends FrontEndTestHelper {
 
   def verifyViewPage(page: String, consignmentId: String, metadataType: String, metadataFields: List[(String, String)], hasMetadata: Boolean = false): Unit = {
     page must include(s"""<span class="govuk-caption-l">${metadataType.capitalize} metadata</span>""")
-    page must include(s"""<h1 class="govuk-heading-l">View $metadataType metadata</h1>""")
+    page must include(s"""<h1 class="govuk-heading-l">View Metadata</h1>""")
     page must include(s"""<p class="govuk-body">View existing $metadataType metadata.</p>""")
 
     if (hasMetadata) {

--- a/test/controllers/AdditionalMetadataSummaryControllerSpec.scala
+++ b/test/controllers/AdditionalMetadataSummaryControllerSpec.scala
@@ -372,11 +372,7 @@ class AdditionalMetadataSummaryControllerSpec extends FrontEndTestHelper {
 
   def verifyViewPage(page: String, consignmentId: String, metadataType: String, metadataFields: List[(String, String)], hasMetadata: Boolean = false): Unit = {
     page must include(s"""<span class="govuk-caption-l">${metadataType.capitalize} metadata</span>""")
-    if (metadataType == "descriptive") {
-      page must include(s"""<h1 class="govuk-heading-l"> View  existing  metadata </h1>""")
-    } else {
-      page must include(s"""<h1 class="govuk-heading-l"> View  metadata </h1>""")
-    }
+    page must include(s"""<h1 class="govuk-heading-l">View $metadataType metadata</h1>""")
     page must include(s"""<p class="govuk-body">View existing $metadataType metadata.</p>""")
 
     if (hasMetadata) {
@@ -435,11 +431,7 @@ class AdditionalMetadataSummaryControllerSpec extends FrontEndTestHelper {
         |      </dd>""".stripMargin
     )
     page must include(
-      s"""        <div class="govuk-button-group">
-         |          <a href="/consignment/$consignmentId/additional-metadata/files/$metadataType" draggable="false" class="govuk-link govuk-link--no-visited-state">
-         |          Return to all files
-         |          </a>
-         |        </div>""".stripMargin
+      s"""<a href="/consignment/$consignmentId/additional-metadata/files/$metadataType" draggable="false" class="govuk-link govuk-link--no-visited-state">""".stripMargin
     )
   }
 }

--- a/test/controllers/ConfirmTransferControllerSpec.scala
+++ b/test/controllers/ConfirmTransferControllerSpec.scala
@@ -85,7 +85,7 @@ class ConfirmTransferControllerSpec extends FrontEndTestHelper {
 
       playStatus(confirmTransferPage) mustBe OK
       contentType(confirmTransferPage) mustBe Some("text/html")
-      confirmTransferPageAsString must include("<title>Confirm transfer</title>")
+      confirmTransferPageAsString must include("<title>Confirm transfer - Transfer Digital Records - GOV.UK</title>")
       confirmTransferPageAsString must include("""<h1 class="govuk-heading-l">Confirm transfer</h1>""")
 
       confirmTransferPageAsString must include(
@@ -760,10 +760,9 @@ class ConfirmTransferControllerSpec extends FrontEndTestHelper {
   }
 
   private def checkForCommonElementsOnConfirmationPage(transferAlreadyConfirmedPageAsString: String, transferType: String = "consignment") = {
-    transferAlreadyConfirmedPageAsString must include(
-      """                <h1 class="govuk-heading-l">Your transfer has already been completed</h1>
-        |                <p class="govuk-body">Click 'Continue' to see the confirmation page again or return to the start.</p>""".stripMargin
-    )
+    transferAlreadyConfirmedPageAsString must include("""<h1 class="govuk-heading-l">Your transfer has already been completed</h1>""")
+    transferAlreadyConfirmedPageAsString must include("""<p class="govuk-body">Click 'Continue' to see the confirmation page again or return to the start.</p>""")
+
     transferAlreadyConfirmedPageAsString must include(
       s"""href="/$transferType/$consignmentId/transfer-complete">Continue""".stripMargin
     )

--- a/test/controllers/ContactControllerSpec.scala
+++ b/test/controllers/ContactControllerSpec.scala
@@ -35,11 +35,9 @@ class ContactControllerSpec extends FrontEndTestHelper {
   }
 
   private def checkForContentOnContactPage(pageAsString: String, signedIn: Boolean = true): Unit = {
-    pageAsString must include("<title>Contact</title>")
+    pageAsString must include("<title>Get in touch - Transfer Digital Records - GOV.UK</title>")
     pageAsString must include("""<h1 class="govuk-heading-l">Get in touch</h1>""")
-    pageAsString must include(
-      """<p class="govuk-body">If you have got feedback, ideas or questions get in touch with the Transfer Digital Records team</p>"""
-    )
+    pageAsString must include("If you have got feedback, ideas or questions")
     pageAsString must include("""<h1 class="govuk-heading-l">Email</h1>""")
     pageAsString must include(
       """<p class="govuk-body"><a class="govuk-link" href="mailto:nationalArchives.email" data-hsupport="email">nationalArchives.email</a></p>"""

--- a/test/controllers/CookiesControllerSpec.scala
+++ b/test/controllers/CookiesControllerSpec.scala
@@ -35,7 +35,7 @@ class CookiesControllerSpec extends FrontEndTestHelper {
   }
 
   private def checkForContentOnCookiesPage(pageAsString: String, signedIn: Boolean = true): Unit = {
-    pageAsString must include("<title>Cookies</title>")
+    pageAsString must include("<title>Cookies - Transfer Digital Records - GOV.UK</title>")
     pageAsString must include("""<h1 class="govuk-heading-l">Cookies</h1>""")
   }
 }

--- a/test/controllers/DeleteAdditionalMetadataControllerSpec.scala
+++ b/test/controllers/DeleteAdditionalMetadataControllerSpec.scala
@@ -555,7 +555,7 @@ class DeleteAdditionalMetadataControllerSpec extends FrontEndTestHelper {
   }
 
   private def checkConfirmDeleteMetadataPage(pageString: String, consignmentId: UUID, metadataType: String, hasEnteredMetadata: Boolean = true): Unit = {
-    pageString must include(s"<title>Delete $metadataType metadata</title>")
+    pageString must include(s"<title>Delete $metadataType metadata - Transfer Digital Records - GOV.UK</title>")
     pageString must include(
       s"""              <h1 class="govuk-heading-xl">
                             Delete $metadataType metadata

--- a/test/controllers/FaqControllerSpec.scala
+++ b/test/controllers/FaqControllerSpec.scala
@@ -67,12 +67,6 @@ class FaqControllerSpec extends FrontEndTestHelper {
     pageAsString must include("""<h2 id="accessing-tdr-account" class="govuk-heading-m">Accessing my TDR account</h2>""")
     pageAsString must include("""<h2 id="upload-process" class="govuk-heading-m">The upload process</h2>""")
     pageAsString must include("""<h2 id="general" class="govuk-heading-m">General</h2>""")
-
-    if (userType == "standard") {
-      pageAsString must include("<title>FAQ</title>")
-    } else {
-      pageAsString must include("<title>judgmentFAQ</title>")
-
-    }
+    pageAsString must include("<title>Frequently Asked Questions - Transfer Digital Records - GOV.UK</title>")
   }
 }

--- a/test/controllers/FileChecksControllerSpec.scala
+++ b/test/controllers/FileChecksControllerSpec.scala
@@ -51,7 +51,7 @@ class FileChecksControllerSpec extends FrontEndTestHelper with TableDrivenProper
         (
           "judgment",
           getValidJudgmentUserKeycloakConfiguration,
-          "<title>Checking your upload</title>",
+          "<title>Checking your upload - Transfer Digital Records - GOV.UK</title>",
           """<h1 class="govuk-heading-l">Checking your upload""",
           """            <p class="govuk-body">Your judgment is being checked for errors.
             |              This may take a few minutes. Once your judgment has been checked, you will be redirected automatically.
@@ -63,7 +63,7 @@ class FileChecksControllerSpec extends FrontEndTestHelper with TableDrivenProper
         (
           "consignment",
           getValidStandardUserKeycloakConfiguration,
-          "<title>Checking your records</title>",
+          "<title>Checking your records - Transfer Digital Records - GOV.UK</title>",
           """<h1 class="govuk-heading-l">Checking your records</h1>""",
           """            <p class="govuk-body">Please wait while your records are being checked. This may take a few minutes.</p>
             |            <p class="govuk-body">The following checks are now being performed:</p>

--- a/test/controllers/FileChecksResultsControllerSpec.scala
+++ b/test/controllers/FileChecksResultsControllerSpec.scala
@@ -87,7 +87,7 @@ class FileChecksResultsControllerSpec extends FrontEndTestHelper {
         (
           "judgment",
           getValidJudgmentUserKeycloakConfiguration,
-          "<title>Results of checks</title>",
+          "<title>Results of checks - Transfer Digital Records - GOV.UK</title>",
           """<h1 class="govuk-heading-l">Results of checks</h1>""",
           s"""                    <p class="govuk-body">Your uploaded file 'test file.docx' has now been validated.</p>
           |                    <p class="govuk-body">Click 'Continue' to transfer it to The National Archives.</p>""".stripMargin,
@@ -107,7 +107,7 @@ class FileChecksResultsControllerSpec extends FrontEndTestHelper {
         (
           "consignment",
           getValidStandardUserKeycloakConfiguration,
-          "<title>Results of your checks</title>",
+          "<title>Results of your checks - Transfer Digital Records - GOV.UK</title>",
           """<h1 class="govuk-heading-l">Results of your checks</h1>""",
           """                    <h3 class="govuk-notification-banner__heading">
             |                        Your folder 'parentFolder' containing 1 record has been uploaded and checked.
@@ -554,16 +554,10 @@ class FileChecksResultsControllerSpec extends FrontEndTestHelper {
       headers(transferAlreadyCompletedPage) mustBe TreeMap("Cache-Control" -> "no-store, must-revalidate")
 
       checkPageForStaticElements.checkContentOfPagesThatUseMainScala(transferAlreadyCompletedPageAsString, userType = userType)
-      transferAlreadyCompletedPageAsString must include("<title>Transfer Already Completed</title>")
-      transferAlreadyCompletedPageAsString must include(
-        """                <h1 class="govuk-heading-l">Your transfer has already been completed</h1>
-        |                <p class="govuk-body">Click 'Continue' to see the confirmation page again or return to the start.</p>""".stripMargin
-      )
-      transferAlreadyCompletedPageAsString must include(
-        s"""                    <a role="button" data-prevent-double-click="true" class="govuk-button" data-module="govuk-button"
-           |                        href="/$userType/$consignmentId/transfer-complete">Continue
-           |                    </a>""".stripMargin
-      )
+      transferAlreadyCompletedPageAsString must include("<title>Your transfer has already been completed - Transfer Digital Records - GOV.UK</title>")
+      transferAlreadyCompletedPageAsString must include("""<h1 class="govuk-heading-l">Your transfer has already been completed</h1>""")
+      transferAlreadyCompletedPageAsString must include("""<p class="govuk-body">Click 'Continue' to see the confirmation page again or return to the start.</p>""")
+      transferAlreadyCompletedPageAsString must include(s"""href="/$userType/$consignmentId/transfer-complete">Continue""")
     }
   }
 

--- a/test/controllers/HelpControllerSpec.scala
+++ b/test/controllers/HelpControllerSpec.scala
@@ -63,12 +63,13 @@ class HelpControllerSpec extends FrontEndTestHelper {
   }
 
   private def checkForContentOnHelpPage(pageAsString: String, userType: String = "standard", signedIn: Boolean = true): Unit = {
-    pageAsString must include("<title>Help</title>")
 
     if (userType == "standard") {
+      pageAsString must include("<title>User Help Guide - Transfer Digital Records - GOV.UK</title>")
       pageAsString must include("""<h1 class="govuk-heading-l">User Help Guide</h1>""")
       pageAsString must include("""<h2 class="govuk-heading-m">This user help guide includes:</h2>""")
     } else {
+      pageAsString must include("<title>Transferring Judgments to The National Archives - Transfer Digital Records - GOV.UK</title>")
       pageAsString must include(
         """<h1 class="govuk-heading-l" id="transferring-judgments">Transferring Judgments to The National Archives</h1>"""
       )

--- a/test/controllers/HomeControllerSpec.scala
+++ b/test/controllers/HomeControllerSpec.scala
@@ -49,7 +49,7 @@ class HomeControllerSpec extends FrontEndTestHelper {
   }
 
   private def checkForContentOnHomePage(pageAsString: String, signedIn: Boolean = true): Unit = {
-    pageAsString must include("<title>Introduction</title>")
+    pageAsString must include("<title>The National Archives Transfer Digital Records - Transfer Digital Records - GOV.UK</title>")
     pageAsString must include("This is a new service – your feedback will help us to improve it. Please")
     pageAsString must include("href=\"/contact\">get in touch (opens in new tab).</a>")
     pageAsString must include("The National Archives Transfer Digital Records")

--- a/test/controllers/HomepageControllerSpec.scala
+++ b/test/controllers/HomepageControllerSpec.scala
@@ -58,7 +58,6 @@ class HomepageControllerSpec extends FrontEndTestHelper {
 
       status(homepagePage) mustBe OK
       contentType(homepagePage) mustBe Some("text/html")
-      homepagePageAsString must include("Registration Complete")
       homepagePageAsString must include("Thank you for completing your registration")
       homepagePageAsString must include("Next Steps")
       checkPageForStaticElements.checkContentOfPagesThatUseMainScala(homepagePageAsString, userType = "", consignmentExists = false)
@@ -230,8 +229,8 @@ class HomepageControllerSpec extends FrontEndTestHelper {
   }
 
   private def checkForContentOnHomepagePage(pageAsString: String, userType: String = "standard"): Unit = {
-    pageAsString must include("<title>Welcome</title>")
     pageAsString must include("Welcome to the Transfer Digital Records service")
+    pageAsString must include("<title>Welcome to the Transfer Digital Records service - Transfer Digital Records - GOV.UK</title>")
     pageAsString must include("Start transfer")
     if (userType == "judgment") {
       pageAsString must include("""<form action="/judgment/homepage" method="POST" novalidate="">""")

--- a/test/controllers/SeriesDetailsControllerSpec.scala
+++ b/test/controllers/SeriesDetailsControllerSpec.scala
@@ -73,16 +73,13 @@ class SeriesDetailsControllerSpec extends FrontEndTestHelper {
 
       playStatus(seriesDetailsPage) mustBe OK
       contentType(seriesDetailsPage) mustBe Some("text/html")
-      seriesDetailsPageAsString must include("<title>Series Information</title>")
+      seriesDetailsPageAsString must include("<title>Choose a series reference - Transfer Digital Records - GOV.UK</title>")
       checkForExpectedSeriesPageContent(seriesDetailsPageAsString)
 
       checkPageForStaticElements.checkContentOfPagesThatUseMainScala(seriesDetailsPageAsString, userType = "standard")
 
       seriesDetailsPageAsString should include("""<select class="govuk-select" id="series" name="series"  >""")
       seriesDetailsPageAsString should include(s"""<option value="${seriesId.toString}">MOCK1</option>""")
-      seriesDetailsPageAsString must include("""<h1 class="govuk-label-wrapper">
-                                               |            <label class="govuk-label govuk-label--l" for="series">Choose a series reference</label>
-                                               |        </h1>""".stripMargin)
       wiremockServer.verify(postRequestedFor(urlEqualTo("/graphql")))
     }
 
@@ -192,7 +189,7 @@ class SeriesDetailsControllerSpec extends FrontEndTestHelper {
       val seriesSubmitAsString = contentAsString(seriesSubmit)
 
       contentType(seriesSubmit) mustBe Some("text/html")
-      contentAsString(seriesSubmit) must include("<title>Error: Series Information</title>")
+      contentAsString(seriesSubmit) must include("<title>Error: Choose a series reference - Transfer Digital Records - GOV.UK</title>")
       seriesSubmitAsString must include("class=\"govuk-visually-hidden\">Error:")
       checkForExpectedSeriesPageContent(seriesSubmitAsString)
       checkPageForStaticElements.checkContentOfPagesThatUseMainScala(seriesSubmitAsString, userType = "standard")

--- a/test/controllers/SignOutControllerSpec.scala
+++ b/test/controllers/SignOutControllerSpec.scala
@@ -17,15 +17,11 @@ class SignOutControllerSpec extends FrontEndTestHelper {
       contentType(signOutPage) mustBe Some("text/html")
 
       checkPageForStaticElements.checkContentOfPagesThatUseMainScala(signOutPageAsString, signedIn = false, userType = "")
-      signOutPageAsString must include("<title>Signed out</title>")
+      signOutPageAsString must include("<title>You have successfully signed out - Transfer Digital Records - GOV.UK</title>")
       signOutPageAsString must include("""<h1 class="govuk-heading-l">You have successfully signed out</h1>""")
       signOutPageAsString must include("""<p class="govuk-body">Thanks for using the Transfer Digital Records service.</p>""")
 
-      contentAsString(signOutPage) must include(
-        """      <a href="/homepage" class="govuk-link">
-        |        Sign in again
-        |      </a>""".stripMargin
-      )
+      contentAsString(signOutPage) must include("""<a href="/homepage" class="govuk-link">""".stripMargin)
     }
   }
 }

--- a/test/controllers/TransferAgreementPart1ControllerSpec.scala
+++ b/test/controllers/TransferAgreementPart1ControllerSpec.scala
@@ -494,7 +494,7 @@ class TransferAgreementPart1ControllerSpec extends FrontEndTestHelper with Table
   }
 
   private def checkForExpectedTAPart1PageContent(pageAsString: String, taAlreadyConfirmed: Boolean = true, expectedWarning: String): Unit = {
-    pageAsString must include("<title>Transfer agreement (part 1)</title>")
+    pageAsString must include("<title>Transfer agreement (part 1) - Transfer Digital Records - GOV.UK</title>")
     pageAsString must include("""<h1 class="govuk-heading-l">Transfer agreement (part 1)</h1>""")
     pageAsString must include(
       s"""|    <strong class="govuk-warning-text__text">

--- a/test/controllers/TransferAgreementPart2ControllerSpec.scala
+++ b/test/controllers/TransferAgreementPart2ControllerSpec.scala
@@ -486,7 +486,7 @@ class TransferAgreementPart2ControllerSpec extends FrontEndTestHelper {
   }
 
   private def checkForExpectedTAPart2PageContent(pageAsString: String, taAlreadyConfirmed: Boolean = true): Unit = {
-    pageAsString must include("<title>Transfer agreement (part 2)</title>")
+    pageAsString must include("<title>Transfer agreement (part 2) - Transfer Digital Records - GOV.UK</title>")
     pageAsString must include("""<h1 class="govuk-heading-l">Transfer agreement (part 2)</h1>""")
     if (taAlreadyConfirmed) {
       pageAsString must include(

--- a/test/controllers/TransferCompleteControllerSpec.scala
+++ b/test/controllers/TransferCompleteControllerSpec.scala
@@ -168,7 +168,7 @@ class TransferCompleteControllerSpec extends FrontEndTestHelper {
   }
 
   private def checkTransferCompletePageForCommonElements(transferCompletePageAsString: String, survey: String = "tdr-feedback") = {
-    transferCompletePageAsString must include("<title>Transfer complete</title>")
+    transferCompletePageAsString must include("<title>Transfer complete - Transfer Digital Records - GOV.UK</title>")
     transferCompletePageAsString must include(
       """                        <h1 class="govuk-panel__title">
         |                            Transfer complete

--- a/test/controllers/UploadControllerSpec.scala
+++ b/test/controllers/UploadControllerSpec.scala
@@ -176,7 +176,7 @@ class UploadControllerSpec extends FrontEndTestHelper {
 
       checkPageForStaticElements.checkContentOfPagesThatUseMainScala(uploadPageAsString, userType = "standard", pageRequiresAwsServices = true)
       checkForExpectedPageContentOnMainUploadPage(uploadPageAsString)
-      uploadPageAsString must include("<title>Upload your records</title>")
+      uploadPageAsString must include("<title>Upload your records - Transfer Digital Records - GOV.UK</title>")
       uploadPageAsString must include("""<h1 class="govuk-heading-l">Upload your records</h1>""")
       uploadPageAsString must include(
         """<p class="govuk-body">Before uploading, all records (files and folders) you wish to transfer must be put into a single, top-level folder.</p>"""
@@ -345,7 +345,7 @@ class UploadControllerSpec extends FrontEndTestHelper {
 
       checkPageForStaticElements.checkContentOfPagesThatUseMainScala(uploadPageAsString, userType = "judgment", pageRequiresAwsServices = true)
       checkForExpectedPageContentOnMainUploadPage(uploadPageAsString)
-      uploadPageAsString must include("<title>Upload your judgment</title>")
+      uploadPageAsString must include("<title>Upload judgment - Transfer Digital Records - GOV.UK</title>")
       uploadPageAsString must include("""<h1 class="govuk-heading-l">Upload judgment</h1>""")
       uploadPageAsString must include("You may now upload the judgment you wish to transfer. You can only upload one file.")
       uploadPageAsString must include("We only accept Microsoft Word files (.docx).")

--- a/test/testUtils/CheckFormPageElements.scala
+++ b/test/testUtils/CheckFormPageElements.scala
@@ -6,9 +6,9 @@ class CheckFormPageElements() {
   val twoOrMoreSpaces = "\\s{2,}"
 
   private val expectedClosureFormHtmlElements = Set(
-    """      <title>Add or edit closure metadata</title>""",
+    """      <title>Add or edit closure metadata - Transfer Digital Records - GOV.UK</title>""",
     """      <span class="govuk-caption-l">Closure metadata</span>""",
-    """      <h1 class="govuk-heading-l">Add or edit metadata</h1>""",
+    """      <h1 class="govuk-heading-l">Add or edit closure metadata</h1>""",
     """            <h2 class="govuk-fieldset__heading">
       |                FOI decision asserted
       |            </h2>""",
@@ -49,9 +49,9 @@ class CheckFormPageElements() {
   )
 
   private val expectedDescriptiveFormHtmlElements = Set(
-    """      <title>Add or edit descriptive metadata</title>""",
+    """      <title>Add or edit descriptive metadata - Transfer Digital Records - GOV.UK</title>""",
     """      <span class="govuk-caption-l">Descriptive metadata</span>""",
-    """      <h1 class="govuk-heading-l">Add or edit metadata</h1>""",
+    """      <h1 class="govuk-heading-l">Add or edit descriptive metadata</h1>""",
     """      <h2 class="govuk-fieldset__heading">Date of the record</h2>""",
     """      <div id="date-input-end_date-hint" class="govuk-hint">The date the most recent change was made to the record</div>""",
     """        <label class="govuk-label govuk-label--m" for=inputtextarea-description>


### PR DESCRIPTION
The accessibility audit has recommended that we change each of the page
titles to match the h1 of the page they're on.

I've updated each of these and added the - Transfer Digital Records - GOV.Uk
suffix they've recommended as well.

I've added a `defining` block to define the title and used this for both
the title and the h1 text so it'll be difficult to get them out of sync
accidentally.

There's a huge amount of whitespace changes because the `defining` block
needs everything else shifted forward. If you ignore whitespaces on the
PR, that might help.

On the subject of whitespace, some of the tests failed because of
whitespace changes. I've simplified/deleted these checks because I'm fed
up of trying to change whitespace in the tests.
