### PR TITLE
TDR 3341 - Remove seconds from date started and date transferred timestamps on View Transfers page

### DIFF
--- a/app/controllers/ViewTransfersController.scala
+++ b/app/controllers/ViewTransfersController.scala
@@ -66,8 +66,8 @@ class ViewTransfersController @Inject() (
         userAction.transferStatus,
         statusColours(userAction.transferStatus),
         userAction,
-        edge.node.exportDatetime.map(DateUtils.format(_)).getOrElse("N/A"),
-        edge.node.createdDatetime.map(DateUtils.format(_)).getOrElse(""),
+        edge.node.exportDatetime.map(edt => DateUtils.format(edt, "dd/MM/yyyy HH:mm")).getOrElse("N/A"),
+        edge.node.createdDatetime.map(cdt => DateUtils.format(cdt, "dd/MM/yyyy HH:mm")).getOrElse(""),
         edge.node.totalFiles
       )
     }

--- a/test/controllers/ViewTransfersControllerSpec.scala
+++ b/test/controllers/ViewTransfersControllerSpec.scala
@@ -35,7 +35,7 @@ class ViewTransfersControllerSpec extends FrontEndTestHelper {
 
   val checkPageForStaticElements = new CheckPageForStaticElements
 
-  private val formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm:ss")
+  private val formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm")
   private val standardType = "standard"
   private val judgmentType = "judgment"
 


### PR DESCRIPTION
|**Before**|**After**|
|---|---|
|![image](https://github.com/nationalarchives/tdr-transfer-frontend/assets/16852485/ee474538-dde3-4637-86f5-f153c9277220)|![image](https://github.com/nationalarchives/tdr-transfer-frontend/assets/16852485/9bdae624-67eb-4e2b-83b5-66c8294d6f23)|