### PR TITLE
TDRD-1448: allow larger metadata file for 10k and max data per row

### DIFF
--- a/conf/application.base.conf
+++ b/conf/application.base.conf
@@ -30,7 +30,7 @@ play {
     port=disabled
     parser {
         maxMemoryBuffer = 10MB
-        maxDiskBuffer = 100MB
+        maxDiskBuffer = 300MB
     }
   }
   


### PR DESCRIPTION
upload fails with maxed out metadata for 10k records which had size of 198M so bump to 300MB limit
