### PR TITLE
Update tdr-state-control

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ libraryDependencies ++= Seq(
   "uk.gov.nationalarchives" %% "tdr-metadata-validation" % "0.0.236",
   "uk.gov.nationalarchives" %% "s3-utils" % "0.1.338",
   "uk.gov.nationalarchives" %% "sns-utils" % "0.1.338",
-  "uk.gov.nationalarchives" %% "tdr-state-control" % "0.0.44",
+  "uk.gov.nationalarchives" %% "tdr-state-control" % "0.0.45",
   "ch.qos.logback" % "logback-classic" % "1.5.38",
   ws,
   "io.opentelemetry" % "opentelemetry-api" % "1.63.0",

--- a/test/controllers/DraftMetadataUploadControllerSpec.scala
+++ b/test/controllers/DraftMetadataUploadControllerSpec.scala
@@ -117,7 +117,7 @@ class DraftMetadataUploadControllerSpec extends FrontEndTestHelper {
       playStatus(draftMetadataUploadPage) mustBe FORBIDDEN
     }
 
-    "redirect to draft metadata checks page when DraftMetadataUpload status is 'Completed'" in {
+    "render upload page when DraftMetadataUpload status is 'Completed'" in {
       setConsignmentTypeResponse(wiremockServer, "standard")
       setConsignmentReferenceResponse(wiremockServer)
       val statuses = List(ConsignmentStatuses(UUID.randomUUID(), consignmentId, "DraftMetadataUpload", "Completed", someDateTime, None))
@@ -128,14 +128,44 @@ class DraftMetadataUploadControllerSpec extends FrontEndTestHelper {
         .draftMetadataUploadPage(consignmentId)
         .apply(FakeRequest(GET, "/draft-metadata/upload").withCSRFToken)
 
-      playStatus(response) mustBe SEE_OTHER
-      redirectLocation(response).get must include regex "/consignment/*.*/draft-metadata/checks"
+      playStatus(response) mustBe OK
     }
 
-    "redirect to draft metadata checks page when DraftMetadataUpload status is 'InProgress'" in {
+    "render upload page when DraftMetadataUpload status is 'InProgress'" in {
       setConsignmentTypeResponse(wiremockServer, "standard")
       setConsignmentReferenceResponse(wiremockServer)
       val statuses = List(ConsignmentStatuses(UUID.randomUUID(), consignmentId, "DraftMetadataUpload", "InProgress", someDateTime, None))
+      setConsignmentStatusResponse(app.configuration, wiremockServer, consignmentStatuses = statuses)
+
+      val controller = instantiateDraftMetadataUploadController()
+      val response = controller
+        .draftMetadataUploadPage(consignmentId)
+        .apply(FakeRequest(GET, "/draft-metadata/upload").withCSRFToken)
+
+      playStatus(response) mustBe OK
+    }
+
+    "render upload page when DraftMetadataUpload status is 'CompletedWithIssues'" in {
+      setConsignmentTypeResponse(wiremockServer, "standard")
+      setConsignmentReferenceResponse(wiremockServer)
+      val statuses = List(ConsignmentStatuses(UUID.randomUUID(), consignmentId, "DraftMetadataUpload", "CompletedWithIssues", someDateTime, None))
+      setConsignmentStatusResponse(app.configuration, wiremockServer, consignmentStatuses = statuses)
+
+      val controller = instantiateDraftMetadataUploadController()
+      val response = controller
+        .draftMetadataUploadPage(consignmentId)
+        .apply(FakeRequest(GET, "/draft-metadata/upload").withCSRFToken)
+
+      playStatus(response) mustBe OK
+    }
+
+    "redirect to draft metadata checks page when MetadataReview status is 'InProgress'" in {
+      setConsignmentTypeResponse(wiremockServer, "standard")
+      setConsignmentReferenceResponse(wiremockServer)
+      val statuses = List(
+        ConsignmentStatuses(UUID.randomUUID(), consignmentId, "DraftMetadataUpload", "Completed", someDateTime, None),
+        ConsignmentStatuses(UUID.randomUUID(), consignmentId, "MetadataReview", "InProgress", someDateTime, None)
+      )
       setConsignmentStatusResponse(app.configuration, wiremockServer, consignmentStatuses = statuses)
 
       val controller = instantiateDraftMetadataUploadController()
@@ -147,10 +177,13 @@ class DraftMetadataUploadControllerSpec extends FrontEndTestHelper {
       redirectLocation(response).get must include regex "/consignment/*.*/draft-metadata/checks"
     }
 
-    "redirect to draft metadata checks page when DraftMetadataUpload status is 'CompletedWithIssues'" in {
+    "redirect to draft metadata checks page when Export status exists" in {
       setConsignmentTypeResponse(wiremockServer, "standard")
       setConsignmentReferenceResponse(wiremockServer)
-      val statuses = List(ConsignmentStatuses(UUID.randomUUID(), consignmentId, "DraftMetadataUpload", "CompletedWithIssues", someDateTime, None))
+      val statuses = List(
+        ConsignmentStatuses(UUID.randomUUID(), consignmentId, "DraftMetadataUpload", "Completed", someDateTime, None),
+        ConsignmentStatuses(UUID.randomUUID(), consignmentId, "Export", "InProgress", someDateTime, None)
+      )
       setConsignmentStatusResponse(app.configuration, wiremockServer, consignmentStatuses = statuses)
 
       val controller = instantiateDraftMetadataUploadController()


### PR DESCRIPTION
The update contains a change to allow user to reupload metadata for as long as they have not done an export and metadata review is not InProgress