### PR TITLE
TDR-68 CSV Metadata download adjustments

### DIFF
--- a/app/controllers/DownloadMetadataController.scala
+++ b/app/controllers/DownloadMetadataController.scala
@@ -3,7 +3,7 @@ package controllers
 import auth.TokenSecurity
 import configuration.KeycloakConfiguration
 import controllers.util.CsvUtils
-import controllers.util.MetadataProperty.{clientSideFileLastModifiedDate, clientSideOriginalFilepath, fileName}
+import controllers.util.MetadataProperty.{clientSideFileLastModifiedDate, clientSideOriginalFilepath, fileName, fileUUID}
 import graphql.codegen.GetConsignmentFilesMetadata.getConsignmentFilesMetadata.GetConsignment.Files.FileMetadata
 import graphql.codegen.GetCustomMetadata.customMetadata.CustomMetadata
 import graphql.codegen.types.DataType
@@ -46,7 +46,7 @@ class DownloadMetadataController @Inject() (
     } yield {
       val parseFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd[ ]['T']HH:mm:ss[.SSS][.SS][.S]")
       val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
-      val systemValues = List(fileName, clientSideOriginalFilepath, clientSideFileLastModifiedDate)
+      val systemValues = List(fileUUID, fileName, clientSideOriginalFilepath, clientSideFileLastModifiedDate)
       val nameMap = displayProperties.filter(dp => dp.active || systemValues.contains(dp.propertyName)).map(dp => (dp.propertyName, dp.displayName)).toMap
       val filteredMetadata: List[CustomMetadata] = customMetadata.filter(cm => nameMap.keySet.contains(cm.name) && cm.allowExport).sortBy(_.exportOrdinal.getOrElse(Int.MaxValue))
       val header: List[String] = filteredMetadata.map(f => nameMap.getOrElse(f.name, f.name))

--- a/app/controllers/DownloadMetadataController.scala
+++ b/app/controllers/DownloadMetadataController.scala
@@ -3,6 +3,7 @@ package controllers
 import auth.TokenSecurity
 import configuration.KeycloakConfiguration
 import controllers.util.CsvUtils
+import controllers.util.MetadataProperty.{clientSideFileLastModifiedDate, clientSideOriginalFilepath, fileName}
 import graphql.codegen.GetConsignmentFilesMetadata.getConsignmentFilesMetadata.GetConsignment.Files.FileMetadata
 import graphql.codegen.GetCustomMetadata.customMetadata.CustomMetadata
 import graphql.codegen.types.DataType
@@ -44,8 +45,9 @@ class DownloadMetadataController @Inject() (
       displayProperties <- displayPropertiesService.getDisplayProperties(consignmentId, request.token.bearerAccessToken, None, showInactive = true)
     } yield {
       val parseFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd[ ]['T']HH:mm:ss[.SSS][.SS][.S]")
-      val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")
-      val nameMap = displayProperties.filter(dp => dp.active || dp.propertyName == "Filename").map(dp => (dp.propertyName, dp.displayName)).toMap
+      val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+      val systemValues = List(fileName, clientSideOriginalFilepath, clientSideFileLastModifiedDate)
+      val nameMap = displayProperties.filter(dp => dp.active || systemValues.contains(dp.propertyName)).map(dp => (dp.propertyName, dp.displayName)).toMap
       val filteredMetadata: List[CustomMetadata] = customMetadata.filter(cm => nameMap.keySet.contains(cm.name) && cm.allowExport).sortBy(_.exportOrdinal.getOrElse(Int.MaxValue))
       val header: List[String] = filteredMetadata.map(f => nameMap.getOrElse(f.name, f.name))
       val fileMetadataRows: List[List[String]] = metadata.files.map { file =>

--- a/app/controllers/util/CustomMetadataUtils.scala
+++ b/app/controllers/util/CustomMetadataUtils.scala
@@ -26,6 +26,7 @@ object MetadataProperty {
   val closureStartDate = "ClosureStartDate"
   val closurePeriod = "ClosurePeriod"
   val foiExemptionCode = "FoiExemptionCode"
+  val fileUUID = "UUID"
   val fileName = "Filename"
   val titleClosed = "TitleClosed"
   val descriptionClosed = "DescriptionClosed"

--- a/test/controllers/DownloadMetadataControllerSpec.scala
+++ b/test/controllers/DownloadMetadataControllerSpec.scala
@@ -4,6 +4,7 @@ import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock.{containing, okJson, post, urlEqualTo}
 import com.github.tototoshi.csv.CSVReader
 import configuration.GraphQLConfiguration
+import controllers.util.MetadataProperty.{clientSideFileLastModifiedDate, clientSideOriginalFilepath, fileName}
 import graphql.codegen.GetConsignmentFilesMetadata.getConsignmentFilesMetadata.GetConsignment.Files
 import graphql.codegen.GetConsignmentFilesMetadata.getConsignmentFilesMetadata.GetConsignment.Files.FileMetadata
 import graphql.codegen.GetCustomMetadata.{customMetadata => cm}
@@ -35,7 +36,7 @@ class DownloadMetadataControllerSpec extends FrontEndTestHelper {
   val checkPageForStaticElements = new CheckPageForStaticElements()
 
   def customMetadata(name: String, fullName: String, exportOrdinal: Int = Int.MaxValue, allowExport: Boolean = true): cm.CustomMetadata = {
-    if (name == "DateTimeProperty") {
+    if (name == "DateTimeProperty" || name == clientSideFileLastModifiedDate) {
       cm.CustomMetadata(name, None, Option(fullName), Supplied, None, DateTime, editable = false, multiValue = false, None, 1, Nil, Option(exportOrdinal), allowExport)
     } else if (name.contains("BooleanProperty")) {
       cm.CustomMetadata(name, None, Option(fullName), Supplied, None, DataType.Boolean, editable = false, multiValue = false, None, 1, Nil, Option(exportOrdinal), allowExport)
@@ -69,24 +70,32 @@ class DownloadMetadataControllerSpec extends FrontEndTestHelper {
         displayProperty("TestProperty1", "Test Property 1 Name"),
         displayProperty("TestProperty2", "Test Property 2 Name"),
         displayProperty("DateTimeProperty", "Date Time Property Name", DataType.DateTime),
-        displayProperty("FileName", "File Name")
+        displayProperty(fileName, "File Name"),
+        displayProperty(clientSideOriginalFilepath, "Filepath"),
+        displayProperty(clientSideFileLastModifiedDate, "Date last modified", DataType.DateTime)
       )
       val customProperties = List(
         customMetadata("TestProperty1", "TestProperty1"),
         customMetadata("TestProperty2", "TestProperty2"),
         customMetadata("DateTimeProperty", "DateTimeProperty"),
-        customMetadata("FileName", "FileName")
+        customMetadata(fileName, "FileName"),
+        customMetadata(clientSideOriginalFilepath, "Filepath"),
+        customMetadata(clientSideFileLastModifiedDate, "Date last modified")
       )
       val metadataFileOne = List(
         FileMetadata("TestProperty1", "TestValue1File1"),
         FileMetadata("TestProperty2", "TestValue2File1"),
         FileMetadata("DateTimeProperty", lastModified.format(DateTimeFormatter.ISO_DATE_TIME)),
-        FileMetadata("FileName", "FileName1")
+        FileMetadata(fileName, "FileName1"),
+        FileMetadata(clientSideOriginalFilepath, "test/path1"),
+        FileMetadata(clientSideFileLastModifiedDate, lastModified.format(DateTimeFormatter.ISO_DATE_TIME))
       )
       val metadataFileTwo = List(
         FileMetadata("TestProperty1", "TestValue1File2"),
         FileMetadata("TestProperty2", "TestValue2File2"),
-        FileMetadata("FileName", "FileName2")
+        FileMetadata(fileName, "FileName2"),
+        FileMetadata(clientSideOriginalFilepath, "test/path2"),
+        FileMetadata(clientSideFileLastModifiedDate, lastModified.format(DateTimeFormatter.ISO_DATE_TIME))
       )
       val files = List(
         gcfm.GetConsignment.Files(UUID.randomUUID(), Some("FileName"), metadataFileOne, Nil),
@@ -98,11 +107,15 @@ class DownloadMetadataControllerSpec extends FrontEndTestHelper {
       csvList.size must equal(2)
       csvList.head("Test Property 1 Name") must equal("TestValue1File1")
       csvList.head("Test Property 2 Name") must equal("TestValue2File1")
-      csvList.head("Date Time Property Name") must equal("2021-02-03T10:33:30")
+      csvList.head("Date Time Property Name") must equal("2021-02-03")
       csvList.head("File Name") must equal("FileName1")
+      csvList.head("Filepath") must equal("test/path1")
+      csvList.head("Date last modified") must equal("2021-02-03")
       csvList.last("Test Property 1 Name") must equal("TestValue1File2")
       csvList.last("Test Property 2 Name") must equal("TestValue2File2")
       csvList.last("File Name") must equal("FileName2")
+      csvList.last("Filepath") must equal("test/path2")
+      csvList.head("Date last modified") must equal("2021-02-03")
     }
 
     "download the csv for rows with different numbers of metadata" in {
@@ -170,35 +183,6 @@ class DownloadMetadataControllerSpec extends FrontEndTestHelper {
       csvList.size must equal(1)
       csvList.head("Test Property 1 Name") must equal("TestValue1File1")
       csvList.head("Test Property 2 Name") must equal("TestValue2File1|TestValue3File1")
-      csvList.head("File Name") must equal("FileName1")
-    }
-
-    "download the csv for datetime rows to include the seconds to the file when the input seconds are zero" in {
-      val lastModified = LocalDateTime.parse("2021-02-03T10:33:00.0")
-      val customProperties = List(
-        customMetadata("TestProperty1", "TestProperty1"),
-        customMetadata("DateTimeProperty", "DateTimeProperty"),
-        customMetadata("FileName", "FileName")
-      )
-      val displayProperties = List(
-        displayProperty("TestProperty1", "Test Property 1 Name"),
-        displayProperty("DateTimeProperty", "Date Time Property Name", DataType.DateTime),
-        displayProperty("FileName", "File Name")
-      )
-      val metadataFileOne = List(
-        FileMetadata("TestProperty1", "TestValue1File1"),
-        FileMetadata("DateTimeProperty", lastModified.format(DateTimeFormatter.ISO_DATE_TIME)),
-        FileMetadata("FileName", "FileName1")
-      )
-      val files = List(
-        gcfm.GetConsignment.Files(UUID.randomUUID(), Some("FileName"), metadataFileOne, Nil)
-      )
-
-      val csvList: List[Map[String, String]] = getCsvFromController(customProperties, files, displayProperties).toLazyListWithHeaders().toList
-
-      csvList.size must equal(1)
-      csvList.head("Test Property 1 Name") must equal("TestValue1File1")
-      csvList.head("Date Time Property Name") must equal("2021-02-03T10:33:00")
       csvList.head("File Name") must equal("FileName1")
     }
 


### PR DESCRIPTION
- Include `clientSideOriginalFilepath` , `clientSideFileLastModifiedDate` & `UUID` in the metadata csv.
- Removed time from date.