### PR TITLE
Add merge queue configuration to mergify

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -18,3 +18,6 @@ pull_request_rules:
         message: Automatically approving Scala Steward
       queue:
         name: default
+merge_queue:
+  max_parallel_checks: 1
+


### PR DESCRIPTION
This PR adds the merge_queue configuration to the .github/mergify.yml file to limit parallel checks to 1.

Changes:
- Added merge_queue section with max_parallel_checks: 1