### PR TITLE
Use different library for upload

### DIFF
--- a/app/configuration/ApplicationConfig.scala
+++ b/app/configuration/ApplicationConfig.scala
@@ -21,6 +21,8 @@ class ApplicationConfig @Inject() (configuration: Configuration) {
 
   val metadataValidationBaseUrl: String = configuration.get[String]("metadatavalidation.baseUrl")
 
+  val s3Endpoint: String = configuration.get[String]("s3.endpoint")
+
   val draft_metadata_s3_bucket_name: String = configuration.get[String]("draft_metadata_s3_bucket_name")
 
 }

--- a/app/controllers/DraftMetadataUploadController.scala
+++ b/app/controllers/DraftMetadataUploadController.scala
@@ -56,7 +56,7 @@ class DraftMetadataUploadController @Inject() (
         firstFilePart <- fromOption(request.body.files.headOption)(new RuntimeException(noDraftMetadataFileUploaded))
         file <- fromOption(request.body.file(firstFilePart.key))(new RuntimeException(noDraftMetadataFileUploaded))
         draftMetadata <- fromOption(Using(scala.io.Source.fromFile(file.ref.getAbsoluteFile))(_.mkString).toOption)(new RuntimeException(noDraftMetadataFileUploaded))
-        _ <- uploadService.uploadDraftMetadata(uploadBucket, uploadKey, draftMetadata)
+        _ <- IO.fromFuture(IO(uploadService.uploadDraftMetadata(uploadBucket, uploadKey, draftMetadata)))
         _ <- IO.fromFuture(IO { draftMetadataService.triggerDraftMetadataValidator(consignmentId, token.bearerAccessToken.getValue) })
         successPage <- IO(play.api.mvc.Results.Redirect(successPage))
       } yield successPage

--- a/app/services/UploadService.scala
+++ b/app/services/UploadService.scala
@@ -1,22 +1,24 @@
 package services
 
-import cats.effect.IO
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken
-import configuration.GraphQLConfiguration
+import configuration.{ApplicationConfig, GraphQLConfiguration}
 import graphql.codegen.AddFilesAndMetadata.{addFilesAndMetadata => afam}
 import graphql.codegen.StartUpload.{startUpload => su}
 import graphql.codegen.types.{AddFileAndMetadataInput, StartUploadInput}
 import services.ApiErrorHandling.sendApiRequest
 import software.amazon.awssdk.core.internal.async.ByteBuffersAsyncRequestBody
-import software.amazon.awssdk.transfer.s3.model.CompletedUpload
-import uk.gov.nationalarchives.DAS3Client
+import software.amazon.awssdk.services.s3.S3AsyncClient
+import software.amazon.awssdk.services.s3.model.{PutObjectRequest, PutObjectResponse}
+import uk.gov.nationalarchives.aws.utils.s3.S3Clients._
 
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
+import scala.jdk.FutureConverters.CompletionStageOps
 
