### PR TITLE
Manual bump @nationalarchives/tdr-generated-graphql from to 1.0.449

### DIFF
--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -15,7 +15,7 @@
         "@aws-sdk/querystring-builder": "^3.374.0",
         "@nationalarchives/file-information": "^1.0.605",
         "@nationalarchives/tdr-components": "1.0.37",
-        "@nationalarchives/tdr-generated-graphql": "1.0.444",
+        "@nationalarchives/tdr-generated-graphql": "1.0.449",
         "copyfiles": "^2.4.1",
         "events": "^3.3.0",
         "graphql": "^16.8.1",
@@ -4298,9 +4298,9 @@
       }
     },
     "node_modules/@nationalarchives/tdr-generated-graphql": {
-      "version": "1.0.444",
-      "resolved": "https://registry.npmjs.org/@nationalarchives/tdr-generated-graphql/-/tdr-generated-graphql-1.0.444.tgz",
-      "integrity": "sha512-KAZJVtIoOMeUW/N6kolnCehaPzUwbTNZlgx+XshWDhrHR3sAS9g6kq9m9i0GL8pPXsdnDjuxpjggrPdefWowFA==",
+      "version": "1.0.449",
+      "resolved": "https://registry.npmjs.org/@nationalarchives/tdr-generated-graphql/-/tdr-generated-graphql-1.0.449.tgz",
+      "integrity": "sha512-djPzhHvyrcYTAY5IJr/ZBRGlCcUirZMFTTUoew5RRdjP1l1xfshsdhjzhQo0ljIY8r0DW8Pke69EYR/+1OIYWw==",
       "dependencies": {
         "@graphql-codegen/cli": "^5.0.2",
         "graphql": "^16.8.1",
@@ -19542,9 +19542,9 @@
       "requires": {}
     },
     "@nationalarchives/tdr-generated-graphql": {
-      "version": "1.0.444",
-      "resolved": "https://registry.npmjs.org/@nationalarchives/tdr-generated-graphql/-/tdr-generated-graphql-1.0.444.tgz",
-      "integrity": "sha512-KAZJVtIoOMeUW/N6kolnCehaPzUwbTNZlgx+XshWDhrHR3sAS9g6kq9m9i0GL8pPXsdnDjuxpjggrPdefWowFA==",
+      "version": "1.0.449",
+      "resolved": "https://registry.npmjs.org/@nationalarchives/tdr-generated-graphql/-/tdr-generated-graphql-1.0.449.tgz",
+      "integrity": "sha512-djPzhHvyrcYTAY5IJr/ZBRGlCcUirZMFTTUoew5RRdjP1l1xfshsdhjzhQo0ljIY8r0DW8Pke69EYR/+1OIYWw==",
       "requires": {
         "@graphql-codegen/cli": "^5.0.2",
         "graphql": "^16.8.1",

--- a/npm/package.json
+++ b/npm/package.json
@@ -47,7 +47,7 @@
     "@aws-sdk/protocol-http": "^3.374.0",
     "@nationalarchives/file-information": "^1.0.605",
     "@nationalarchives/tdr-components": "1.0.37",
-    "@nationalarchives/tdr-generated-graphql": "1.0.444",
+    "@nationalarchives/tdr-generated-graphql": "1.0.449",
     "copyfiles": "^2.4.1",
     "events": "^3.3.0",
     "graphql": "^16.8.1",


### PR DESCRIPTION
Manual redo of dependabot update