### PR TITLE
[TDRD 398] DTA Review Transfers Resume

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ development environment for the other TDR services.
   - Set the Tasks parameter to `run`
   - Configure the environment variables:
     - AUTH_SECRET=\<the secret for the Keycloak client that you copied above\>
+    - READ_AUTH_SECRET=\<follow the steps above for obtaining `AUTH_SECRET`, but using parameter key `/intg/keycloak/user_read_client/secret`\>
     - NOTIFICATION_SNS_TOPIC_ARN=\<the arn for sns topic for slack notifications you obtained above>
+    - AWS_PROFILE=<the name of your AWS CLI profile logged into integration>
 - Follow the Static Assets steps below to build the CSS and JS
 - Run the project from IntelliJ
 - Visit `http://localhost:9000`

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ development environment for the other TDR services.
 - In IntelliJ, create a new sbt run configuration:
   - Set the Tasks parameter to `run`
   - Configure the environment variables:
+    - AUTH_URL=https://auth.tdr-integration.nationalarchives.gov.uk
     - AUTH_SECRET=\<the secret for the Keycloak client that you copied above\>
     - READ_AUTH_SECRET=\<follow the steps above for obtaining `AUTH_SECRET`, but using parameter key `/intg/keycloak/user_read_client/secret`\>
     - NOTIFICATION_SNS_TOPIC_ARN=\<the arn for sns topic for slack notifications you obtained above>

--- a/app/controllers/MetadataReviewActionController.scala
+++ b/app/controllers/MetadataReviewActionController.scala
@@ -12,7 +12,16 @@ import play.api.data.Forms._
 import play.api.i18n.I18nSupport
 import play.api.mvc.{request, _}
 import services.MessagingService.MetadataReviewSubmittedEvent
-import services.Statuses.{ClosureMetadataType, CompletedValue, CompletedWithIssuesValue, DescriptiveMetadataType, DraftMetadataType, InProgressValue, IncompleteValue, MetadataReviewType}
+import services.Statuses.{
+  ClosureMetadataType,
+  CompletedValue,
+  CompletedWithIssuesValue,
+  DescriptiveMetadataType,
+  DraftMetadataType,
+  InProgressValue,
+  IncompleteValue,
+  MetadataReviewType
+}
 import services.{ConsignmentService, ConsignmentStatusService, MessagingService}
 
 import java.util.UUID
