### PR TITLE
TDRD-717 Fix spacing

### DIFF
--- a/app/views/partials/daAlert.scala.html
+++ b/app/views/partials/daAlert.scala.html
@@ -1,11 +1,10 @@
-@import java.util.UUID
 @(heading: String, content: Html)
 <div class="da-alert da-alert--default">
     <div class="da-alert__content">
         <h2 class="da-alert__heading da-alert__heading--s">
             @heading
         </h2>
-        <p>
+        <p class="govuk-body">
             @content
         </p>
     </div>

--- a/app/views/partials/downloadMetadataLink.scala.html
+++ b/app/views/partials/downloadMetadataLink.scala.html
@@ -1,6 +1,6 @@
 @import java.util.UUID
 @(consignmentId: UUID, linkLabel: String = "Download metadata", url: String)
-<a class="govuk-button govuk-button--secondary govuk-!-margin-bottom-8 download-metadata" href="@url">
+<a class="govuk-button govuk-button--secondary download-metadata" href="@url">
     <span aria-hidden="true" class="tna-button-icon">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 23 23">
             <path fill="#020202" d="m11.5 16.75-6.563-6.563 1.838-1.903 3.412 3.413V1h2.626v10.697l3.412-3.413 1.837 1.903L11.5 16.75ZM3.625 22c-.722 0-1.34-.257-1.853-.77A2.533 2.533 0 0 1 1 19.375v-3.938h2.625v3.938h15.75v-3.938H22v3.938c0 .722-.257 1.34-.77 1.855a2.522 2.522 0 0 1-1.855.77H3.625Z"></path>

--- a/app/views/partials/draftMetadataChecksActionProcess.scala.html
+++ b/app/views/partials/draftMetadataChecksActionProcess.scala.html
@@ -31,7 +31,7 @@
             Action
         </dt>
         <dd class="govuk-summary-list__value">
-            <p>@Html(actionMessage)</p>
+            @Html(actionMessage)
             @if(affectedProperties.nonEmpty) {
                 <ul class="govuk-list govuk-list--bullet">
                     @for(property <- affectedProperties) {

--- a/test/controllers/DownloadMetadataControllerSpec.scala
+++ b/test/controllers/DownloadMetadataControllerSpec.scala
@@ -196,7 +196,7 @@ class DownloadMetadataControllerSpec extends FrontEndTestHelper {
       checkPageForStaticElements.checkContentOfPagesThatUseMainScala(responseAsString, userType = "standard")
       responseAsString must include("""<svg""")
       responseAsString must include(
-        s"""<a class="govuk-button govuk-button--secondary govuk-!-margin-bottom-8 download-metadata" href="/consignment/$consignmentId/additional-metadata/download-metadata/csv">"""
+        s"""<a class="govuk-button govuk-button--secondary download-metadata" href="/consignment/$consignmentId/additional-metadata/download-metadata/csv">"""
       )
       responseAsString must include(s"""<a class="govuk-button" href="/consignment/$consignmentId/confirm-transfer"""")
       responseAsString must include(s"""<a href="/consignment/$consignmentId/additional-metadata/entry-method"""")
@@ -214,7 +214,7 @@ class DownloadMetadataControllerSpec extends FrontEndTestHelper {
       checkPageForStaticElements.checkContentOfPagesThatUseMainScala(responseAsString, userType = "standard")
       responseAsString must include("""<svg""")
       responseAsString must include(
-        s"""<a class="govuk-button govuk-button--secondary govuk-!-margin-bottom-8 download-metadata" href="/consignment/$consignmentId/additional-metadata/download-metadata/csv">"""
+        s"""<a class="govuk-button govuk-button--secondary download-metadata" href="/consignment/$consignmentId/additional-metadata/download-metadata/csv">"""
       )
       responseAsString must include(s"""<a href="/consignment/$consignmentId/metadata-review/request"""")
     }

--- a/test/controllers/DraftMetadataChecksResultsControllerSpec.scala
+++ b/test/controllers/DraftMetadataChecksResultsControllerSpec.scala
@@ -174,7 +174,7 @@ class DraftMetadataChecksResultsControllerSpec extends FrontEndTestHelper {
               |        <h2 class="da-alert__heading da-alert__heading--s">
               |            Leaving and returning to this transfer
               |        </h2>
-              |        <p>
+              |        <p class="govuk-body">
               |            You can sign out and return to continue working on this transfer at any time from <a class='govuk-link' href='/view-transfers'>View transfers</a>.
               |        </p>
               |    </div>
@@ -182,7 +182,7 @@ class DraftMetadataChecksResultsControllerSpec extends FrontEndTestHelper {
               |""".stripMargin
           )
           pageAsString must include(
-            s"""<a class="govuk-button govuk-button--secondary govuk-!-margin-bottom-8 download-metadata" href="/consignment/$consignmentId/draft-metadata/download-report">
+            s"""<a class="govuk-button govuk-button--secondary download-metadata" href="/consignment/$consignmentId/draft-metadata/download-report">
                |    <span aria-hidden="true" class="tna-button-icon">
                |        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 23 23">
                |            <path fill="#020202" d="m11.5 16.75-6.563-6.563 1.838-1.903 3.412 3.413V1h2.626v10.697l3.412-3.413 1.837 1.903L11.5 16.75ZM3.625 22c-.722 0-1.34-.257-1.853-.77A2.533 2.533 0 0 1 1 19.375v-3.938h2.625v3.938h15.75v-3.938H22v3.938c0 .722-.257 1.34-.77 1.855a2.522 2.522 0 0 1-1.855.77H3.625Z"></path>
@@ -264,7 +264,7 @@ class DraftMetadataChecksResultsControllerSpec extends FrontEndTestHelper {
               |        <h2 class="da-alert__heading da-alert__heading--s">
               |            Leaving and returning to this transfer
               |        </h2>
-              |        <p>
+              |        <p class="govuk-body">
               |            You can sign out and return to continue working on this transfer at any time from <a class='govuk-link' href='/view-transfers'>View transfers</a>.
               |        </p>
               |    </div>

--- a/test/testUtils/FrontEndTestHelper.scala
+++ b/test/testUtils/FrontEndTestHelper.scala
@@ -1147,7 +1147,7 @@ trait FrontEndTestHelper extends PlaySpec with MockitoSugar with Injecting with 
     }.toList
 
   def downloadLinkHTML(consignmentId: UUID): String = {
-    val linkHTML: String = s"""<a class="govuk-button govuk-button--secondary govuk-!-margin-bottom-8 download-metadata" href="/consignment/$consignmentId/additional-metadata/download-metadata/csv">
+    val linkHTML: String = s"""<a class="govuk-button govuk-button--secondary download-metadata" href="/consignment/$consignmentId/additional-metadata/download-metadata/csv">
                               |    <span aria-hidden="true" class="tna-button-icon">
                               |        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 23 23">
                               |            <path fill="#020202" d="m11.5 16.75-6.563-6.563 1.838-1.903 3.412 3.413V1h2.626v10.697l3.412-3.413 1.837 1.903L11.5 16.75ZM3.625 22c-.722 0-1.34-.257-1.853-.77A2.533 2.533 0 0 1 1 19.375v-3.938h2.625v3.938h15.75v-3.938H22v3.938c0 .722-.257 1.34-.77 1.855a2.522 2.522 0 0 1-1.855.77H3.625Z"></path>


### PR DESCRIPTION
Fix some spacing to more closely match the prototype 
![Screenshot from 2025-04-03 12-13-37](https://github.com/user-attachments/assets/c34330d4-3283-474d-8a93-cbd466a98070)
I removed the `govuk-!-margin-bottom-8`  from the partial view of the download button. Not sure why there is this additional margin-bottom, but I had a look at the pages that uses the partial and it still looks okay after removing it.