### PR TITLE
TDR3151 add details component to file navigation page

### DIFF
--- a/app/views/standard/additionalMetadataNavigation.scala.html
+++ b/app/views/standard/additionalMetadataNavigation.scala.html
@@ -88,12 +88,20 @@
       <div class="govuk-grid-column-full">
         <form method="post" action="@routes.AdditionalMetadataNavigationController.submitFiles(consignmentId, metadataType)">
           @CSRF.formField
+          <details class="govuk-details" data-module="govuk-details">
+            <summary class="govuk-details__summary">
+              <span class="govuk-details__summary-text">
+                Using the keyboard to choose a file
+              </span>
+            </summary>
+            <div class="govuk-details__text" id="tree-view-description">
+              The arrow keys can be used to navigate and select a file. Right arrow to open and left arrow to close a folder. Up and down arrows to move between files and folders. Space or enter to select a file or open and close a folder.
+            </div>
+          </details>
           <div class="tna-tree" id="file-selection">
-            <fieldset class="govuk-fieldset">
-              <ul tabindex="0" class="tna-tree__root-list" id="radio-tree" role="tree">
-                @display(files, 1, files.children.length, 1)
-              </ul>
-            </fieldset>
+            <ul aria-labelledby="tree-view-label" aria-describedby="tree-view-description" class="tna-tree__root-list" id="radio-tree" role="tree">
+              @display(files, 1, files.children.length, 1)
+            </ul>
           </div>
           <div aria-atomic="true" aria-live="assertive" class="govuk-inset-text">File selected: <span class="govuk-!-font-weight-bold" id="radio-tree-selected">No file selected</span></div>
           <div class="govuk-button-group">

--- a/test/controllers/AdditionalMetadataNavigationControllerSpec.scala
+++ b/test/controllers/AdditionalMetadataNavigationControllerSpec.scala
@@ -70,6 +70,17 @@ class AdditionalMetadataNavigationControllerSpec extends FrontEndTestHelper {
           content must include(s"${metadataType.capitalize} metadata")
           content must include("""<h1 class="govuk-heading-l">Choose a file</h1>""")
           content must include(s"Select the file you wish to add or edit $metadataType metadata.")
+          content must include(
+            s"""<details class="govuk-details" data-module="govuk-details">
+               |            <summary class="govuk-details__summary">
+               |              <span class="govuk-details__summary-text">
+               |                Using the keyboard to choose a file
+               |              </span>
+               |            </summary>
+               |            <div class="govuk-details__text" id="tree-view-description">
+               |              The arrow keys can be used to navigate and select a file. Right arrow to open and left arrow to close a folder. Up and down arrows to move between files and folders. Space or enter to select a file or open and close a folder.
+               |            </div>
+               |          </details>""".stripMargin)
           content must not include ("Select a file to proceed")
           content must include(
             s"""<a href="/consignment/$consignmentId/additional-metadata" class="govuk-back-link">Step additionalMetadataStart.progress: Descriptive and closure metadata</a>"""

--- a/test/controllers/AdditionalMetadataNavigationControllerSpec.scala
+++ b/test/controllers/AdditionalMetadataNavigationControllerSpec.scala
@@ -70,8 +70,7 @@ class AdditionalMetadataNavigationControllerSpec extends FrontEndTestHelper {
           content must include(s"${metadataType.capitalize} metadata")
           content must include("""<h1 class="govuk-heading-l">Choose a file</h1>""")
           content must include(s"Select the file you wish to add or edit $metadataType metadata.")
-          content must include(
-            s"""<details class="govuk-details" data-module="govuk-details">
+          content must include(s"""<details class="govuk-details" data-module="govuk-details">
                |            <summary class="govuk-details__summary">
                |              <span class="govuk-details__summary-text">
                |                Using the keyboard to choose a file


### PR DESCRIPTION
Add missing `<details>` component on the tree navigation page
![image](https://user-images.githubusercontent.com/9700622/235703802-c7904173-c5c8-48fe-b987-7a16241d11bc.png)