@@ -47,7 +56,7 @@ class MetadataReviewActionController @Inject() (
     val errorFunction: Form[SelectedStatusData] => Future[Result] = { formWithErrors: Form[SelectedStatusData] =>
       getConsignmentMetadataDetails(consignmentId, request, BadRequest, formWithErrors)
     }
-    
+
     val successFunction: SelectedStatusData => Future[Result] = { formData: SelectedStatusData =>
       logger.info(s"TNA user: ${request.token.userId} has set consignment: $consignmentId to ${formData.statusId}")
       for {
@@ -124,11 +133,14 @@ class MetadataReviewActionController @Inject() (
 object MetadataReviewActionController {
   def consignmentStatusUpdates(formData: SelectedStatusData): Seq[(String, String)] = {
     val metadataReviewStatusUpdate = (MetadataReviewType.id, formData.statusId)
-    val metadataStatusResets = if (formData.statusId == CompletedWithIssuesValue.value) Seq(
-      (DescriptiveMetadataType.id, IncompleteValue.value),
-      (ClosureMetadataType.id, IncompleteValue.value),
-      (DraftMetadataType.id, InProgressValue.value)
-    ) else Seq.empty
+    val metadataStatusResets =
+      if (formData.statusId == CompletedWithIssuesValue.value)
+        Seq(
+          (DescriptiveMetadataType.id, IncompleteValue.value),
+          (ClosureMetadataType.id, IncompleteValue.value),
+          (DraftMetadataType.id, InProgressValue.value)
+        )
+      else Seq.empty
     Seq(metadataReviewStatusUpdate) ++ metadataStatusResets
   }
 }

--- a/app/controllers/MetadataReviewActionController.scala
+++ b/app/controllers/MetadataReviewActionController.scala
@@ -2,6 +2,7 @@ package controllers
 
 import auth.TokenSecurity
 import configuration.KeycloakConfiguration
+import controllers.MetadataReviewActionController.consignmentStatusUpdates
 import controllers.util.{DropdownField, InputNameAndValue}
 import graphql.codegen.types.ConsignmentStatusInput
 import org.pac4j.play.scala.SecurityComponents
@@ -9,9 +10,9 @@ import play.api.Logging
 import play.api.data.Form
 import play.api.data.Forms._
 import play.api.i18n.I18nSupport
-import play.api.mvc._
+import play.api.mvc.{request, _}
 import services.MessagingService.MetadataReviewSubmittedEvent
-import services.Statuses.{CompletedValue, CompletedWithIssuesValue, MetadataReviewType}
+import services.Statuses.{ClosureMetadataType, CompletedValue, CompletedWithIssuesValue, DescriptiveMetadataType, DraftMetadataType, InProgressValue, IncompleteValue, MetadataReviewType}
 import services.{ConsignmentService, ConsignmentStatusService, MessagingService}
 
 import java.util.UUID
@@ -46,13 +47,17 @@ class MetadataReviewActionController @Inject() (
     val errorFunction: Form[SelectedStatusData] => Future[Result] = { formWithErrors: Form[SelectedStatusData] =>
       getConsignmentMetadataDetails(consignmentId, request, BadRequest, formWithErrors)
     }
-
+    
     val successFunction: SelectedStatusData => Future[Result] = { formData: SelectedStatusData =>
       logger.info(s"TNA user: ${request.token.userId} has set consignment: $consignmentId to ${formData.statusId}")
       for {
-        _ <- consignmentStatusService.updateConsignmentStatus(
-          ConsignmentStatusInput(consignmentId, MetadataReviewType.id, Some(formData.statusId)),
-          request.token.bearerAccessToken
+        _ <- Future.sequence(
+          consignmentStatusUpdates(formData).map { case (statusType, statusValue) =>
+            consignmentStatusService.updateConsignmentStatus(
+              ConsignmentStatusInput(consignmentId, statusType, Some(statusValue)),
+              request.token.bearerAccessToken
+            )
+          }
         )
       } yield {
         messagingService.sendMetadataReviewSubmittedNotification(
@@ -113,6 +118,18 @@ class MetadataReviewActionController @Inject() (
   private def generateUrlLink(request: Request[AnyContent], route: String): String = {
     val baseUrl = if (request.secure) "https" else "http"
     baseUrl + "://" + request.host + route
+  }
+}
+
+object MetadataReviewActionController {
+  def consignmentStatusUpdates(formData: SelectedStatusData): Seq[(String, String)] = {
+    val metadataReviewStatusUpdate = (MetadataReviewType.id, formData.statusId)
+    val metadataStatusResets = if (formData.statusId == CompletedWithIssuesValue.value) Seq(
+      (DescriptiveMetadataType.id, IncompleteValue.value),
+      (ClosureMetadataType.id, IncompleteValue.value),
+      (DraftMetadataType.id, InProgressValue.value)
+    ) else Seq.empty
+    Seq(metadataReviewStatusUpdate) ++ metadataStatusResets
   }
 }
 

--- a/app/controllers/MetadataReviewActionController.scala
+++ b/app/controllers/MetadataReviewActionController.scala
@@ -10,7 +10,7 @@ import play.api.Logging
 import play.api.data.Form
 import play.api.data.Forms._
 import play.api.i18n.I18nSupport
-import play.api.mvc.{request, _}
+import play.api.mvc. _
 import services.MessagingService.MetadataReviewSubmittedEvent
 import services.Statuses.{
   ClosureMetadataType,

--- a/app/controllers/MetadataReviewActionController.scala
+++ b/app/controllers/MetadataReviewActionController.scala
@@ -10,7 +10,7 @@ import play.api.Logging
 import play.api.data.Form
 import play.api.data.Forms._
 import play.api.i18n.I18nSupport
-import play.api.mvc. _
+import play.api.mvc._
 import services.MessagingService.MetadataReviewSubmittedEvent
 import services.Statuses.{
   ClosureMetadataType,

--- a/app/controllers/MetadataReviewActionController.scala
+++ b/app/controllers/MetadataReviewActionController.scala
@@ -136,8 +136,8 @@ object MetadataReviewActionController {
     val metadataStatusResets =
       if (formData.statusId == CompletedWithIssuesValue.value)
         Seq(
-          (DescriptiveMetadataType.id, InProgress.value),
-          (ClosureMetadataType.id, InProgress.value),
+          (DescriptiveMetadataType.id, InProgressValue.value),
+          (ClosureMetadataType.id, InProgressValue.value),
           (DraftMetadataType.id, InProgressValue.value)
         )
       else Seq.empty

--- a/app/controllers/MetadataReviewActionController.scala
+++ b/app/controllers/MetadataReviewActionController.scala
@@ -136,8 +136,8 @@ object MetadataReviewActionController {
     val metadataStatusResets =
       if (formData.statusId == CompletedWithIssuesValue.value)
         Seq(
-          (DescriptiveMetadataType.id, IncompleteValue.value),
-          (ClosureMetadataType.id, IncompleteValue.value),
+          (DescriptiveMetadataType.id, InProgress.value),
+          (ClosureMetadataType.id, InProgress.value),
           (DraftMetadataType.id, InProgressValue.value)
         )
       else Seq.empty

--- a/app/controllers/MetadataReviewStatusController.scala
+++ b/app/controllers/MetadataReviewStatusController.scala
@@ -28,36 +28,9 @@ class MetadataReviewStatusController @Inject() (
         consignmentStatus <- consignmentStatusService.consignmentStatusSeries(consignmentId, request.token.bearerAccessToken)
         reviewStatus = consignmentStatus.flatMap(s => consignmentStatusService.getStatusValues(s.consignmentStatuses, MetadataReviewType).values.headOption.flatten)
         reference <- consignmentService.getConsignmentRef(consignmentId, request.token.bearerAccessToken)
-        result <- reviewStatus match {
-          case Some(InProgressValue.value) | Some(CompletedValue.value) | Some(CompletedWithIssuesValue.value) =>
-            Future(
-              Ok(views.html.standard.metadataReviewStatus(consignmentId, reference, request.token.name, request.token.email, reviewStatus.get))
-            )
-          case None =>
-            Future(Ok(views.html.notFoundError(name = request.token.name, isLoggedIn = true, isJudgmentUser = false)))
-          case _ =>
-            throw new IllegalStateException(s"Unexpected review status: $reviewStatus for consignment $consignmentId")
-        }
-      } yield result
-    }
-  }
-
-  def metadataReviewActionRequired(consignmentId: UUID): Action[AnyContent] = standardTypeAction(consignmentId) { implicit request: Request[AnyContent] =>
-    for {
-      _ <- consignmentStatusService.updateConsignmentStatus(
-        ConsignmentStatusInput(consignmentId, DescriptiveMetadataType.id, Some(InProgressValue.value)),
-        request.token.bearerAccessToken
-      )
-      _ <- consignmentStatusService.updateConsignmentStatus(
-        ConsignmentStatusInput(consignmentId, ClosureMetadataType.id, Some(InProgressValue.value)),
-        request.token.bearerAccessToken
-      )
-      _ <- consignmentStatusService.updateConsignmentStatus(
-        ConsignmentStatusInput(consignmentId, DraftMetadataType.id, Some(InProgressValue.value)),
-        request.token.bearerAccessToken
-      )
-    } yield {
-      Redirect(routes.AdditionalMetadataController.start(consignmentId))
+      } yield reviewStatus
+        .map(status => Ok(views.html.standard.metadataReviewStatus(consignmentId, reference, request.token.name, request.token.email, status)))
+        .getOrElse(Ok(views.html.notFoundError(name = request.token.name, isLoggedIn = true, isJudgmentUser = false)))
     }
   }
 }

--- a/app/controllers/ViewTransfersController.scala
+++ b/app/controllers/ViewTransfersController.scala
@@ -88,7 +88,7 @@ class ViewTransfersController @Inject() (
       case s if s.containsStatuses(ExportType) => toExportAction(s.find(_.statusType == ExportType.id).get, judgmentType, consignmentId, consignmentRef)
       case s if s.statusValue(ConfirmTransferType).contains(CompletedValue.value) =>
         UserAction(InProgress.value, routes.TransferCompleteController.transferComplete(consignmentId).url, Resume.value)
-      case s if s.containsStatuses(MetadataReviewType) =>
+      case s if s.containsStatuses(MetadataReviewType) && !applicationConfig.blockMetadataReview =>
         UserAction(InProgress.value, routes.MetadataReviewStatusController.metadataReviewStatusPage(consignmentId).url, Resume.value)
       case s if additionalMetadataEntered(s) =>
         UserAction(InProgress.value, routes.AdditionalMetadataController.start(consignmentId).url, Resume.value)

--- a/app/controllers/ViewTransfersController.scala
+++ b/app/controllers/ViewTransfersController.scala
@@ -88,6 +88,8 @@ class ViewTransfersController @Inject() (
       case s if s.containsStatuses(ExportType) => toExportAction(s.find(_.statusType == ExportType.id).get, judgmentType, consignmentId, consignmentRef)
       case s if s.statusValue(ConfirmTransferType).contains(CompletedValue.value) =>
         UserAction(InProgress.value, routes.TransferCompleteController.transferComplete(consignmentId).url, Resume.value)
+      case s if s.containsStatuses(MetadataReviewType) =>
+        UserAction(InProgress.value, routes.MetadataReviewStatusController.metadataReviewStatusPage(consignmentId).url, Resume.value)
       case s if additionalMetadataEntered(s) =>
         UserAction(InProgress.value, routes.AdditionalMetadataController.start(consignmentId).url, Resume.value)
       case s if s.containsStatuses(ServerAntivirusType, ServerChecksumType, ServerFFIDType) =>

--- a/app/views/partials/metadataReviewFailure.scala.html
+++ b/app/views/partials/metadataReviewFailure.scala.html
@@ -29,12 +29,9 @@
 
     @downloadMetadataLink(consignmentId)
 
+<div class="govuk-button-group">
+    <a class="govuk-button" href="@routes.AdditionalMetadataController.start(consignmentId)" role="button" draggable="false" data-module="govuk-button">
+        Continue
+    </a>
+</div>
 
-    @form(routes.MetadataReviewStatusController.metadataReviewActionRequired(consignmentId), (Symbol("novalidate"), "")) {
-        @CSRF.formField
-        <div class="govuk-button-group">
-            <button data-prevent-double-click="true" class="govuk-button" type="submit" data-module="govuk-button" role="button">
-                Continue
-            </button>
-        </div>
-    }

--- a/conf/routes
+++ b/conf/routes
@@ -36,7 +36,6 @@ GET         /consignment/:consignmentId/draft-metadata/checks-results           
 GET         /consignment/:consignmentId/metadata-review/request                                          controllers.RequestMetadataReviewController.requestMetadataReviewPage(consignmentId: java.util.UUID)
 POST        /consignment/:consignmentId/metadata-review/request                                          controllers.RequestMetadataReviewController.submitMetadataForReview(consignmentId: java.util.UUID)
 GET         /consignment/:consignmentId/metadata-review/review-progress                                  controllers.MetadataReviewStatusController.metadataReviewStatusPage(consignmentId: java.util.UUID)
-POST        /consignment/:consignmentId/metadata-review/review-progress                                  controllers.MetadataReviewStatusController.metadataReviewActionRequired(consignmentId: java.util.UUID)
 GET         /consignment/:consignmentId/additional-metadata/entry-method                                 controllers.AdditionalMetadataEntryMethodController.additionalMetadataEntryMethodPage(consignmentId: java.util.UUID)
 POST        /consignment/:consignmentId/additional-metadata/entry-method                                 controllers.AdditionalMetadataEntryMethodController.submitAdditionalMetadataEntryMethod(consignmentId: java.util.UUID)
 GET         /consignment/:consignmentId/additional-metadata                                              controllers.AdditionalMetadataController.start(consignmentId: java.util.UUID)

--- a/test/controllers/MetadataReviewActionControllerSpec.scala
+++ b/test/controllers/MetadataReviewActionControllerSpec.scala
@@ -18,7 +18,16 @@ import play.api.test.CSRFTokenHelper._
 import play.api.test.FakeRequest
 import play.api.test.Helpers.{status, status => playStatus, _}
 import services.MessagingService.MetadataReviewSubmittedEvent
-import services.Statuses.{ClosureMetadataType, CompletedValue, CompletedWithIssuesValue, DescriptiveMetadataType, DraftMetadataType, InProgressValue, IncompleteValue, MetadataReviewType}
+import services.Statuses.{
+  ClosureMetadataType,
+  CompletedValue,
+  CompletedWithIssuesValue,
+  DescriptiveMetadataType,
+  DraftMetadataType,
+  InProgressValue,
+  IncompleteValue,
+  MetadataReviewType
+}
 import services.{ConsignmentService, ConsignmentStatusService, MessagingService}
 import testUtils.{CheckPageForStaticElements, FrontEndTestHelper}
 
@@ -100,11 +109,13 @@ class MetadataReviewActionControllerSpec extends FrontEndTestHelper {
       playStatus(reviewSubmit) mustBe SEE_OTHER
       redirectLocation(reviewSubmit) must be(Some(s"/admin/metadata-review"))
       verify(messagingService, times(1)).sendMetadataReviewSubmittedNotification(argThat(metadataReviewDecisionEventMatcher))
-      
-      wiremockServer.verify(postRequestedFor(urlEqualTo("/graphql"))
-        .withRequestBody(containing("updateConsignmentStatus"))
-        .withRequestBody(containing("MetadataReview"))
-        .withRequestBody(containing("Completed")))
+
+      wiremockServer.verify(
+        postRequestedFor(urlEqualTo("/graphql"))
+          .withRequestBody(containing("updateConsignmentStatus"))
+          .withRequestBody(containing("MetadataReview"))
+          .withRequestBody(containing("Completed"))
+      )
     }
 
     "Update the consignment metadata review status, reset metadata statuses and send MetadataReviewSubmittedEvent message when a valid form is submitted with a rejected review and the api response is successful" in {
@@ -113,7 +124,7 @@ class MetadataReviewActionControllerSpec extends FrontEndTestHelper {
 
       // Custom ArgumentMatcher to match the event based on the consignment reference, path, userEmail and status
       class MetadataReviewSubmittedEventMatcher(expectedConsignmentRef: String, expectedPath: String, expectedEmail: String, expectedStatus: String)
-        extends ArgumentMatcher[MetadataReviewSubmittedEvent] {
+          extends ArgumentMatcher[MetadataReviewSubmittedEvent] {
         override def matches(event: MetadataReviewSubmittedEvent): Boolean = {
           event.consignmentReference == expectedConsignmentRef && event.urlLink.contains(expectedPath) && event.userEmail == expectedEmail && event.status == expectedStatus
         }
@@ -132,26 +143,34 @@ class MetadataReviewActionControllerSpec extends FrontEndTestHelper {
       wiremockServer.getAllServeEvents.forEach { e =>
         println(e.getRequest.toString)
       }
-      
-      wiremockServer.verify(postRequestedFor(urlEqualTo("/graphql"))
-        .withRequestBody(containing("updateConsignmentStatus"))
-        .withRequestBody(containing("MetadataReview"))
-        .withRequestBody(containing("CompletedWithIssues")))
 
-      wiremockServer.verify(postRequestedFor(urlEqualTo("/graphql"))
-        .withRequestBody(containing("updateConsignmentStatus"))
-        .withRequestBody(containing("DescriptiveMetadata"))
-        .withRequestBody(containing("Incomplete")))
+      wiremockServer.verify(
+        postRequestedFor(urlEqualTo("/graphql"))
+          .withRequestBody(containing("updateConsignmentStatus"))
+          .withRequestBody(containing("MetadataReview"))
+          .withRequestBody(containing("CompletedWithIssues"))
+      )
 
-      wiremockServer.verify(postRequestedFor(urlEqualTo("/graphql"))
-        .withRequestBody(containing("updateConsignmentStatus"))
-        .withRequestBody(containing("ClosureMetadata"))
-        .withRequestBody(containing("Incomplete")))
+      wiremockServer.verify(
+        postRequestedFor(urlEqualTo("/graphql"))
+          .withRequestBody(containing("updateConsignmentStatus"))
+          .withRequestBody(containing("DescriptiveMetadata"))
+          .withRequestBody(containing("Incomplete"))
+      )
 
-      wiremockServer.verify(postRequestedFor(urlEqualTo("/graphql"))
-        .withRequestBody(containing("updateConsignmentStatus"))
-        .withRequestBody(containing("DraftMetadata"))
-        .withRequestBody(containing("InProgress")))
+      wiremockServer.verify(
+        postRequestedFor(urlEqualTo("/graphql"))
+          .withRequestBody(containing("updateConsignmentStatus"))
+          .withRequestBody(containing("ClosureMetadata"))
+          .withRequestBody(containing("Incomplete"))
+      )
+
+      wiremockServer.verify(
+        postRequestedFor(urlEqualTo("/graphql"))
+          .withRequestBody(containing("updateConsignmentStatus"))
+          .withRequestBody(containing("DraftMetadata"))
+          .withRequestBody(containing("InProgress"))
+      )
     }
 
     "display errors when an invalid form is submitted" in {

--- a/test/controllers/MetadataReviewActionControllerSpec.scala
+++ b/test/controllers/MetadataReviewActionControllerSpec.scala
@@ -242,8 +242,8 @@ class MetadataReviewActionControllerSpec extends FrontEndTestHelper {
 
       result mustBe Seq(
         (MetadataReviewType.id, CompletedWithIssuesValue.value),
-        (DescriptiveMetadataType.id, InProgress.value),
-        (ClosureMetadataType.id, InProgress.value),
+        (DescriptiveMetadataType.id, InProgressValue.value),
+        (ClosureMetadataType.id, InProgressValue.value),
         (DraftMetadataType.id, InProgressValue.value)
       )
     }

--- a/test/controllers/MetadataReviewActionControllerSpec.scala
+++ b/test/controllers/MetadataReviewActionControllerSpec.scala
@@ -3,6 +3,7 @@ package controllers
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock._
 import configuration.{GraphQLConfiguration, KeycloakConfiguration}
+import controllers.MetadataReviewActionController.consignmentStatusUpdates
 import graphql.codegen.GetConsignmentDetailsForMetadataReview.getConsignmentDetailsForMetadataReview
 import io.circe.Printer
 import io.circe.generic.auto._
@@ -17,7 +18,7 @@ import play.api.test.CSRFTokenHelper._
 import play.api.test.FakeRequest
 import play.api.test.Helpers.{status, status => playStatus, _}
 import services.MessagingService.MetadataReviewSubmittedEvent
-import services.Statuses.CompletedValue
+import services.Statuses.{ClosureMetadataType, CompletedValue, CompletedWithIssuesValue, DescriptiveMetadataType, DraftMetadataType, InProgressValue, IncompleteValue, MetadataReviewType}
 import services.{ConsignmentService, ConsignmentStatusService, MessagingService}
 import testUtils.{CheckPageForStaticElements, FrontEndTestHelper}
 
@@ -43,6 +44,10 @@ class MetadataReviewActionControllerSpec extends FrontEndTestHelper {
   }
 
   val checkPageForStaticElements = new CheckPageForStaticElements
+
+  val consignmentRef = "TDR-TEST-2024"
+  val userEmail = "test@test.com"
+  val expectedPath = s"/consignment/$consignmentId/metadata-review/review-progress"
 
   "MetadataReviewActionController GET" should {
 
@@ -74,12 +79,9 @@ class MetadataReviewActionControllerSpec extends FrontEndTestHelper {
       status(response) mustBe FORBIDDEN
     }
 
-    "Update the consignment status and send MetadataReviewSubmittedEvent message when a valid form is submitted and the api response is successful" in {
+    "Update the metadata review consignment status and send MetadataReviewSubmittedEvent message when a valid form is submitted with an accepted review and the api response is successful" in {
       val controller = instantiateMetadataReviewActionController(getAuthorisedSecurityComponents, getValidTNAUserKeycloakConfiguration)
-      val consignmentRef = "TDR-TEST-2024"
-      val userEmail = "test@test.com"
       val status = CompletedValue.value
-      val expectedPath = s"/consignment/$consignmentId/metadata-review/review-progress"
 
       // Custom ArgumentMatcher to match the event based on the consignment reference, path, userEmail and status
       class MetadataReviewSubmittedEventMatcher(expectedConsignmentRef: String, expectedPath: String, expectedEmail: String, expectedStatus: String)
@@ -98,6 +100,58 @@ class MetadataReviewActionControllerSpec extends FrontEndTestHelper {
       playStatus(reviewSubmit) mustBe SEE_OTHER
       redirectLocation(reviewSubmit) must be(Some(s"/admin/metadata-review"))
       verify(messagingService, times(1)).sendMetadataReviewSubmittedNotification(argThat(metadataReviewDecisionEventMatcher))
+      
+      wiremockServer.verify(postRequestedFor(urlEqualTo("/graphql"))
+        .withRequestBody(containing("updateConsignmentStatus"))
+        .withRequestBody(containing("MetadataReview"))
+        .withRequestBody(containing("Completed")))
+    }
+
+    "Update the consignment metadata review status, reset metadata statuses and send MetadataReviewSubmittedEvent message when a valid form is submitted with a rejected review and the api response is successful" in {
+      val controller = instantiateMetadataReviewActionController(getAuthorisedSecurityComponents, getValidTNAUserKeycloakConfiguration)
+      val status = CompletedWithIssuesValue.value
+
+      // Custom ArgumentMatcher to match the event based on the consignment reference, path, userEmail and status
+      class MetadataReviewSubmittedEventMatcher(expectedConsignmentRef: String, expectedPath: String, expectedEmail: String, expectedStatus: String)
+        extends ArgumentMatcher[MetadataReviewSubmittedEvent] {
+        override def matches(event: MetadataReviewSubmittedEvent): Boolean = {
+          event.consignmentReference == expectedConsignmentRef && event.urlLink.contains(expectedPath) && event.userEmail == expectedEmail && event.status == expectedStatus
+        }
+      }
+
+      val metadataReviewDecisionEventMatcher = new MetadataReviewSubmittedEventMatcher(consignmentRef, expectedPath, userEmail, status)
+
+      setUpdateConsignmentStatus(wiremockServer)
+
+      val reviewSubmit =
+        controller.submitReview(consignmentId, consignmentRef, userEmail).apply(FakeRequest().withFormUrlEncodedBody(("status", status)).withCSRFToken)
+      playStatus(reviewSubmit) mustBe SEE_OTHER
+      redirectLocation(reviewSubmit) must be(Some(s"/admin/metadata-review"))
+      verify(messagingService, times(1)).sendMetadataReviewSubmittedNotification(argThat(metadataReviewDecisionEventMatcher))
+
+      wiremockServer.getAllServeEvents.forEach { e =>
+        println(e.getRequest.toString)
+      }
+      
+      wiremockServer.verify(postRequestedFor(urlEqualTo("/graphql"))
+        .withRequestBody(containing("updateConsignmentStatus"))
+        .withRequestBody(containing("MetadataReview"))
+        .withRequestBody(containing("CompletedWithIssues")))
+
+      wiremockServer.verify(postRequestedFor(urlEqualTo("/graphql"))
+        .withRequestBody(containing("updateConsignmentStatus"))
+        .withRequestBody(containing("DescriptiveMetadata"))
+        .withRequestBody(containing("Incomplete")))
+
+      wiremockServer.verify(postRequestedFor(urlEqualTo("/graphql"))
+        .withRequestBody(containing("updateConsignmentStatus"))
+        .withRequestBody(containing("ClosureMetadata"))
+        .withRequestBody(containing("Incomplete")))
+
+      wiremockServer.verify(postRequestedFor(urlEqualTo("/graphql"))
+        .withRequestBody(containing("updateConsignmentStatus"))
+        .withRequestBody(containing("DraftMetadata"))
+        .withRequestBody(containing("InProgress")))
     }
 
     "display errors when an invalid form is submitted" in {
@@ -160,6 +214,29 @@ class MetadataReviewActionControllerSpec extends FrontEndTestHelper {
         .withRequestBody(containing("getConsignmentDetailsForMetadataReview"))
         .willReturn(okJson(dataString))
     )
+  }
+
+  "consignmentStatusUpdates" should {
+    "return correct updates when status is CompletedWithIssues" in {
+      val formData = SelectedStatusData(CompletedWithIssuesValue.value)
+      val result = consignmentStatusUpdates(formData)
+
+      result mustBe Seq(
+        (MetadataReviewType.id, CompletedWithIssuesValue.value),
+        (DescriptiveMetadataType.id, IncompleteValue.value),
+        (ClosureMetadataType.id, IncompleteValue.value),
+        (DraftMetadataType.id, InProgressValue.value)
+      )
+    }
+
+    "return only metadata review status update when status is Completed" in {
+      val formData = SelectedStatusData(CompletedValue.value)
+      val result = consignmentStatusUpdates(formData)
+
+      result mustBe Seq(
+        (MetadataReviewType.id, CompletedValue.value)
+      )
+    }
   }
 
   private def checkForExpectedMetadataReviewActionPageContent(pageAsString: String): Unit = {

--- a/test/controllers/MetadataReviewActionControllerSpec.scala
+++ b/test/controllers/MetadataReviewActionControllerSpec.scala
@@ -155,14 +155,14 @@ class MetadataReviewActionControllerSpec extends FrontEndTestHelper {
         postRequestedFor(urlEqualTo("/graphql"))
           .withRequestBody(containing("updateConsignmentStatus"))
           .withRequestBody(containing("DescriptiveMetadata"))
-          .withRequestBody(containing("Incomplete"))
+          .withRequestBody(containing("InProgress"))
       )
 
       wiremockServer.verify(
         postRequestedFor(urlEqualTo("/graphql"))
           .withRequestBody(containing("updateConsignmentStatus"))
           .withRequestBody(containing("ClosureMetadata"))
-          .withRequestBody(containing("Incomplete"))
+          .withRequestBody(containing("InProgress"))
       )
 
       wiremockServer.verify(
@@ -242,8 +242,8 @@ class MetadataReviewActionControllerSpec extends FrontEndTestHelper {
 
       result mustBe Seq(
         (MetadataReviewType.id, CompletedWithIssuesValue.value),
-        (DescriptiveMetadataType.id, IncompleteValue.value),
-        (ClosureMetadataType.id, IncompleteValue.value),
+        (DescriptiveMetadataType.id, InProgress.value),
+        (ClosureMetadataType.id, InProgress.value),
         (DraftMetadataType.id, InProgressValue.value)
       )
     }

--- a/test/controllers/MetadataReviewStatusControllerSpec.scala
+++ b/test/controllers/MetadataReviewStatusControllerSpec.scala
@@ -135,13 +135,13 @@ class MetadataReviewStatusControllerSpec extends FrontEndTestHelper {
       )
 
       metadataReviewStatusPageAsString must include(downloadLinkHTML(consignmentId))
-      metadataReviewStatusPageAsString must include(s"""<form action="/consignment/$consignmentId/metadata-review/review-progress" method="POST" novalidate="">""")
       metadataReviewStatusPageAsString must include(
-        s"""<div class="govuk-button-group">
-           |            <button data-prevent-double-click="true" class="govuk-button" type="submit" data-module="govuk-button" role="button">
-           |                Continue
-           |            </button>
-           |        </div>""".stripMargin
+        s"""
+           |<div class="govuk-button-group">
+           |    <a class="govuk-button" href="/consignment/$consignmentId/additional-metadata" role="button" draggable="false" data-module="govuk-button">
+           |        Continue
+           |    </a>
+           |</div>""".stripMargin
       )
 
       checkPageForStaticElements.checkContentOfPagesThatUseMainScala(metadataReviewStatusPageAsString, userType = "standard")
@@ -234,26 +234,8 @@ class MetadataReviewStatusControllerSpec extends FrontEndTestHelper {
 
       playStatus(page) mustBe FORBIDDEN
     }
-
   }
-
-  "metadataReviewStatusPage POST" should {
-    "update the status and redirect to the File Check Results page with an authenticated user" in {
-      val consignmentId = UUID.randomUUID()
-      setConsignmentTypeResponse(wiremockServer, "standard")
-      setUpdateConsignmentStatus(wiremockServer)
-
-      val controller = instantiateMetadataReviewStatusController(getAuthorisedSecurityComponents, getValidStandardUserKeycloakConfiguration)
-      val metadataReviewStatusPage = controller
-        .metadataReviewActionRequired(consignmentId)
-        .apply(FakeRequest(POST, s"/consignment/$consignmentId/metadata-review/review-progress"))
-
-      playStatus(metadataReviewStatusPage) mustBe SEE_OTHER
-      redirectLocation(metadataReviewStatusPage).get must equal(s"/consignment/$consignmentId/additional-metadata")
-
-    }
-  }
-
+  
   private def instantiateMetadataReviewStatusController(
       securityComponents: SecurityComponents,
       keycloakConfiguration: KeycloakConfiguration = getValidStandardUserKeycloakConfiguration,
@@ -279,5 +261,4 @@ class MetadataReviewStatusControllerSpec extends FrontEndTestHelper {
        |""".stripMargin
     linkHTML
   }
-
 }

--- a/test/controllers/MetadataReviewStatusControllerSpec.scala
+++ b/test/controllers/MetadataReviewStatusControllerSpec.scala
@@ -235,7 +235,7 @@ class MetadataReviewStatusControllerSpec extends FrontEndTestHelper {
       playStatus(page) mustBe FORBIDDEN
     }
   }
-  
+
   private def instantiateMetadataReviewStatusController(
       securityComponents: SecurityComponents,
       keycloakConfiguration: KeycloakConfiguration = getValidStandardUserKeycloakConfiguration,

--- a/test/testUtils/ConsignmentStatusesOptions.scala
+++ b/test/testUtils/ConsignmentStatusesOptions.scala
@@ -43,9 +43,13 @@ object ConsignmentStatusesOptions {
   private val ffidCompleted: Map[StatusType, StatusValue] = Map(ServerFFIDType -> CompletedValue)
   private val descriptiveMetadataNotEntered: Map[StatusType, StatusValue] = Map(DescriptiveMetadataType -> NotEnteredValue)
   private val descriptiveMetadataEntered: Map[StatusType, StatusValue] = Map(DescriptiveMetadataType -> EnteredValue)
+  private val descriptiveMetadataComplete: Map[StatusType, StatusValue] = Map(DescriptiveMetadataType -> CompletedValue)
   private val closureMetadataNotEntered: Map[StatusType, StatusValue] = Map(ClosureMetadataType -> NotEnteredValue)
   private val closureMetadataIncomplete: Map[StatusType, StatusValue] = Map(ClosureMetadataType -> IncompleteValue)
   private val closureMetadataComplete: Map[StatusType, StatusValue] = Map(ClosureMetadataType -> CompletedValue)
+  private val metadataReviewInProgress: Map[StatusType, StatusValue] = Map(MetadataReviewType -> InProgressValue)
+  private val metadataReviewCompleted: Map[StatusType, StatusValue] = Map(MetadataReviewType -> CompletedValue)
+  private val metadataReviewCompletedWithIssues: Map[StatusType, StatusValue] = Map(MetadataReviewType -> CompletedWithIssuesValue)
   private val confirmCompleted: Map[StatusType, StatusValue] = Map(ConfirmTransferType -> CompletedValue)
   private val exportInProgress: Map[StatusType, StatusValue] = Map(ExportType -> InProgressValue)
   private val exportFailed: Map[StatusType, StatusValue] = Map(ExportType -> FailedValue)
@@ -324,6 +328,46 @@ object ConsignmentStatusesOptions {
       "Resume transfer"
     ),
     (
+      "descriptive and closure metadata complete",
+      generateStatuses(
+        seriesCompleted ++ taCompleted ++ clientChecksCompleted ++ uploadCompleted ++ antivirusCompleted ++ checksumCompleted ++ ffidCompleted ++ descriptiveMetadataComplete ++ closureMetadataComplete,
+        includeDefaultStatuses = false
+      ),
+      "/additional-metadata",
+      "In Progress",
+      "Resume transfer"
+    ),
+    (
+      "metadata review in progress",
+      generateStatuses(
+        seriesCompleted ++ taCompleted ++ clientChecksCompleted ++ uploadCompleted ++ antivirusCompleted ++ checksumCompleted ++ ffidCompleted ++ descriptiveMetadataComplete ++ closureMetadataComplete ++ metadataReviewInProgress,
+        includeDefaultStatuses = false
+      ),
+      "/metadata-review/review-progress",
+      "In Progress",
+      "Resume transfer"
+    ),
+    (
+      "metadata review rejected",
+      generateStatuses(
+        seriesCompleted ++ taCompleted ++ clientChecksCompleted ++ uploadCompleted ++ antivirusCompleted ++ checksumCompleted ++ ffidCompleted ++ descriptiveMetadataComplete ++ closureMetadataComplete ++ metadataReviewCompletedWithIssues,
+        includeDefaultStatuses = false
+      ),
+      "/metadata-review/review-progress",
+      "In Progress",
+      "Resume transfer"
+    ),
+    (
+      "metadata review accepted",
+      generateStatuses(
+        seriesCompleted ++ taCompleted ++ clientChecksCompleted ++ uploadCompleted ++ antivirusCompleted ++ checksumCompleted ++ ffidCompleted ++ descriptiveMetadataComplete ++ closureMetadataComplete ++ metadataReviewCompleted,
+        includeDefaultStatuses = false
+      ),
+      "/metadata-review/review-progress",
+      "In Progress",
+      "Resume transfer"
+    ),
+    (
       "confirm transfer completed with no additional metadata",
       generateStatuses(
         seriesCompleted ++ taCompleted ++ clientChecksCompleted ++ uploadCompleted ++ antivirusCompleted ++ checksumCompleted ++ ffidCompleted ++ confirmCompleted
@@ -345,7 +389,7 @@ object ConsignmentStatusesOptions {
     (
       "confirm transfer completed with descriptive metadata only entered",
       generateStatuses(
-        seriesCompleted ++ taCompleted ++ clientChecksCompleted ++ uploadCompleted ++ antivirusCompleted ++ checksumCompleted ++ ffidCompleted ++ confirmCompleted ++ descriptiveMetadataEntered ++ closureMetadataNotEntered,
+        seriesCompleted ++ taCompleted ++ clientChecksCompleted ++ uploadCompleted ++ antivirusCompleted ++ checksumCompleted ++ ffidCompleted ++ confirmCompleted ++ descriptiveMetadataEntered ++ closureMetadataNotEntered ++ metadataReviewCompleted,
         includeDefaultStatuses = false
       ),
       "/transfer-complete",
@@ -355,7 +399,7 @@ object ConsignmentStatusesOptions {
     (
       "confirm transfer completed with closure metadata only entered",
       generateStatuses(
-        seriesCompleted ++ taCompleted ++ clientChecksCompleted ++ uploadCompleted ++ antivirusCompleted ++ checksumCompleted ++ ffidCompleted ++ confirmCompleted ++ descriptiveMetadataNotEntered ++ closureMetadataComplete,
+        seriesCompleted ++ taCompleted ++ clientChecksCompleted ++ uploadCompleted ++ antivirusCompleted ++ checksumCompleted ++ ffidCompleted ++ confirmCompleted ++ descriptiveMetadataNotEntered ++ closureMetadataComplete ++ metadataReviewCompleted,
         includeDefaultStatuses = false
       ),
       "/transfer-complete",


### PR DESCRIPTION
Including:

- View transfers page link to review status page when metadata review status is present + associated tests
- Small README update with a couple of extra steps to run locally
- Small refactor to make GET in `MetadataReviewStatusController` a little more succinct
- Move status reset logic from the TB facing review status controller to the DTA reviewer decision page (ensuring it is reset only once, rather than potentially being reset each time a TB user revisits their metadata via the View Transfers page)