### PR TITLE
[TDRD-411] Add meaningful forbidden message for TNA users

### DIFF
--- a/app/auth/TokenSecurity.scala
+++ b/app/auth/TokenSecurity.scala
@@ -73,7 +73,8 @@ trait TokenSecurity extends OidcSecurity with I18nSupport {
           views.html.forbiddenError(
             request.token.name,
             getProfile(request).isPresent,
-            request.token.isJudgmentUser
+            request.token.isJudgmentUser,
+            request.token.isTNAUser
           )(request2Messages(request), request)
         )
       )

--- a/app/errors/ErrorHandler.scala
+++ b/app/errors/ErrorHandler.scala
@@ -46,16 +46,28 @@ class ErrorHandler @Inject() (val messagesApi: MessagesApi, implicit val pac4jTe
       })
   }
 
+  def tnaUser(request: RequestHeader): Boolean = {
+    pac4jTemplateHelper
+      .getCurrentProfiles(request)
+      .headOption
+      .exists(profile => {
+        val token = profile.asInstanceOf[OidcProfile].getAccessToken.asInstanceOf[BearerAccessToken]
+        val parsedToken = SignedJWT.parse(token.getValue).getJWTClaimsSet
+        Option(parsedToken.getStringClaim("tna_user")).contains("true")
+      })
+  }
+
   override def onClientError(request: RequestHeader, statusCode: Int, message: String): Future[Result] = {
     logger.error(s"Client error with status code $statusCode at path '${request.path}' with message: '$message'")
     val loggedIn = isLoggedIn(request)
     val name = getName(request)
     val isJudgmentUser = judgmentUser(request)
+    val isTNAUser = tnaUser(request)
     val response = statusCode match {
       case 401 =>
         Unauthorized(views.html.unauthenticatedError(name, loggedIn, isJudgmentUser)(request2Messages(request), request))
       case 403 =>
-        Forbidden(views.html.forbiddenError(name, loggedIn, isJudgmentUser)(request2Messages(request), request))
+        Forbidden(views.html.forbiddenError(name, loggedIn, isJudgmentUser, isTNAUser)(request2Messages(request), request))
       case 404 =>
         NotFound(views.html.notFoundError(name, loggedIn, isJudgmentUser)(request2Messages(request), request))
       case _ =>
@@ -75,9 +87,10 @@ class ErrorHandler @Inject() (val messagesApi: MessagesApi, implicit val pac4jTe
     val name = getName(request)
     val loggedIn = isLoggedIn(request)
     val isJudgmentUser = judgmentUser(request)
+    val isTNAUser = tnaUser(request)
     val response = exception match {
       case _: AuthorisationException =>
-        Forbidden(views.html.forbiddenError(name, loggedIn, isJudgmentUser)(request2Messages(request), request))
+        Forbidden(views.html.forbiddenError(name, loggedIn, isJudgmentUser, isTNAUser)(request2Messages(request), request))
       case e: CompletionException if Option(e.getCause).exists(e => e.isInstanceOf[TechnicalException] && e.getMessage == "State cannot be determined") =>
         Redirect(redirectUrl(isJudgmentUser))
       case _ =>

--- a/app/errors/ErrorHandler.scala
+++ b/app/errors/ErrorHandler.scala
@@ -53,7 +53,7 @@ class ErrorHandler @Inject() (val messagesApi: MessagesApi, implicit val pac4jTe
       .exists(profile => {
         val token = profile.asInstanceOf[OidcProfile].getAccessToken.asInstanceOf[BearerAccessToken]
         val parsedToken = SignedJWT.parse(token.getValue).getJWTClaimsSet
-        Option(parsedToken.getStringClaim("tna_user")).contains("true")
+        parsedToken.getBooleanClaim("tna_user")
       })
   }
 

--- a/app/views/forbiddenError.scala.html
+++ b/app/views/forbiddenError.scala.html
@@ -1,4 +1,4 @@
-@(name: String, isLoggedIn: Boolean, isJudgmentUser: Boolean)(implicit messages: Messages, request: RequestHeader)
+@(name: String, isLoggedIn: Boolean, isJudgmentUser: Boolean, isTNAUser: Boolean = false)(implicit messages: Messages, request: RequestHeader)
 
 @defining("You are not permitted to see this page") { title =>
   @main(title, name = name, isLoggedIn = isLoggedIn, isJudgmentUser = isJudgmentUser) {
@@ -6,7 +6,11 @@
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-two-thirds">
                     <h1 class="govuk-heading-l">@title</h1>
-                    <p class="govuk-body">This page is restricted to certain users only.</p>
+                    @if(isTNAUser) {
+                        <p class="govuk-body">This page is only accessible from the TNA network. Please check you are connected to the office network or TNA and try again.</p>
+                    } else {
+                        <p class="govuk-body">This page is restricted to certain users only.</p>
+                    }
                 </div>
             </div>
         }

--- a/app/views/forbiddenError.scala.html
+++ b/app/views/forbiddenError.scala.html
@@ -7,7 +7,7 @@
                 <div class="govuk-grid-column-two-thirds">
                     <h1 class="govuk-heading-l">@title</h1>
                     @if(isTNAUser) {
-                        <p class="govuk-body">This page is only accessible from the TNA network. Please check you are connected to the office network or TNA and try again.</p>
+                        <p class="govuk-body">This page is only accessible from the TNA network. Please check you are connected to the office network or VPN and try again.</p>
                     } else {
                         <p class="govuk-body">This page is restricted to certain users only.</p>
                     }

--- a/test/errors/ErrorHandlerSpec.scala
+++ b/test/errors/ErrorHandlerSpec.scala
@@ -87,6 +87,23 @@ class ErrorHandlerSpec extends AnyFlatSpec with Matchers {
     response.header.headers("Location") should equal("/view-transfers")
   }
 
+  "forbiddenError" should "show office network message for TNA user" in {
+    implicit val request: Request[_] = FakeRequest()
+    implicit val messages = new DefaultMessagesApi().preferred(request)
+    val content = views.html.forbiddenError("", isLoggedIn = false, isJudgmentUser = false, isTNAUser = true).toString()
+
+    content should include("TNA network")
+  }
+
+  "forbiddenError" should "show restricted users message for non-TNA user" in {
+    implicit val request: Request[_] = FakeRequest()
+    implicit val messages = new DefaultMessagesApi().preferred(request)
+    val content = views.html.forbiddenError("", isLoggedIn = false, isJudgmentUser = false, isTNAUser = false).toString()
+
+    content should include("restricted to certain users only")
+    content should not include "TNA network"
+  }
+
   "redirectUrl" should "return url '/view-transfers' for non-judgment user" in {
     val redirectUrl = errorHandler.redirectUrl(false)
 


### PR DESCRIPTION
TNA users seeing a 403 are most likely off the office network. Vary the forbidden page message to prompt them to check their network/VPN connection.

## Changes
- **forbiddenError.scala.html**: Added `isTNAUser` parameter; TNA users see a message asking them to check their office network/VPN connection
- **ErrorHandler.scala**: Added `tnaUser()` method to extract the `tna_user` claim from the JWT
- **TokenSecurity.scala**: Pass `isTNAUser` to the forbidden template
- **ErrorHandlerSpec.scala**: Two new tests verifying the conditional message