-class UploadService @Inject() (val graphqlConfiguration: GraphQLConfiguration)(implicit val ec: ExecutionContext) {
+class UploadService @Inject() (val graphqlConfiguration: GraphQLConfiguration, val applicationConfig: ApplicationConfig)(implicit val ec: ExecutionContext) {
   private val startUploadClient = graphqlConfiguration.getClient[su.Data, su.Variables]()
   private val addFilesAndMetadataClient = graphqlConfiguration.getClient[afam.Data, afam.Variables]()
+  private val s3Endpoint = applicationConfig.s3Endpoint
 
   def startUpload(startUploadInput: StartUploadInput, token: BearerAccessToken): Future[String] = {
     val variables = su.Variables(startUploadInput)
@@ -28,13 +30,13 @@ class UploadService @Inject() (val graphqlConfiguration: GraphQLConfiguration)(i
     sendApiRequest(addFilesAndMetadataClient, afam.document, token, variables).map(data => data.addFilesAndMetadata)
   }
 
-  def uploadDraftMetadata(bucket: String, key: String, draftMetadata: String): IO[CompletedUpload] = {
-    uploadDraftMetadata(bucket, key, draftMetadata, DAS3Client[IO]())
+  def uploadDraftMetadata(bucket: String, key: String, draftMetadata: String): Future[PutObjectResponse] = {
+    uploadDraftMetadata(bucket, key, draftMetadata, s3Async(s3Endpoint))
   }
 
-  def uploadDraftMetadata(bucket: String, key: String, draftMetadata: String, s3client: DAS3Client[IO]): IO[CompletedUpload] = {
+  def uploadDraftMetadata(bucket: String, key: String, draftMetadata: String, s3AsyncClient: S3AsyncClient): Future[PutObjectResponse] = {
     val bytes = draftMetadata.getBytes
-    val publisher = ByteBuffersAsyncRequestBody.from("application/octet-stream", bytes)
-    s3client.upload(bucket, key, bytes.size, publisher)
+    val publisher: ByteBuffersAsyncRequestBody = ByteBuffersAsyncRequestBody.from("application/octet-stream", bytes)
+    s3AsyncClient.putObject(PutObjectRequest.builder.bucket(bucket).key(key).build, publisher).asScala
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,7 @@ libraryDependencies ++= Seq(
   "uk.gov.nationalarchives" %% "tdr-auth-utils" % "0.0.190",
   "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.361",
   "uk.gov.nationalarchives" %% "tdr-metadata-validation" % "0.0.14",
-  "uk.gov.nationalarchives" %% "da-s3-client" % "0.1.41",
+  "uk.gov.nationalarchives" %% "s3-utils" % "0.1.151",
   "com.github.tototoshi" %% "scala-csv" % "1.3.10",
   "ch.qos.logback" % "logback-classic" % "1.5.0",
   ws,

--- a/conf/application.base.conf
+++ b/conf/application.base.conf
@@ -11,6 +11,8 @@ consignmentapi.url = ${consignmentapi.domain}"/graphql"
 
 logout.url="http://localhost:9000/signed-out"
 
+s3.endpoint = "https://s3.eu-west-2.amazonaws.com/"
+
 play.filters.enabled += play.filters.https.RedirectHttpsFilter
 
 play {

--- a/test/controllers/UploadControllerSpec.scala
+++ b/test/controllers/UploadControllerSpec.scala
@@ -2,7 +2,7 @@ package controllers
 
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock.{containing, okJson, post, serverError, urlEqualTo}
-import configuration.GraphQLConfiguration
+import configuration.{ApplicationConfig, GraphQLConfiguration}
 import graphql.codegen.AddMultipleFileStatuses.addMultipleFileStatuses
 import graphql.codegen.AddFilesAndMetadata.addFilesAndMetadata
 import graphql.codegen.AddFilesAndMetadata.addFilesAndMetadata.AddFilesAndMetadata
@@ -24,6 +24,8 @@ import java.util.UUID
 import scala.collection.immutable.TreeMap
 import scala.concurrent.ExecutionContext
 import org.scalatest.concurrent.ScalaFutures._
+import org.scalatestplus.mockito.MockitoSugar.mock
+import play.api.Configuration
 import play.api.test.WsTestClient.InternalWSClient
 import services.Statuses.CompletedWithIssuesValue
 
@@ -33,6 +35,8 @@ import scala.jdk.CollectionConverters._
 class UploadControllerSpec extends FrontEndTestHelper {
   val wiremockServer = new WireMockServer(9006)
   val triggerBackendChecksServer = new WireMockServer(9008)
+  private val configuration: Configuration = mock[Configuration]
+  val applicationConfig: ApplicationConfig = new ApplicationConfig(configuration)
 
   override def beforeEach(): Unit = {
     triggerBackendChecksServer.start()
@@ -55,7 +59,7 @@ class UploadControllerSpec extends FrontEndTestHelper {
     "redirect to the transfer agreement page if the transfer agreement for that consignment has not been signed" in {
       val graphQLConfiguration: GraphQLConfiguration = new GraphQLConfiguration(app.configuration)
       val consignmentService: ConsignmentService = new ConsignmentService(graphQLConfiguration)
-      val uploadService = new UploadService(graphQLConfiguration)
+      val uploadService = new UploadService(graphQLConfiguration, applicationConfig)
       val fileStatusService = new FileStatusService(graphQLConfiguration)
       val backendChecksService = new BackendChecksService(new InternalWSClient("http", 9007), app.configuration)
       val consignmentId = UUID.fromString("c2efd3e6-6664-4582-8c28-dcf891f60e68")
@@ -83,7 +87,7 @@ class UploadControllerSpec extends FrontEndTestHelper {
 
     "redirect to the transfer agreement page if the transfer agreement for that consignment has not been agreed to" in {
       val graphQLConfiguration: GraphQLConfiguration = new GraphQLConfiguration(app.configuration)
-      val uploadService = new UploadService(graphQLConfiguration)
+      val uploadService = new UploadService(graphQLConfiguration, applicationConfig)
       val consignmentService: ConsignmentService = new ConsignmentService(graphQLConfiguration)
       val fileStatusService = new FileStatusService(graphQLConfiguration)
       val backendChecksService = new BackendChecksService(new InternalWSClient("http", 9007), app.configuration)
@@ -112,7 +116,7 @@ class UploadControllerSpec extends FrontEndTestHelper {
 
     "redirect to the transfer agreement page if the transfer agreement for that consignment has been partially agreed to" in {
       val graphQLConfiguration: GraphQLConfiguration = new GraphQLConfiguration(app.configuration)
-      val uploadService = new UploadService(graphQLConfiguration)
+      val uploadService = new UploadService(graphQLConfiguration, applicationConfig)
       val consignmentService: ConsignmentService = new ConsignmentService(graphQLConfiguration)
       val fileStatusService = new FileStatusService(graphQLConfiguration)
       val backendChecksService = new BackendChecksService(new InternalWSClient("http", 9007), app.configuration)
@@ -143,7 +147,7 @@ class UploadControllerSpec extends FrontEndTestHelper {
 
     "show the standard upload page if the transfer agreement for that consignment has been agreed to in full" in {
       val graphQLConfiguration: GraphQLConfiguration = new GraphQLConfiguration(app.configuration)
-      val uploadService = new UploadService(graphQLConfiguration)
+      val uploadService = new UploadService(graphQLConfiguration, applicationConfig)
       val consignmentService: ConsignmentService = new ConsignmentService(graphQLConfiguration)
       val fileStatusService = new FileStatusService(graphQLConfiguration)
       val backendChecksService = new BackendChecksService(new InternalWSClient("http", 9007), app.configuration)
@@ -236,7 +240,7 @@ class UploadControllerSpec extends FrontEndTestHelper {
 
     "render the 'upload in progress' page if a standard upload is in progress" in {
       val graphQLConfiguration: GraphQLConfiguration = new GraphQLConfiguration(app.configuration)
-      val uploadService = new UploadService(graphQLConfiguration)
+      val uploadService = new UploadService(graphQLConfiguration, applicationConfig)
       val consignmentService: ConsignmentService = new ConsignmentService(graphQLConfiguration)
       val fileStatusService = new FileStatusService(graphQLConfiguration)
       val backendChecksService = new BackendChecksService(new InternalWSClient("http", 9007), app.configuration)
@@ -274,7 +278,7 @@ class UploadControllerSpec extends FrontEndTestHelper {
 
     "render 'upload is complete' page if a standard upload has completed" in {
       val graphQLConfiguration: GraphQLConfiguration = new GraphQLConfiguration(app.configuration)
-      val uploadService = new UploadService(graphQLConfiguration)
+      val uploadService = new UploadService(graphQLConfiguration, applicationConfig)
       val consignmentService: ConsignmentService = new ConsignmentService(graphQLConfiguration)
       val fileStatusService = new FileStatusService(graphQLConfiguration)
       val backendChecksService = new BackendChecksService(new InternalWSClient("http", 9007), app.configuration)
@@ -318,7 +322,7 @@ class UploadControllerSpec extends FrontEndTestHelper {
 
     "render the 'upload in progress' error page if a standard upload has a 'completedWithIssues' status" in {
       val graphQLConfiguration: GraphQLConfiguration = new GraphQLConfiguration(app.configuration)
-      val uploadService = new UploadService(graphQLConfiguration)
+      val uploadService = new UploadService(graphQLConfiguration, applicationConfig)
       val consignmentService: ConsignmentService = new ConsignmentService(graphQLConfiguration)
       val fileStatusService = new FileStatusService(graphQLConfiguration)
       val backendChecksService = new BackendChecksService(new InternalWSClient("http", 9007), app.configuration)
@@ -356,7 +360,7 @@ class UploadControllerSpec extends FrontEndTestHelper {
 
     "render the 'upload in progress error' page if a judgment file upload has a 'completedWithIssues' status" in {
       val graphQLConfiguration: GraphQLConfiguration = new GraphQLConfiguration(app.configuration)
-      val uploadService = new UploadService(graphQLConfiguration)
+      val uploadService = new UploadService(graphQLConfiguration, applicationConfig)
       val consignmentService: ConsignmentService = new ConsignmentService(graphQLConfiguration)
       val fileStatusService = new FileStatusService(graphQLConfiguration)
       val backendChecksService = new BackendChecksService(new InternalWSClient("http", 9007), app.configuration)
@@ -394,7 +398,7 @@ class UploadControllerSpec extends FrontEndTestHelper {
 
     "show the judgment upload page for judgments" in {
       val graphQLConfiguration: GraphQLConfiguration = new GraphQLConfiguration(app.configuration)
-      val uploadService = new UploadService(graphQLConfiguration)
+      val uploadService = new UploadService(graphQLConfiguration, applicationConfig)
       val consignmentService: ConsignmentService = new ConsignmentService(graphQLConfiguration)
       val fileStatusService = new FileStatusService(graphQLConfiguration)
       val backendChecksService = new BackendChecksService(new InternalWSClient("http", 9007), app.configuration)
@@ -465,7 +469,7 @@ class UploadControllerSpec extends FrontEndTestHelper {
 
     "render the 'upload in progress' page if a judgment file upload is in progress" in {
       val graphQLConfiguration: GraphQLConfiguration = new GraphQLConfiguration(app.configuration)
-      val uploadService = new UploadService(graphQLConfiguration)
+      val uploadService = new UploadService(graphQLConfiguration, applicationConfig)
       val consignmentService: ConsignmentService = new ConsignmentService(graphQLConfiguration)
       val fileStatusService = new FileStatusService(graphQLConfiguration)
       val backendChecksService = new BackendChecksService(new InternalWSClient("http", 9007), app.configuration)
@@ -505,7 +509,7 @@ class UploadControllerSpec extends FrontEndTestHelper {
 
     "render the judgment 'upload is complete' page if the upload has completed" in {
       val graphQLConfiguration: GraphQLConfiguration = new GraphQLConfiguration(app.configuration)
-      val uploadService = new UploadService(graphQLConfiguration)
+      val uploadService = new UploadService(graphQLConfiguration, applicationConfig)
       val consignmentService: ConsignmentService = new ConsignmentService(graphQLConfiguration)
       val fileStatusService = new FileStatusService(graphQLConfiguration)
       val backendChecksService = new BackendChecksService(new InternalWSClient("http", 9007), app.configuration)
@@ -552,7 +556,7 @@ class UploadControllerSpec extends FrontEndTestHelper {
     s"The $url upload page" should {
       s"return 403 if the url doesn't match the consignment type" in {
         val graphQLConfiguration: GraphQLConfiguration = new GraphQLConfiguration(app.configuration)
-        val uploadService = new UploadService(graphQLConfiguration)
+        val uploadService = new UploadService(graphQLConfiguration, applicationConfig)
         val consignmentService: ConsignmentService = new ConsignmentService(graphQLConfiguration)
         val fileStatusService = new FileStatusService(graphQLConfiguration)
         val backendChecksService = new BackendChecksService(new InternalWSClient("http", 9007), app.configuration)
@@ -590,7 +594,7 @@ class UploadControllerSpec extends FrontEndTestHelper {
     s"The $url upload in progress page" should {
       s"return 403 if the url doesn't match the consignment type" in {
         val graphQLConfiguration: GraphQLConfiguration = new GraphQLConfiguration(app.configuration)
-        val uploadService = new UploadService(graphQLConfiguration)
+        val uploadService = new UploadService(graphQLConfiguration, applicationConfig)
         val consignmentService: ConsignmentService = new ConsignmentService(graphQLConfiguration)
         val fileStatusService = new FileStatusService(graphQLConfiguration)
         val backendChecksService = new BackendChecksService(new InternalWSClient("http", 9007), app.configuration)
@@ -633,7 +637,7 @@ class UploadControllerSpec extends FrontEndTestHelper {
     s"The $url upload has completed page" should {
       s"return 403 if the url doesn't match the consignment type" in {
         val graphQLConfiguration: GraphQLConfiguration = new GraphQLConfiguration(app.configuration)
-        val uploadService = new UploadService(graphQLConfiguration)
+        val uploadService = new UploadService(graphQLConfiguration, applicationConfig)
         val consignmentService: ConsignmentService = new ConsignmentService(graphQLConfiguration)
         val fileStatusService = new FileStatusService(graphQLConfiguration)
         val backendChecksService = new BackendChecksService(new InternalWSClient("http", 9007), app.configuration)
@@ -681,7 +685,7 @@ class UploadControllerSpec extends FrontEndTestHelper {
       val consignmentService: ConsignmentService = new ConsignmentService(graphQLConfiguration)
       val fileStatusService = new FileStatusService(graphQLConfiguration)
       val backendChecksService = new BackendChecksService(new InternalWSClient("http", 9007), app.configuration)
-      val uploadService = new UploadService(graphQLConfiguration)
+      val uploadService = new UploadService(graphQLConfiguration, applicationConfig)
       val consignmentId = UUID.fromString("c2efd3e6-6664-4582-8c28-dcf891f60e68")
       val fileId = UUID.randomUUID()
       val clientSideMetadataInput = ClientSideMetadataInput("originalPath", "checksum", 1, 1, 1) :: Nil
@@ -726,7 +730,7 @@ class UploadControllerSpec extends FrontEndTestHelper {
       val consignmentService: ConsignmentService = new ConsignmentService(graphQLConfiguration)
       val fileStatusService = new FileStatusService(graphQLConfiguration)
       val backendChecksService = new BackendChecksService(new InternalWSClient("http", 9007), app.configuration)
-      val uploadService = new UploadService(graphQLConfiguration)
+      val uploadService = new UploadService(graphQLConfiguration, applicationConfig)
       val controller = new UploadController(
         getAuthorisedSecurityComponents,
         graphQLConfiguration,
@@ -753,7 +757,7 @@ class UploadControllerSpec extends FrontEndTestHelper {
       val consignmentService: ConsignmentService = new ConsignmentService(graphQLConfiguration)
       val fileStatusService = new FileStatusService(graphQLConfiguration)
       val backendChecksService = new BackendChecksService(new InternalWSClient("http", 9007), app.configuration)
-      val uploadService = new UploadService(graphQLConfiguration)
+      val uploadService = new UploadService(graphQLConfiguration, applicationConfig)
       val controller = new UploadController(
         getAuthorisedSecurityComponents,
         graphQLConfiguration,
@@ -791,7 +795,7 @@ class UploadControllerSpec extends FrontEndTestHelper {
       val consignmentService: ConsignmentService = new ConsignmentService(graphQLConfiguration)
       val fileStatusService = new FileStatusService(graphQLConfiguration)
       val backendChecksService = new BackendChecksService(new InternalWSClient("http", 9007), app.configuration)
-      val uploadService = new UploadService(graphQLConfiguration)
+      val uploadService = new UploadService(graphQLConfiguration, applicationConfig)
       val fileId = UUID.randomUUID()
       val addFileStatusInput = AddMultipleFileStatusesInput(List(AddFileStatusInput(fileId, "Upload", "Success")))
       val data = client.GraphqlData(Option(addMultipleFileStatuses.Data(List(addMultipleFileStatuses.AddMultipleFileStatuses(fileId, "Upload", "Success")))), Nil)
@@ -835,7 +839,7 @@ class UploadControllerSpec extends FrontEndTestHelper {
       val consignmentService: ConsignmentService = new ConsignmentService(graphQLConfiguration)
       val fileStatusService = new FileStatusService(graphQLConfiguration)
       val backendChecksService = new BackendChecksService(new InternalWSClient("http", 9007), app.configuration)
-      val uploadService = new UploadService(graphQLConfiguration)
+      val uploadService = new UploadService(graphQLConfiguration, applicationConfig)
       val controller = new UploadController(
         getAuthorisedSecurityComponents,
         graphQLConfiguration,
@@ -862,7 +866,7 @@ class UploadControllerSpec extends FrontEndTestHelper {
       val consignmentService: ConsignmentService = new ConsignmentService(graphQLConfiguration)
       val fileStatusService = new FileStatusService(graphQLConfiguration)
       val backendChecksService = new BackendChecksService(new InternalWSClient("http", 9007), app.configuration)
-      val uploadService = new UploadService(graphQLConfiguration)
+      val uploadService = new UploadService(graphQLConfiguration, applicationConfig)
       val fileId = UUID.randomUUID()
       val addFileStatusInput = AddMultipleFileStatusesInput(List(AddFileStatusInput(fileId, "Upload", "Success")))
 
@@ -901,7 +905,7 @@ class UploadControllerSpec extends FrontEndTestHelper {
       val consignmentService: ConsignmentService = new ConsignmentService(graphQLConfiguration)
       val fileStatusService = new FileStatusService(graphQLConfiguration)
       val backendChecksService = new BackendChecksService(new InternalWSClient("http", 9007), app.configuration)
-      val uploadService = new UploadService(graphQLConfiguration)
+      val uploadService = new UploadService(graphQLConfiguration, applicationConfig)
       val consignmentId = UUID.fromString("c2efd3e6-6664-4582-8c28-dcf891f60e68")
       val startUploadInput = StartUploadInput(consignmentId, "parent", Some(false))
       val data = client.GraphqlData(Option(startUpload.Data("ok")), Nil)
@@ -941,7 +945,7 @@ class UploadControllerSpec extends FrontEndTestHelper {
       val consignmentService: ConsignmentService = new ConsignmentService(graphQLConfiguration)
       val fileStatusService = new FileStatusService(graphQLConfiguration)
       val backendChecksService = new BackendChecksService(new InternalWSClient("http", 9007), app.configuration)
-      val uploadService = new UploadService(graphQLConfiguration)
+      val uploadService = new UploadService(graphQLConfiguration, applicationConfig)
       val controller = new UploadController(
         getAuthorisedSecurityComponents,
         graphQLConfiguration,
@@ -968,7 +972,7 @@ class UploadControllerSpec extends FrontEndTestHelper {
       val consignmentService: ConsignmentService = new ConsignmentService(graphQLConfiguration)
       val fileStatusService = new FileStatusService(graphQLConfiguration)
       val backendChecksService = new BackendChecksService(new InternalWSClient("http", 9007), app.configuration)
-      val uploadService = new UploadService(graphQLConfiguration)
+      val uploadService = new UploadService(graphQLConfiguration, applicationConfig)
       val consignmentId = UUID.fromString("c2efd3e6-6664-4582-8c28-dcf891f60e68")
       val controller = new UploadController(
         getAuthorisedSecurityComponents,

--- a/test/resources/application.conf
+++ b/test/resources/application.conf
@@ -16,4 +16,5 @@ play.filters.hosts {
 
 export.baseUrl = "http://localhost:9007"
 backendchecks.baseUrl = "http://localhost:9008"
+s3.endpoint = "https://s3.eu-west-2.amazonaws.com/"
 draft_metadata_s3_bucket_name = "tdr-draft_metadata"

--- a/test/services/UploadServiceSpec.scala
+++ b/test/services/UploadServiceSpec.scala
@@ -1,36 +1,34 @@
 package services
 
-import cats.effect.IO
-import cats.effect.unsafe.implicits.global
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken
 import configuration.GraphQLBackend._
-import configuration.GraphQLConfiguration
+import configuration.{ApplicationConfig, GraphQLConfiguration}
 import graphql.codegen.AddFilesAndMetadata.{addFilesAndMetadata => afam}
 import graphql.codegen.StartUpload.{startUpload => su}
 import graphql.codegen.types.{AddFileAndMetadataInput, ClientSideMetadataInput, StartUploadInput}
+import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.when
-import org.reactivestreams.Publisher
+import org.mockito.Mockito.{doAnswer, when}
 import org.scalatest.concurrent.ScalaFutures._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers._
 import org.scalatestplus.mockito.MockitoSugar.mock
-import software.amazon.awssdk.auth.credentials.{AwsCredentials, AwsCredentialsProvider}
-import software.amazon.awssdk.regions.Region
+import play.api.Configuration
+import software.amazon.awssdk.core.internal.async.ByteBuffersAsyncRequestBody
 import software.amazon.awssdk.services.s3.S3AsyncClient
-import software.amazon.awssdk.services.s3.model.PutObjectResponse
-import software.amazon.awssdk.transfer.s3.model.CompletedUpload
-import uk.gov.nationalarchives.DAS3Client
+import software.amazon.awssdk.services.s3.model.{PutObjectRequest, PutObjectResponse}
 import uk.gov.nationalarchives.tdr.{GraphQLClient, GraphQlResponse}
 
-import java.nio.ByteBuffer
 import java.util.UUID
+import java.util.concurrent.CompletableFuture
 import scala.concurrent.{ExecutionContext, Future}
 
 class UploadServiceSpec extends AnyFlatSpec {
   implicit val ec: ExecutionContext = ExecutionContext.global
   private val graphQlConfig = mock[GraphQLConfiguration]
   private val token = new BearerAccessToken("some-token")
+  private val configuration: Configuration = mock[Configuration]
+  val applicationConfig: ApplicationConfig = new ApplicationConfig(configuration)
 
   "startUpload" should "return the correct data" in {
     val input = StartUploadInput(UUID.randomUUID(), "parent", Some(false))
@@ -43,7 +41,7 @@ class UploadServiceSpec extends AnyFlatSpec {
     when(graphQlClientForStartUpload.getResult(token, su.document, Some(su.Variables(input))))
       .thenReturn(Future.successful(graphQlResponse))
 
-    val response = new UploadService(graphQlConfig).startUpload(input, token).futureValue
+    val response = new UploadService(graphQlConfig, applicationConfig).startUpload(input, token).futureValue
     response should equal("ok")
   }
 
@@ -61,43 +59,40 @@ class UploadServiceSpec extends AnyFlatSpec {
     when(graphQlClientForAddFilesAndMetadata.getResult(token, afam.document, Some(afam.Variables(addFileAndMetadataInput))))
       .thenReturn(Future.successful(graphQlResponse))
 
-    val response = new UploadService(graphQlConfig).saveClientMetadata(addFileAndMetadataInput, token).futureValue
+    val response = new UploadService(graphQlConfig, applicationConfig).saveClientMetadata(addFileAndMetadataInput, token).futureValue
     response.size should equal(1)
     response.head should equal(input)
   }
 
-  "uploadDraftMetadata" should "return an IO[CompletedUpload] indicating success " in {
+  "uploadDraftMetadata" should "return call s3AsyncClient putObject with correct arguments " in {
 
-    val s3client = mock[DAS3Client[IO]]
+    val s3AsyncClient = mock[S3AsyncClient]
     val putObjectResponse = PutObjectResponse.builder().eTag("testEtag").build()
-    val completedUpload = IO(CompletedUpload.builder().response(putObjectResponse).build())
-    when(s3client.upload(any[String], any[String], any[Long], any[Publisher[ByteBuffer]])).thenReturn(completedUpload)
 
-    val completedUploadIO: IO[CompletedUpload] = new UploadService(graphQlConfig).uploadDraftMetadata("test-draft-metadata-bucket", "draft-metadata.csv", "id,code\n12,A", s3client)
+    val putObjectRequestCaptor: ArgumentCaptor[PutObjectRequest] = ArgumentCaptor.forClass(classOf[PutObjectRequest])
+    val requestBodyCaptor: ArgumentCaptor[ByteBuffersAsyncRequestBody] = ArgumentCaptor.forClass(classOf[ByteBuffersAsyncRequestBody])
+    val mockResponse = CompletableFuture.completedFuture(putObjectResponse)
+    doAnswer(_ => mockResponse).when(s3AsyncClient).putObject(putObjectRequestCaptor.capture(), requestBodyCaptor.capture())
+    when(configuration.get[String]("s3.endpoint")).thenReturn("http://localhost:9009")
 
-    completedUploadIO.unsafeRunSync().response().eTag() shouldBe "testEtag"
+    new UploadService(graphQlConfig, applicationConfig)
+      .uploadDraftMetadata("test-draft-metadata-bucket", "draft-metadata.csv", "id,code\n12,A", s3AsyncClient)
+
+    putObjectRequestCaptor.getValue.bucket() shouldBe "test-draft-metadata-bucket"
+    putObjectRequestCaptor.getValue.key() shouldBe "draft-metadata.csv"
+    requestBodyCaptor.getValue.contentLength().get() shouldBe 12
   }
 
-  "uploadDraftMetadata" should "return an IO[CompletedUpload] error when unable to save draft metadata " in {
+  "uploadDraftMetadata" should "return error when unable to save draft metadata" in {
+    val s3AsyncClient = mock[S3AsyncClient]
+    val mockResponse = CompletableFuture.failedFuture(new RuntimeException("Failed to upload"))
+    doAnswer(_ => mockResponse).when(s3AsyncClient).putObject(any[PutObjectRequest], any[ByteBuffersAsyncRequestBody])
+    when(configuration.get[String]("s3.endpoint")).thenReturn("http://localhost:9009")
 
-    val s3Client = S3AsyncClient
-      .crtBuilder()
-      .region(Region.EU_WEST_2)
-      .credentialsProvider(new AwsCredentialsProvider {
-        override def resolveCredentials(): AwsCredentials = new AwsCredentials {
-          override def accessKeyId(): String = "accessKeyId"
-          override def secretAccessKey(): String = "secretAccessKey"
-        }
-      })
-      .targetThroughputInGbps(20.0)
-      .minimumPartSizeInBytes(10 * 1024 * 1024)
-      .build()
-
-    val daS3client = DAS3Client[IO](s3Client)
-    val completedUploadIO: IO[CompletedUpload] =
-      new UploadService(graphQlConfig).uploadDraftMetadata("test-draft-metadata-bucket", "draft-metadata.csv", "id,code\n12,A", daS3client)
-
-    completedUploadIO.recoverWith(error => IO(error.toString)).unsafeRunSync().toString should include("S3Exception")
+    val response = new UploadService(graphQlConfig, applicationConfig)
+      .uploadDraftMetadata("test-draft-metadata-bucket", "draft-metadata.csv", "id,code\n12,A", s3AsyncClient)
+      .failed
+      .futureValue
+    response.getMessage shouldBe "Failed to upload"
   }
-
 }


### PR DESCRIPTION
'da-s3-client' library does not work from an ECS task

Reverting to the 's3-utils' library which does work from an ECS task