### PR TITLE
TDRD-7 Review metadata page `back button`

### DIFF
--- a/app/views/standard/downloadMetadata.scala.html
+++ b/app/views/standard/downloadMetadata.scala.html
@@ -30,7 +30,7 @@
 
       </div>
       <div class="govuk-button-group">
-        <a href="@routes.AdditionalMetadataController.start(consignmentId)" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="govuk-button">
+        <a href="@routes.AdditionalMetadataEntryMethodController.additionalMetadataEntryMethodPage(consignmentId)" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="govuk-button">
           Back
         </a>
         <a class="govuk-button" href="@routes.ConfirmTransferController.confirmTransfer(consignmentId)" role="button" draggable="false" data-module="govuk-button">

--- a/test/controllers/DownloadMetadataControllerSpec.scala
+++ b/test/controllers/DownloadMetadataControllerSpec.scala
@@ -332,7 +332,7 @@ class DownloadMetadataControllerSpec extends FrontEndTestHelper {
   }
 
   "DownloadMetadataController downloadMetadataPage GET" should {
-    "load the download metadata page with the image, download link and continue button" in {
+    "load the download metadata page with the image, download link, next button and back button" in {
       setConsignmentReferenceResponse(wiremockServer)
 
       val controller = createController("standard")
@@ -346,6 +346,7 @@ class DownloadMetadataControllerSpec extends FrontEndTestHelper {
         s"""<a class="govuk-button govuk-!-margin-bottom-8 download-metadata" href="/consignment/$consignmentId/additional-metadata/download-metadata/csv">"""
       )
       responseAsString must include(s"""<a class="govuk-button" href="/consignment/$consignmentId/confirm-transfer"""")
+      responseAsString must include(s"""<a href="/consignment/$consignmentId/additional-metadata/entry-method"""")
     }
 
     "return forbidden for a judgment user" in {


### PR DESCRIPTION
Change `back` button on `download-metadata` page to direct to `entry-method` page