### PR TITLE
'File filters' use 'custom metadata' which is to be retired

### DIFF
--- a/app/controllers/DownloadMetadataController.scala
+++ b/app/controllers/DownloadMetadataController.scala
@@ -52,7 +52,7 @@ class DownloadMetadataController @Inject() (
       val fileSortColumn = metadataConfiguration.propertyToOutputMapper("tdrDataLoadHeader")("file_path")
 
       for {
-        metadata <- consignmentService.getConsignmentFileMetadata(consignmentId, request.token.bearerAccessToken, None, None)
+        metadata <- consignmentService.getConsignmentFileMetadata(consignmentId, request.token.bearerAccessToken)
         downloadDisplayProperties = metadataConfiguration.downloadFileDisplayProperties(downloadType.getOrElse("MetadataDownloadTemplate")).sortBy(_.columnIndex)
         excelFile = ExcelUtils.createExcelFile(
           metadata.consignmentReference,

--- a/app/services/ConsignmentService.scala
+++ b/app/services/ConsignmentService.scala
@@ -77,13 +77,11 @@ class ConsignmentService @Inject() (val graphqlConfiguration: GraphQLConfigurati
 
   def getConsignmentFileMetadata(
       consignmentId: UUID,
-      token: BearerAccessToken,
-      metadataType: Option[String],
-      fileIds: Option[List[UUID]],
-      additionalProperties: Option[List[String]] = None
+      token: BearerAccessToken
   ): Future[gcfm.GetConsignment] = {
+    val defaultFileFilter = Option(FileFilters(Option("File"), None, None, None))
     val variables: gcfm.Variables =
-      new GetConsignmentFilesMetadata.getConsignmentFilesMetadata.Variables(consignmentId, getFileFilters(metadataType, fileIds, additionalProperties))
+      new GetConsignmentFilesMetadata.getConsignmentFilesMetadata.Variables(consignmentId, defaultFileFilter)
 
     sendApiRequest(getConsignmentFilesMetadataClient, gcfm.document, token, variables)
       .map(data =>
@@ -183,16 +181,6 @@ class ConsignmentService @Inject() (val graphqlConfiguration: GraphQLConfigurati
     val variables = new ucsdmfn.Variables(input)
     sendApiRequest(updateDraftMetadataFileNameClient, ucsdmfn.document, token, variables)
       .map(data => data.updateClientSideDraftMetadataFileName.get)
-  }
-
-  private def getFileFilters(metadataType: Option[String], fileIds: Option[List[UUID]], additionalProperties: Option[List[String]]): Option[FileFilters] = {
-    val metadataTypeFilter = metadataType match {
-      case None                => additionalProperties.map(p => FileMetadataFilters(None, None, Some(p)))
-      case Some("closure")     => Some(FileMetadataFilters(Some(true), None, additionalProperties))
-      case Some("descriptive") => Some(FileMetadataFilters(None, Some(true), additionalProperties))
-      case Some(value)         => throw new IllegalArgumentException(s"Invalid metadata type: $value")
-    }
-    Option(FileFilters(Option("File"), fileIds, None, metadataTypeFilter))
   }
 }
 object ConsignmentService {

--- a/test/services/ConsignmentServiceSpec.scala
+++ b/test/services/ConsignmentServiceSpec.scala
@@ -261,7 +261,7 @@ class ConsignmentServiceSpec extends AnyWordSpec with MockitoSugar with BeforeAn
   }
 
   "getConsignmentFileMetadata" should {
-    "return consignment with file metadata when consignment id and selected file ids are passed" in {
+    "return consignment with file metadata for the consignment with default file filter applied" in {
       val fileId = UUID.randomUUID()
       val exemptionCode = "Open"
       val graphQlGetConsignmentFilesMetadata =
@@ -271,81 +271,15 @@ class ConsignmentServiceSpec extends AnyWordSpec with MockitoSugar with BeforeAn
         )
 
       val response = GraphQlResponse[gcfm.Data](Some(gcfm.Data(Some(graphQlGetConsignmentFilesMetadata))), Nil)
+      val expectedFileFilter = FileFilters(Some("File"), None, None, None)
 
-      val selectedFileIds = Option(List(fileId))
-      val fileFilters = Option(FileFilters(Some("File"), selectedFileIds, None, None))
-      when(getConsignmentFilesMetadataClient.getResult(bearerAccessToken, gcfm.document, Some(gcfm.Variables(consignmentId, fileFilters))))
+      when(getConsignmentFilesMetadataClient.getResult(bearerAccessToken, gcfm.document, Some(gcfm.Variables(consignmentId, Some(expectedFileFilter)))))
         .thenReturn(Future.successful(response))
 
-      val getConsignmentDetails = consignmentService.getConsignmentFileMetadata(consignmentId, bearerAccessToken, None, selectedFileIds, None).futureValue
+      val getConsignmentDetails = consignmentService.getConsignmentFileMetadata(consignmentId, bearerAccessToken).futureValue
 
       getConsignmentDetails.files.size should be(1)
       getConsignmentDetails.files.head.fileMetadata.head.value should be(exemptionCode)
-    }
-
-    "return consignment with file metadata when only consignment id and additionalProperties are passed" in {
-      val fileId = UUID.randomUUID()
-      val exemptionCode = "Open"
-      val graphQlGetConsignmentFilesMetadata =
-        gcfm.GetConsignment(List(gcfm.GetConsignment.Files(fileId, Some("FileName"), List(gcfm.GetConsignment.Files.FileMetadata("", exemptionCode)), Nil)), "TEST-TDR-2021-GB")
-
-      val response = GraphQlResponse[gcfm.Data](Some(gcfm.Data(Some(graphQlGetConsignmentFilesMetadata))), Nil)
-
-      val additionalProperties = Some(List("property1"))
-      val fileFilter = FileFilters("File".some, None, None, FileMetadataFilters(None, None, additionalProperties).some).some
-      when(getConsignmentFilesMetadataClient.getResult(bearerAccessToken, gcfm.document, Some(gcfm.Variables(consignmentId, fileFilter))))
-        .thenReturn(Future.successful(response))
-
-      val getConsignmentDetails = consignmentService.getConsignmentFileMetadata(consignmentId, bearerAccessToken, None, None, additionalProperties).futureValue
-
-      getConsignmentDetails.files.size should be(1)
-      getConsignmentDetails.files.head.fileMetadata.head.value should be(exemptionCode)
-    }
-
-    "return consignment with closure metadata when metadata type is 'closure', fileIds and additionalProperties are passed" in {
-      val fileId = UUID.randomUUID()
-      val exemptionCode = "Open"
-      val graphQlGetConsignmentFilesMetadata =
-        gcfm.GetConsignment(List(gcfm.GetConsignment.Files(fileId, Some("FileName"), List(gcfm.GetConsignment.Files.FileMetadata("", exemptionCode)), Nil)), "TEST-TDR-2021-GB")
-
-      val response = GraphQlResponse[gcfm.Data](Some(gcfm.Data(Some(graphQlGetConsignmentFilesMetadata))), Nil)
-
-      val additionalProperties = Some(List("property1"))
-      val fileFilter = FileFilters("File".some, List(fileId).some, None, FileMetadataFilters(Some(true), None, additionalProperties).some).some
-      when(getConsignmentFilesMetadataClient.getResult(bearerAccessToken, gcfm.document, Some(gcfm.Variables(consignmentId, fileFilter))))
-        .thenReturn(Future.successful(response))
-
-      val getConsignmentDetails =
-        consignmentService.getConsignmentFileMetadata(consignmentId, bearerAccessToken, "closure".some, List(fileId).some, additionalProperties).futureValue
-
-      getConsignmentDetails.files.size should be(1)
-      getConsignmentDetails.files.head.fileMetadata.head.value should be(exemptionCode)
-    }
-
-    "return consignment with descriptive metadata when metadata type as 'descriptive' passed" in {
-      val fileId = UUID.randomUUID()
-      val exemptionCode = "Open"
-      val graphQlGetConsignmentFilesMetadata =
-        gcfm.GetConsignment(List(gcfm.GetConsignment.Files(fileId, Some("FileName"), List(gcfm.GetConsignment.Files.FileMetadata("", exemptionCode)), Nil)), "TEST-TDR-2021-GB")
-
-      val response = GraphQlResponse[gcfm.Data](Some(gcfm.Data(Some(graphQlGetConsignmentFilesMetadata))), Nil)
-
-      val additionalProperties = Some(List("property1"))
-      val fileFilter = FileFilters("File".some, None, None, FileMetadataFilters(None, Some(true), additionalProperties).some).some
-      when(getConsignmentFilesMetadataClient.getResult(bearerAccessToken, gcfm.document, Some(gcfm.Variables(consignmentId, fileFilter))))
-        .thenReturn(Future.successful(response))
-
-      val getConsignmentDetails = consignmentService.getConsignmentFileMetadata(consignmentId, bearerAccessToken, "descriptive".some, None, additionalProperties).futureValue
-
-      getConsignmentDetails.files.size should be(1)
-      getConsignmentDetails.files.head.fileMetadata.head.value should be(exemptionCode)
-    }
-
-    "raise an exception if given metadata type is not valid" in {
-      val thrownException =
-        the[IllegalArgumentException] thrownBy consignmentService.getConsignmentFileMetadata(consignmentId, bearerAccessToken, "invalidMetadataType".some, None, None)
-
-      thrownException.getMessage should equal("Invalid metadata type: invalidMetadataType")
     }
 
     "raise an exception if given consignment id does not exist" in {
@@ -354,7 +288,7 @@ class ConsignmentServiceSpec extends AnyWordSpec with MockitoSugar with BeforeAn
       when(getConsignmentFilesMetadataClient.getResult(bearerAccessToken, gcfm.document, Some(gcfm.Variables(consignmentId, FileFilters("File".some, None, None, None).some))))
         .thenReturn(Future.successful(response))
 
-      val results = consignmentService.getConsignmentFileMetadata(consignmentId, bearerAccessToken, None, None, None)
+      val results = consignmentService.getConsignmentFileMetadata(consignmentId, bearerAccessToken)
 
       results.failed.futureValue shouldBe a[IllegalStateException]
       results.failed.futureValue.getMessage shouldBe s"No consignment found for consignment $consignmentId"
@@ -364,7 +298,7 @@ class ConsignmentServiceSpec extends AnyWordSpec with MockitoSugar with BeforeAn
       when(getConsignmentFilesMetadataClient.getResult(bearerAccessToken, gcfm.document, Some(gcfm.Variables(consignmentId, FileFilters("File".some, None, None, None).some))))
         .thenReturn(Future.failed(HttpError("something went wrong", StatusCode.InternalServerError)))
 
-      val results = consignmentService.getConsignmentFileMetadata(consignmentId, bearerAccessToken, None, None, None)
+      val results = consignmentService.getConsignmentFileMetadata(consignmentId, bearerAccessToken)
       results.failed.futureValue shouldBe a[HttpError[_]]
     }
   }


### PR DESCRIPTION
The 'File Filters' will be refacterd in the API to no longer rely on the 'custom metadata'

Restrict usage of 'file filters' in the Frontend to a default to allow for the refactor without causing breaking changes in the Frontent

The only filter being applied in the Frontend is 'FileType' = 'File'