### PR TITLE
TDRD-1314: auth failures in file checks recover with reload

### DIFF
--- a/app/controllers/FileChecksController.scala
+++ b/app/controllers/FileChecksController.scala
@@ -142,7 +142,7 @@ class FileChecksController @Inject() (
           throw new Exception(s"Backend checks trigger failure for consignment $consignmentId")
         }
     } yield {
-      if (false) {
+      if (fileChecks.isComplete) {
         Ok(
           views.html.fileChecksProgressAlreadyConfirmed(
             consignmentId,

--- a/app/controllers/FileChecksController.scala
+++ b/app/controllers/FileChecksController.scala
@@ -142,7 +142,7 @@ class FileChecksController @Inject() (
           throw new Exception(s"Backend checks trigger failure for consignment $consignmentId")
         }
     } yield {
-      if (fileChecks.isComplete) {
+      if (false) {
         Ok(
           views.html.fileChecksProgressAlreadyConfirmed(
             consignmentId,

--- a/npm/src/checks/index.ts
+++ b/npm/src/checks/index.ts
@@ -1,85 +1,85 @@
 import {
-    hasDraftMetadataValidationCompleted,
-    haveFileChecksCompleted
+  hasDraftMetadataValidationCompleted,
+  haveFileChecksCompleted
 } from "./verify-checks-have-completed"
-import {displayChecksCompletedBanner} from "./display-checks-completed-banner"
+import { displayChecksCompletedBanner } from "./display-checks-completed-banner"
 import {
-    continueTransfer,
-    getDraftMetadataValidationProgress,
-    getFileChecksProgress,
-    getTransferProgress,
-    IDraftMetadataValidationProgress,
-    IFileCheckProgress
+  continueTransfer,
+  getDraftMetadataValidationProgress,
+  getFileChecksProgress,
+  getTransferProgress,
+  IDraftMetadataValidationProgress,
+  IFileCheckProgress
 } from "./get-checks-progress"
-import {isError} from "../errorhandling"
+import { isError } from "../errorhandling"
 
 export class Checks {
-    checkJudgmentTransferProgress: (
-        goToNextPage: (formId: string) => void
-    ) => void | Error = (goToNextPage: (formId: string) => void) => {
-        continueTransfer()
-        const intervalId: ReturnType<typeof setInterval> = setInterval(async () => {
-            const isCompleted: Boolean | Error = await getTransferProgress()
-            if (!isError(isCompleted)) {
-                if (isCompleted) {
-                    clearInterval(intervalId)
-                    goToNextPage("#file-checks-form")
-                }
-            } else {
-                return isCompleted
-            }
-        }, 5000)
-    }
-
-    updateFileCheckProgress: (
-        isJudgmentUser: boolean,
-        goToNextPage: (formId: string) => void
-    ) => void | Error = (
-        isJudgmentUser: boolean,
-        goToNextPage: (formId: string) => void
-    ) => {
-        if (isJudgmentUser) {
-            this.checkJudgmentTransferProgress(goToNextPage)
-        } else {
-            const intervalId: ReturnType<typeof setInterval> = setInterval(
-                async () => {
-                    const fileChecksProgress: IFileCheckProgress | Error =
-                        await getFileChecksProgress()
-                    if (!isError(fileChecksProgress)) {
-                        const checksCompleted = haveFileChecksCompleted(fileChecksProgress)
-                        if (checksCompleted) {
-                            // clearInterval(intervalId)
-                            // displayChecksCompletedBanner("file-checks")
-                        }
-                    } else {
-                        console.log("=====> FILE CHECKS ERROR")
-                        clearInterval(intervalId)
-                        setTimeout(async () => {
-                            window.location.reload()
-                        }, 10000)
-                    }
-                },
-                10000
-            )
+  checkJudgmentTransferProgress: (
+    goToNextPage: (formId: string) => void
+  ) => void | Error = (goToNextPage: (formId: string) => void) => {
+    continueTransfer()
+    const intervalId: ReturnType<typeof setInterval> = setInterval(async () => {
+      const isCompleted: Boolean | Error = await getTransferProgress()
+      if (!isError(isCompleted)) {
+        if (isCompleted) {
+          clearInterval(intervalId)
+          goToNextPage("#file-checks-form")
         }
-    }
+      } else {
+        return isCompleted
+      }
+    }, 5000)
+  }
 
-    updateDraftMetadataValidationProgress: () => void | Error = () => {
-        const intervalId: ReturnType<typeof setInterval> = setInterval(async () => {
-            const validationChecksProgress: IDraftMetadataValidationProgress | Error =
-                await getDraftMetadataValidationProgress()
-            if (!isError(validationChecksProgress)) {
-                const checksCompleted = hasDraftMetadataValidationCompleted(
-                    validationChecksProgress
-                )
-                if (checksCompleted) {
-                    clearInterval(intervalId)
-                    displayChecksCompletedBanner("draft-metadata-checks")
-                }
-            } else {
-                clearInterval(intervalId)
-                return validationChecksProgress
+  updateFileCheckProgress: (
+    isJudgmentUser: boolean,
+    goToNextPage: (formId: string) => void
+  ) => void | Error = (
+    isJudgmentUser: boolean,
+    goToNextPage: (formId: string) => void
+  ) => {
+    if (isJudgmentUser) {
+      this.checkJudgmentTransferProgress(goToNextPage)
+    } else {
+      const intervalId: ReturnType<typeof setInterval> = setInterval(
+        async () => {
+          const fileChecksProgress: IFileCheckProgress | Error =
+            await getFileChecksProgress()
+          if (!isError(fileChecksProgress)) {
+            const checksCompleted = haveFileChecksCompleted(fileChecksProgress)
+            if (checksCompleted) {
+              // clearInterval(intervalId)
+              // displayChecksCompletedBanner("file-checks")
             }
-        }, 5000)
+          } else {
+            console.log("=====> FILE CHECKS ERROR")
+            clearInterval(intervalId)
+            setTimeout(async () => {
+              window.location.reload()
+            }, 10000)
+          }
+        },
+        10000
+      )
     }
+  }
+
+  updateDraftMetadataValidationProgress: () => void | Error = () => {
+    const intervalId: ReturnType<typeof setInterval> = setInterval(async () => {
+      const validationChecksProgress: IDraftMetadataValidationProgress | Error =
+        await getDraftMetadataValidationProgress()
+      if (!isError(validationChecksProgress)) {
+        const checksCompleted = hasDraftMetadataValidationCompleted(
+          validationChecksProgress
+        )
+        if (checksCompleted) {
+          clearInterval(intervalId)
+          displayChecksCompletedBanner("draft-metadata-checks")
+        }
+      } else {
+        clearInterval(intervalId)
+        return validationChecksProgress
+      }
+    }, 5000)
+  }
 }

--- a/npm/src/checks/index.ts
+++ b/npm/src/checks/index.ts
@@ -48,11 +48,10 @@ export class Checks {
           if (!isError(fileChecksProgress)) {
             const checksCompleted = haveFileChecksCompleted(fileChecksProgress)
             if (checksCompleted) {
-              // clearInterval(intervalId)
-              // displayChecksCompletedBanner("file-checks")
+              clearInterval(intervalId)
+              displayChecksCompletedBanner("file-checks")
             }
           } else {
-            console.log("=====> FILE CHECKS ERROR")
             clearInterval(intervalId)
             setTimeout(async () => {
               window.location.reload()

--- a/npm/src/checks/index.ts
+++ b/npm/src/checks/index.ts
@@ -33,24 +33,14 @@ export class Checks {
 
   updateFileCheckProgress: (
     isJudgmentUser: boolean,
-    goToNextPage: (formId: string) => void,
-    checksPageRefreshInterval: number
+    goToNextPage: (formId: string) => void
   ) => void | Error = (
     isJudgmentUser: boolean,
-    goToNextPage: (formId: string) => void,
-    checksPageRefreshInterval: number
+    goToNextPage: (formId: string) => void
   ) => {
     if (isJudgmentUser) {
       this.checkJudgmentTransferProgress(goToNextPage)
     } else {
-      const refreshPageIntervalId: ReturnType<typeof setInterval> = setInterval(
-        async () => {
-          clearInterval(intervalId)
-          window.location.reload()
-        },
-        checksPageRefreshInterval
-      )
-
       const intervalId: ReturnType<typeof setInterval> = setInterval(
         async () => {
           const fileChecksProgress: IFileCheckProgress | Error =
@@ -58,13 +48,13 @@ export class Checks {
           if (!isError(fileChecksProgress)) {
             const checksCompleted = haveFileChecksCompleted(fileChecksProgress)
             if (checksCompleted) {
-              clearInterval(intervalId)
-              clearInterval(refreshPageIntervalId)
-              displayChecksCompletedBanner("file-checks")
+              // clearInterval(intervalId)
+              // displayChecksCompletedBanner("file-checks")
             }
           } else {
-            clearInterval(refreshPageIntervalId)
-            return fileChecksProgress
+            console.log("=====> FILE CHECKS ERROR")
+            clearInterval(intervalId)
+            setTimeout( async () => { window.location.reload() }, 10000)
           }
         },
         10000

--- a/npm/src/checks/index.ts
+++ b/npm/src/checks/index.ts
@@ -1,83 +1,85 @@
 import {
-  hasDraftMetadataValidationCompleted,
-  haveFileChecksCompleted
+    hasDraftMetadataValidationCompleted,
+    haveFileChecksCompleted
 } from "./verify-checks-have-completed"
-import { displayChecksCompletedBanner } from "./display-checks-completed-banner"
+import {displayChecksCompletedBanner} from "./display-checks-completed-banner"
 import {
-  continueTransfer,
-  getDraftMetadataValidationProgress,
-  getFileChecksProgress,
-  getTransferProgress,
-  IDraftMetadataValidationProgress,
-  IFileCheckProgress
+    continueTransfer,
+    getDraftMetadataValidationProgress,
+    getFileChecksProgress,
+    getTransferProgress,
+    IDraftMetadataValidationProgress,
+    IFileCheckProgress
 } from "./get-checks-progress"
-import { isError } from "../errorhandling"
+import {isError} from "../errorhandling"
 
 export class Checks {
-  checkJudgmentTransferProgress: (
-    goToNextPage: (formId: string) => void
-  ) => void | Error = (goToNextPage: (formId: string) => void) => {
-    continueTransfer()
-    const intervalId: ReturnType<typeof setInterval> = setInterval(async () => {
-      const isCompleted: Boolean | Error = await getTransferProgress()
-      if (!isError(isCompleted)) {
-        if (isCompleted) {
-          clearInterval(intervalId)
-          goToNextPage("#file-checks-form")
-        }
-      } else {
-        return isCompleted
-      }
-    }, 5000)
-  }
-
-  updateFileCheckProgress: (
-    isJudgmentUser: boolean,
-    goToNextPage: (formId: string) => void
-  ) => void | Error = (
-    isJudgmentUser: boolean,
-    goToNextPage: (formId: string) => void
-  ) => {
-    if (isJudgmentUser) {
-      this.checkJudgmentTransferProgress(goToNextPage)
-    } else {
-      const intervalId: ReturnType<typeof setInterval> = setInterval(
-        async () => {
-          const fileChecksProgress: IFileCheckProgress | Error =
-            await getFileChecksProgress()
-          if (!isError(fileChecksProgress)) {
-            const checksCompleted = haveFileChecksCompleted(fileChecksProgress)
-            if (checksCompleted) {
-              // clearInterval(intervalId)
-              // displayChecksCompletedBanner("file-checks")
+    checkJudgmentTransferProgress: (
+        goToNextPage: (formId: string) => void
+    ) => void | Error = (goToNextPage: (formId: string) => void) => {
+        continueTransfer()
+        const intervalId: ReturnType<typeof setInterval> = setInterval(async () => {
+            const isCompleted: Boolean | Error = await getTransferProgress()
+            if (!isError(isCompleted)) {
+                if (isCompleted) {
+                    clearInterval(intervalId)
+                    goToNextPage("#file-checks-form")
+                }
+            } else {
+                return isCompleted
             }
-          } else {
-            console.log("=====> FILE CHECKS ERROR")
-            clearInterval(intervalId)
-            setTimeout( async () => { window.location.reload() }, 10000)
-          }
-        },
-        10000
-      )
+        }, 5000)
     }
-  }
 
-  updateDraftMetadataValidationProgress: () => void | Error = () => {
-    const intervalId: ReturnType<typeof setInterval> = setInterval(async () => {
-      const validationChecksProgress: IDraftMetadataValidationProgress | Error =
-        await getDraftMetadataValidationProgress()
-      if (!isError(validationChecksProgress)) {
-        const checksCompleted = hasDraftMetadataValidationCompleted(
-          validationChecksProgress
-        )
-        if (checksCompleted) {
-          clearInterval(intervalId)
-          displayChecksCompletedBanner("draft-metadata-checks")
+    updateFileCheckProgress: (
+        isJudgmentUser: boolean,
+        goToNextPage: (formId: string) => void
+    ) => void | Error = (
+        isJudgmentUser: boolean,
+        goToNextPage: (formId: string) => void
+    ) => {
+        if (isJudgmentUser) {
+            this.checkJudgmentTransferProgress(goToNextPage)
+        } else {
+            const intervalId: ReturnType<typeof setInterval> = setInterval(
+                async () => {
+                    const fileChecksProgress: IFileCheckProgress | Error =
+                        await getFileChecksProgress()
+                    if (!isError(fileChecksProgress)) {
+                        const checksCompleted = haveFileChecksCompleted(fileChecksProgress)
+                        if (checksCompleted) {
+                            // clearInterval(intervalId)
+                            // displayChecksCompletedBanner("file-checks")
+                        }
+                    } else {
+                        console.log("=====> FILE CHECKS ERROR")
+                        clearInterval(intervalId)
+                        setTimeout(async () => {
+                            window.location.reload()
+                        }, 10000)
+                    }
+                },
+                10000
+            )
         }
-      } else {
-        clearInterval(intervalId)
-        return validationChecksProgress
-      }
-    }, 5000)
-  }
+    }
+
+    updateDraftMetadataValidationProgress: () => void | Error = () => {
+        const intervalId: ReturnType<typeof setInterval> = setInterval(async () => {
+            const validationChecksProgress: IDraftMetadataValidationProgress | Error =
+                await getDraftMetadataValidationProgress()
+            if (!isError(validationChecksProgress)) {
+                const checksCompleted = hasDraftMetadataValidationCompleted(
+                    validationChecksProgress
+                )
+                if (checksCompleted) {
+                    clearInterval(intervalId)
+                    displayChecksCompletedBanner("draft-metadata-checks")
+                }
+            } else {
+                clearInterval(intervalId)
+                return validationChecksProgress
+            }
+        }, 5000)
+    }
 }

--- a/npm/src/index.ts
+++ b/npm/src/index.ts
@@ -124,13 +124,9 @@ export const renderModules = async () => {
         const checksModule = await import("./checks")
         const nextPageModule =
           await import("./nextpageredirect/next-page-redirect")
-        //interval for page reload set at 60% of token validity period
-        const checksPageRefreshInterval =
-          (keycloak.tokenParsed?.exp * 1000 - Date.now()) * 0.8
         const resultOrError = new checksModule.Checks().updateFileCheckProgress(
           isJudgmentUser,
-          nextPageModule.goToNextPage,
-          checksPageRefreshInterval
+          nextPageModule.goToNextPage
         )
         if (errorHandlingModule.isError(resultOrError)) {
           errorHandlingModule.handleUploadError(resultOrError)

--- a/npm/test/update-check-progress.test.ts
+++ b/npm/test/update-check-progress.test.ts
@@ -134,7 +134,7 @@ test("'updateFileCheckProgress' calls setInterval correctly", async () => {
   jest.spyOn(global, "setInterval")
   await checks.updateFileCheckProgress(false, mockGoToNextPage)
   jest.runOnlyPendingTimers()
-  expect(setInterval).toHaveBeenCalledTimes(2)
+  expect(setInterval).toHaveBeenCalledTimes(1)
 })
 
 test("'updateDraftMetadataValidationProgress' calls setInterval correctly", async () => {

--- a/npm/test/update-check-progress.test.ts
+++ b/npm/test/update-check-progress.test.ts
@@ -305,7 +305,7 @@ test("'updateFileCheckProgress' calls goToNextPage for a judgment user, if all c
 
   mockTransferProgress("complete")
 
-  checks.updateFileCheckProgress(true, mockGoToNextPage, 300000)
+  checks.updateFileCheckProgress(true, mockGoToNextPage)
   await jest.runOnlyPendingTimers()
 
   expect(mockGoToNextPage).toHaveBeenCalled()
@@ -318,7 +318,7 @@ test("'updateFileCheckProgress' does not call goToNextPage for a judgment user i
   )
   mockTransferProgress("inProgress")
 
-  checks.updateFileCheckProgress(true, mockGoToNextPage, 300000)
+  checks.updateFileCheckProgress(true, mockGoToNextPage)
   await jest.runOnlyPendingTimers()
 
   expect(mockGoToNextPage).toHaveBeenCalled()
@@ -331,7 +331,7 @@ test("'updateFileCheckProgress' does not call goToNextPage for a judgment user i
   )
   mockTransferProgress("noData")
 
-  checks.updateFileCheckProgress(true, mockGoToNextPage, 300000)
+  checks.updateFileCheckProgress(true, mockGoToNextPage)
   await jest.runOnlyPendingTimers()
 
   expect(mockGoToNextPage).not.toHaveBeenCalled()

--- a/npm/test/update-check-progress.test.ts
+++ b/npm/test/update-check-progress.test.ts
@@ -132,7 +132,7 @@ const mockDisplayChecksHaveCompletedBanner: () => void = () =>
 
 test("'updateFileCheckProgress' calls setInterval correctly", async () => {
   jest.spyOn(global, "setInterval")
-  await checks.updateFileCheckProgress(false, mockGoToNextPage, 300000)
+  await checks.updateFileCheckProgress(false, mockGoToNextPage)
   jest.runOnlyPendingTimers()
   expect(setInterval).toHaveBeenCalledTimes(2)
 })
@@ -160,7 +160,7 @@ test("'updateFileCheckProgress' shows a standard user, the notification banner a
 
   mockDisplayChecksHaveCompletedBanner()
 
-  checks.updateFileCheckProgress(false, mockGoToNextPage, 300000)
+  checks.updateFileCheckProgress(false, mockGoToNextPage)
   await jest.runOnlyPendingTimers()
 
   expect(haveFileChecksCompleted).toHaveBeenCalled()
@@ -227,7 +227,7 @@ test("'updateFileCheckProgress' shows a standard user, no banner and a disabled 
   )
   mockDisplayChecksHaveCompletedBanner()
 
-  checks.updateFileCheckProgress(false, mockGoToNextPage, 300000)
+  checks.updateFileCheckProgress(false, mockGoToNextPage)
   await jest.runOnlyPendingTimers()
 
   expect(haveFileChecksCompleted).toHaveBeenCalled()
@@ -269,7 +269,7 @@ test("'updateFileCheckProgress' shows a standard user, no banner and a disabled 
   )
   mockDisplayChecksHaveCompletedBanner()
 
-  checks.updateFileCheckProgress(false, mockGoToNextPage, 300000)
+  checks.updateFileCheckProgress(false, mockGoToNextPage)
   await jest.runOnlyPendingTimers()
 
   expect(haveFileChecksCompleted).toHaveBeenCalled()


### PR DESCRIPTION
- remove page refresh interval approach (incl update of tests)
- use a page refresh to recover from a fail in file-checks-progress (wait 10 secs first to mitigate any failure loops)
