### PR TITLE
fix judgment user

### DIFF
--- a/npm/src/upload/form/upload-form.ts
+++ b/npm/src/upload/form/upload-form.ts
@@ -411,10 +411,11 @@ export class UploadForm {
     this.dropzone.removeEventListener("drop", this.handleDroppedItems)
   }
 
-  private convertFilesToEntries(files: File[]): IEntry[] {
-    this.checkIfFolderHasFiles(files)
+  private convertFilesToEntries(files: File[] | FileList): IEntry[] {
+    const fileArray = Array.from(files)
+    this.checkIfFolderHasFiles(fileArray)
 
-    return files.map((file) => ({
+    return fileArray.map((file) => ({
       file,
       path: file.webkitRelativePath || file.name,
       kind: EntryKind.File

--- a/npm/src/upload/form/upload-form.ts
+++ b/npm/src/upload/form/upload-form.ts
@@ -248,7 +248,7 @@ export class UploadForm {
         void this.handleSelectedItems()
       }
       const label = this.itemRetriever.labels?.[0]
-      if (label && this.itemRetriever.hasAttribute("webkitdirectory")) {
+      if (label) {
         label.setAttribute("role", "button")
         label.tabIndex = 0
         label.addEventListener("click", openDirectoryPicker)

--- a/npm/src/upload/form/upload-form.ts
+++ b/npm/src/upload/form/upload-form.ts
@@ -248,7 +248,7 @@ export class UploadForm {
         void this.handleSelectedItems()
       }
       const label = this.itemRetriever.labels?.[0]
-      if (label) {
+      if (label && this.itemRetriever.hasAttribute("webkitdirectory")) {
         label.setAttribute("role", "button")
         label.tabIndex = 0
         label.addEventListener("click", openDirectoryPicker)


### PR DESCRIPTION
Fix judgment file upload broken by File System Access API refactor

Problem
Judgment users could not upload a  .docx  file. After selecting a file and clicking Start upload, the page showed:

You did not select a file for upload.

Cause
The recent File System Access API refactor changed  convertFilesToEntries  to call  .map()  directly on its argument. For judgment uploads the argument is  form.files.files  — a native  FileList , which has no  .map() . The call threw, so  selectedFiles  was never populated and submission was rejected.

Unit tests didn’t catch it because they assign a plain  Array  ( { files: [dummyFile] } ) to the mock form, which does have  .map() .

Fix
Convert the input to an array first:

const fileArray = Array.from(files)

Impact  

• Judgment file selection works again.  
• Standard folder upload path is unaffected — it already passes a  File[]  from  getAllFilesFromHandle , and  Array.from(File[])  is a no-op.  
• No UI changes, no new error messages.