### PR TITLE
Enable grouping on npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,4 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+      

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: "/npm"
     schedule:
       interval: "daily"
+    groups:
+      npm-dependencies:
+      applies-to: version-updates
+        - "*"
     versioning-strategy: increase
   - package-ecosystem: "docker"
     directory: "/"


### PR DESCRIPTION
It looks like this feature came out of beta last October, and could really help with our npm pull request spam.

This should lead to all npm version updates being consolidated in one pull request (though security updates will still come through in a new PR).

Would be keen to try this out on tdr-transfer-frontend and roll out on others if it works- thoughts welcome.

Announcement:
https://github.com/dependabot/dependabot-core/issues/2265#issuecomment-1742364365

Doc:
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups