### PR TITLE
TDRD-778: file-checks reload page at 80% validity instead of 90%

### DIFF
--- a/npm/src/index.ts
+++ b/npm/src/index.ts
@@ -116,9 +116,9 @@ export const renderModules = async () => {
         const nextPageModule = await import(
           "./nextpageredirect/next-page-redirect"
         )
-        //interval for page reload set at 90% of token validity period
+        //interval for page reload set at 80% of token validity period
         const checksPageRefreshInterval =
-          (keycloak.tokenParsed?.exp * 1000 - Date.now()) * 0.9
+          (keycloak.tokenParsed?.exp * 1000 - Date.now()) * 0.8
         const resultOrError = new checksModule.Checks().updateFileCheckProgress(
           isJudgmentUser,
           nextPageModule.goToNextPage,


### PR DESCRIPTION
- for larger capacity transfers (10k) front end fails at file checks page as auth runs out after 5 mins, therefore we reload the page before auth is lost
- reload after approx 4 mins 30 secs (90%  of 5 mins) was working fine (primarily tested on local machine in office), but often fails at this stage when overnight capacity e2e tests are on github runners
- testing change to 80% to see if things just a bit slower there and reload after 4 mins (80% of 5 mins) is better 