### PR TITLE
Update choose file page title.

### DIFF
--- a/app/views/standard/additionalMetadataNavigation.scala.html
+++ b/app/views/standard/additionalMetadataNavigation.scala.html
@@ -61,7 +61,7 @@
   }
 }
 @defining("Choose a file") { title =>
-  @main(title, name = name, backLink = Some(backLink(routes.AdditionalMetadataController.start(consignmentId).url, "additionalMetadataStart.progress", "Descriptive and closure metadata"))) {
+  @main(s"${metadataType.capitalize} metadata - choose a file", name = name, backLink = Some(backLink(routes.AdditionalMetadataController.start(consignmentId).url, "additionalMetadataStart.progress", "Descriptive and closure metadata"))) {
 @*  Only render the noscript if not expanded to prevent a continuous page refresh when no javascript, if hierarchy:
     already expanded then irrelevant if no javascript or not;
     not expanded then expand if no javascript


### PR DESCRIPTION
This was changed so that the title matched the `<h1>` but the h1 is “Choose a file” for both pages so we’ve got the same problem.

I’ve checked with Gareth. He wants to keep the heading the same and change the title. I’ve udated the title to Descriptive metadata choose a file and Closure metadata choose a file
